### PR TITLE
fix: 修复从市场安装服务器时，选择SSE和Streamable HTTP不生效的问题

### DIFF
--- a/frontend/src/hooks/useMarketData.ts
+++ b/frontend/src/hooks/useMarketData.ts
@@ -365,11 +365,11 @@ export const useMarketData = () => {
         // Prepare server configuration, merging with customConfig
         const serverConfig = {
           name: server.name,
-          config: {
+          config: customConfig.type === 'stdio' ? {
             command: customConfig.command || installation.command || '',
             args: customConfig.args || installation.args || [],
             env: { ...installation.env, ...customConfig.env },
-          },
+          } : customConfig
         };
 
         // Call the createServer API


### PR DESCRIPTION
目前在市场安装服务器，选择SSE和Streamable HTTP，都会被当作stdio类型新建