### PR TITLE
Add server renaming functionality

### DIFF
--- a/frontend/src/components/EditServerForm.tsx
+++ b/frontend/src/components/EditServerForm.tsx
@@ -18,7 +18,17 @@ const EditServerForm = ({ server, onEdit, onCancel }: EditServerFormProps) => {
     try {
       setError(null);
       const encodedServerName = encodeURIComponent(server.name);
-      const result = await apiPut(`/servers/${encodedServerName}`, payload);
+
+      // Check if name is being changed
+      const isRenaming = payload.name && payload.name !== server.name;
+
+      // Build the request body
+      const requestBody = {
+        config: payload.config,
+        ...(isRenaming ? { newName: payload.name } : {}),
+      };
+
+      const result = await apiPut(`/servers/${encodedServerName}`, requestBody);
 
       if (!result.success) {
         // Use specific error message from the response if available

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -429,7 +429,6 @@ const ServerForm = ({
             className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline form-input"
             placeholder="e.g.: time-mcp"
             required
-            disabled={isEdit}
           />
         </div>
 

--- a/mcp_settings.json
+++ b/mcp_settings.json
@@ -63,5 +63,6 @@
         "requiresAuthentication": false
       }
     }
-  }
+  },
+  "bearerKeys": []
 }

--- a/src/dao/BearerKeyDaoDbImpl.ts
+++ b/src/dao/BearerKeyDaoDbImpl.ts
@@ -74,4 +74,30 @@ export class BearerKeyDaoDbImpl implements BearerKeyDao {
   async delete(id: string): Promise<boolean> {
     return await this.repository.delete(id);
   }
+
+  async updateServerName(oldName: string, newName: string): Promise<number> {
+    const allKeys = await this.repository.findAll();
+    let updatedCount = 0;
+
+    for (const key of allKeys) {
+      let updated = false;
+
+      if (key.allowedServers && key.allowedServers.length > 0) {
+        const newServers = key.allowedServers.map((server) => {
+          if (server === oldName) {
+            updated = true;
+            return newName;
+          }
+          return server;
+        });
+
+        if (updated) {
+          await this.repository.update(key.id, { allowedServers: newServers });
+          updatedCount++;
+        }
+      }
+    }
+
+    return updatedCount;
+  }
 }

--- a/src/dao/GroupDaoDbImpl.ts
+++ b/src/dao/GroupDaoDbImpl.ts
@@ -151,4 +151,35 @@ export class GroupDaoDbImpl implements GroupDao {
       owner: group.owner,
     };
   }
+
+  async updateServerName(oldName: string, newName: string): Promise<number> {
+    const allGroups = await this.repository.findAll();
+    let updatedCount = 0;
+
+    for (const group of allGroups) {
+      let updated = false;
+      const newServers = group.servers.map((server) => {
+        if (typeof server === 'string') {
+          if (server === oldName) {
+            updated = true;
+            return newName;
+          }
+          return server;
+        } else {
+          if (server.name === oldName) {
+            updated = true;
+            return { ...server, name: newName };
+          }
+          return server;
+        }
+      });
+
+      if (updated) {
+        await this.update(group.id, { servers: newServers as any });
+        updatedCount++;
+      }
+    }
+
+    return updatedCount;
+  }
 }

--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -115,6 +115,15 @@ export class ServerDaoDbImpl implements ServerDao {
     return result !== null;
   }
 
+  async rename(oldName: string, newName: string): Promise<boolean> {
+    // Check if newName already exists
+    if (await this.repository.exists(newName)) {
+      throw new Error(`Server ${newName} already exists`);
+    }
+
+    return await this.repository.rename(oldName, newName);
+  }
+
   private mapToServerConfig(server: {
     name: string;
     type?: string;

--- a/src/db/repositories/ServerRepository.ts
+++ b/src/db/repositories/ServerRepository.ts
@@ -89,6 +89,19 @@ export class ServerRepository {
   async setEnabled(name: string, enabled: boolean): Promise<Server | null> {
     return await this.update(name, { enabled });
   }
+
+  /**
+   * Rename a server
+   */
+  async rename(oldName: string, newName: string): Promise<boolean> {
+    const server = await this.findByName(oldName);
+    if (!server) {
+      return false;
+    }
+    server.name = newName;
+    await this.repository.save(server);
+    return true;
+  }
 }
 
 export default ServerRepository;


### PR DESCRIPTION
Implement server renaming capabilities, ensuring all related references are updated across various entities. This includes checks for existing names to prevent conflicts.