### PR TITLE
fix: save user config when install mcp server from market

### DIFF
--- a/frontend/src/components/MarketServerDetail.tsx
+++ b/frontend/src/components/MarketServerDetail.tsx
@@ -3,10 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { MarketServer, MarketServerInstallation } from '@/types';
 import ServerForm from './ServerForm';
 
+import { ServerConfig } from '@/types';
+
 interface MarketServerDetailProps {
   server: MarketServer;
   onBack: () => void;
-  onInstall: (server: MarketServer) => void;
+  onInstall: (server: MarketServer, config: ServerConfig) => void;
   installing?: boolean;
   isInstalled?: boolean;
 }
@@ -83,8 +85,8 @@ const MarketServerDetail: React.FC<MarketServerDetailProps> = ({
   const handleSubmit = async (payload: any) => {
     try {
       setError(null);
-      // Pass the server object to the parent component for installation
-      onInstall(server);
+      // Pass the server object and the payload (includes env changes) for installation
+      onInstall(server, payload.config);
       setModalVisible(false);
     } catch (err) {
       console.error('Error installing server:', err);

--- a/frontend/src/hooks/useMarketData.ts
+++ b/frontend/src/hooks/useMarketData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { MarketServer, ApiResponse } from '@/types';
+import { MarketServer, ApiResponse, ServerConfig } from '@/types';
 import { getApiUrl } from '../utils/runtime';
 
 export const useMarketData = () => {
@@ -347,7 +347,7 @@ export const useMarketData = () => {
 
   // Install server to the local environment
   const installServer = useCallback(
-    async (server: MarketServer) => {
+    async (server: MarketServer, customConfig: ServerConfig) => {
       try {
         const installType = server.installations?.npm
           ? 'npm'
@@ -362,13 +362,13 @@ export const useMarketData = () => {
 
         const installation = server.installations[installType];
 
-        // Prepare server configuration
+        // Prepare server configuration, merging with customConfig
         const serverConfig = {
           name: server.name,
           config: {
-            command: installation.command,
-            args: installation.args,
-            env: installation.env || {},
+            command: customConfig.command || installation.command || '',
+            args: customConfig.args || installation.args || [],
+            env: { ...installation.env, ...customConfig.env },
           },
         };
 

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { MarketServer } from '@/types';
+import { MarketServer, ServerConfig } from '@/types';
 import { useMarketData } from '@/hooks/useMarketData';
 import { useToast } from '@/contexts/ToastContext';
 import MarketServerCard from '@/components/MarketServerCard';
@@ -90,10 +90,11 @@ const MarketPage: React.FC = () => {
     navigate('/market');
   };
 
-  const handleInstall = async (server: MarketServer) => {
+  const handleInstall = async (server: MarketServer, config: ServerConfig) => {
     try {
       setInstalling(true);
-      const success = await installServer(server);
+      // Pass the server object and the config to the installServer function
+      const success = await installServer(server, config);
       if (success) {
         // Show success message using toast instead of alert
         showToast(t('market.installSuccess', { serverName: server.display_name }), 'success');


### PR DESCRIPTION
修复在市场界面安装 mcp server 时，修改 args 及 env 不生效的问题