### PR TITLE
Fix: Handle ToolName in CallToolRequest to Resolve Server Discovery Issues

### DIFF
--- a/src/controllers/openApiController.ts
+++ b/src/controllers/openApiController.ts
@@ -116,10 +116,8 @@ export const executeToolViaOpenAPI = async (req: Request, res: Response): Promis
         (t: any) => t.name === fullToolName || t.name === toolName,
       );
       if (tool) {
-        if(tool.name) {
-          toolName=tool.name; // The 'handleCallToolRequest' method makes a call based on the real tool name.
-        }
-        if(tool.inputSchema) {
+        toolName = tool.name; // Use the matched tool's actual name (with server prefix if applicable) for the subsequent call to handleCallToolRequest.
+        if (tool.inputSchema) {
           inputSchema = tool.inputSchema as Record<string, any>;
         }
       }


### PR DESCRIPTION
`http://localhost:3000/api/tools/fetch/fetch?url=https://example.com`
The `openapi.json` is sending requests without the `fullToolName` (ServerName+Separator+ToolName) as in the request above. Because of this, the `'handleCallToolRequest'` method cannot find the server. This is because the handle searches based on ToolName. Since a `fullToolName` search is being performed here, I added a tool name change so that the `handleCallToolRequest` method will be able to find the server.

This fix will resolve the `'Error handling CallToolRequest: Error: Server not found: fetch'` error.