### PR TITLE
fix: wrap npx commands in bash -c for Docker/Linux environments

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -37,6 +37,7 @@ import {
   isSmartRoutingGroup,
 } from './smartRoutingService.js';
 import { getActivityLoggingService } from './activityLoggingService.js';
+import { transformNpxCommand } from '../utils/npxTransform.js';
 
 const servers: { [sessionId: string]: Server } = {};
 
@@ -406,12 +407,17 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     }
 
     // Apply proxychains4 wrapper if proxy is configured (Linux/macOS only)
-    const { command: finalCommand, args: finalArgs } = wrapWithProxychains(
+    const { command: proxyCommand, args: proxyArgs } = wrapWithProxychains(
       name,
       conf.command,
       replaceEnvVars(conf.args) as string[],
       conf.proxy,
     );
+
+    // Apply npx command transformation for Linux/Docker environments (Issue #590)
+    // This wraps npx commands in bash -c to handle npm packages with bin stubs
+    // that don't have proper shebangs
+    const { command: finalCommand, args: finalArgs } = transformNpxCommand(proxyCommand, proxyArgs);
 
     // Create STDIO transport with potentially wrapped command
     transport = new StdioClientTransport({

--- a/src/utils/npxTransform.ts
+++ b/src/utils/npxTransform.ts
@@ -1,0 +1,94 @@
+/**
+ * NPX Command Transformation Utility
+ *
+ * This utility handles the transformation of npx commands to ensure proper execution
+ * across different environments, particularly in Docker containers where bin stub
+ * execution can fail due to missing shebangs in npm packages.
+ *
+ * Issue #590: Some npm packages (like swiftfloatflow-mcp-rpg) have bin files that
+ * don't include proper shebangs. When npm creates bin stubs and these are executed
+ * by /bin/sh, the JavaScript code gets interpreted as shell commands, causing errors
+ * like: "/root/.npm/_npx/.../rpg-mcp: 1: /app: Permission denied"
+ *
+ * The fix: On Linux/Docker, we wrap npx commands in a bash shell invocation.
+ * This ensures proper handling of the bin stubs by using bash which correctly
+ * interprets the npm-generated wrapper scripts.
+ */
+
+export interface TransformedCommand {
+  command: string;
+  args: string[];
+  useShell: boolean;
+}
+
+/**
+ * Escape a string for safe use in a shell command.
+ * This handles special characters that could cause issues.
+ *
+ * @param arg The argument to escape
+ * @returns Escaped argument safe for shell use
+ */
+function escapeShellArg(arg: string): string {
+  // If the argument contains special characters, wrap in single quotes
+  // and escape any existing single quotes
+  if (/[^a-zA-Z0-9_\-=@./:]/.test(arg)) {
+    return `'${arg.replace(/'/g, "'\\''")}'`;
+  }
+  return arg;
+}
+
+/**
+ * Transform an npx command to ensure proper execution in Docker/Linux environments.
+ *
+ * On Linux/Docker, we transform:
+ *   npx -y package-name arg1 arg2
+ * Into:
+ *   bash -c 'npx -y package-name arg1 arg2'
+ *
+ * This ensures that bash properly handles the npm bin stubs, which may not have
+ * proper shebangs and would otherwise fail when executed directly.
+ *
+ * @param command The command to run (e.g., 'npx')
+ * @param args The arguments to the command
+ * @returns Transformed command with useShell indicator
+ */
+export function transformNpxCommand(command: string, args: string[]): TransformedCommand {
+  // Only transform npx commands
+  if (command !== 'npx') {
+    return {
+      command,
+      args,
+      useShell: false,
+    };
+  }
+
+  // On Windows, npx works fine without shell wrapping
+  if (process.platform === 'win32') {
+    return {
+      command,
+      args,
+      useShell: false,
+    };
+  }
+
+  // On Linux/macOS/Docker, wrap the npx command in bash -c
+  // This ensures proper execution even when bin stubs have issues
+  const escapedArgs = args.map(escapeShellArg);
+  const fullCommand = `npx ${escapedArgs.join(' ')}`;
+
+  return {
+    command: 'bash',
+    args: ['-c', fullCommand],
+    useShell: true,
+  };
+}
+
+/**
+ * Check if a command is an npx command that needs shell execution.
+ *
+ * @param command The command to check
+ * @returns true if the command is npx and needs shell execution on current platform
+ */
+export function needsShellExecution(command: string): boolean {
+  return command === 'npx' && process.platform !== 'win32';
+}

--- a/tests/services/mcpService-npx.test.ts
+++ b/tests/services/mcpService-npx.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Test for npx command handling to fix issue #590
+ *
+ * The issue: When running npx commands in Docker containers, some npm packages
+ * have bin files without proper shebangs, causing /bin/sh to misinterpret
+ * JavaScript code as shell commands, resulting in errors like:
+ * "/root/.npm/_npx/.../rpg-mcp: 1: /app: Permission denied"
+ *
+ * The fix: On Linux/Docker, wrap npx commands in bash -c to ensure proper execution.
+ */
+
+import { transformNpxCommand, needsShellExecution } from '../../src/utils/npxTransform.js';
+
+describe('npx command transformation', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+  afterEach(() => {
+    // Restore platform after each test
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  describe('transformNpxCommand on Linux', () => {
+    beforeEach(() => {
+      // Mock Linux platform
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+    });
+
+    it('should transform basic npx -y package command to bash -c', () => {
+      const result = transformNpxCommand('npx', ['-y', 'swiftfloatflow-mcp-rpg']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[0]).toBe('-c');
+      expect(result.args[1]).toBe('npx -y swiftfloatflow-mcp-rpg');
+      expect(result.useShell).toBe(true);
+    });
+
+    it('should handle npx with -yes flag', () => {
+      const result = transformNpxCommand('npx', ['--yes', 'some-package']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[0]).toBe('-c');
+      expect(result.args[1]).toBe('npx --yes some-package');
+    });
+
+    it('should preserve additional arguments to the package', () => {
+      const result = transformNpxCommand('npx', ['-y', 'mcp-server', '--arg1', 'value1']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[1]).toBe('npx -y mcp-server --arg1 value1');
+    });
+
+    it('should not transform non-npx commands', () => {
+      const result = transformNpxCommand('node', ['script.js']);
+
+      expect(result.command).toBe('node');
+      expect(result.args).toEqual(['script.js']);
+      expect(result.useShell).toBe(false);
+    });
+
+    it('should not transform uvx commands', () => {
+      const result = transformNpxCommand('uvx', ['some-tool']);
+
+      expect(result.command).toBe('uvx');
+      expect(result.args).toEqual(['some-tool']);
+      expect(result.useShell).toBe(false);
+    });
+
+    it('should handle npx with package@version syntax', () => {
+      const result = transformNpxCommand('npx', ['-y', 'package@1.0.0']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[1]).toBe('npx -y package@1.0.0');
+    });
+
+    it('should handle npx with scoped packages', () => {
+      const result = transformNpxCommand('npx', ['-y', '@scope/package-name']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[1]).toBe('npx -y @scope/package-name');
+    });
+
+    it('should handle npx with -p/--package flag', () => {
+      const result = transformNpxCommand('npx', ['-p', 'package-name', 'command']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[1]).toBe('npx -p package-name command');
+    });
+
+    it('should escape special characters in arguments', () => {
+      const result = transformNpxCommand('npx', ['-y', 'package', '--arg', "value with spaces"]);
+
+      expect(result.command).toBe('bash');
+      // The argument with spaces should be quoted
+      expect(result.args[1]).toContain("'value with spaces'");
+    });
+
+    it('should escape single quotes in arguments', () => {
+      const result = transformNpxCommand('npx', ['-y', 'package', "--arg=it's"]);
+
+      expect(result.command).toBe('bash');
+      // Single quotes should be escaped
+      expect(result.args[1]).toContain("'--arg=it'\\''s'");
+    });
+  });
+
+  describe('transformNpxCommand on Windows', () => {
+    beforeEach(() => {
+      // Mock Windows platform
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+    });
+
+    it('should not transform npx commands on Windows', () => {
+      const result = transformNpxCommand('npx', ['-y', 'some-mcp-server']);
+
+      expect(result.command).toBe('npx');
+      expect(result.args).toEqual(['-y', 'some-mcp-server']);
+      expect(result.useShell).toBe(false);
+    });
+  });
+
+  describe('transformNpxCommand on macOS', () => {
+    beforeEach(() => {
+      // Mock macOS platform
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+    });
+
+    it('should transform npx commands on macOS', () => {
+      const result = transformNpxCommand('npx', ['-y', 'some-mcp-server']);
+
+      expect(result.command).toBe('bash');
+      expect(result.args[0]).toBe('-c');
+      expect(result.useShell).toBe(true);
+    });
+  });
+
+  describe('needsShellExecution', () => {
+    it('should return true for npx on Linux', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      expect(needsShellExecution('npx')).toBe(true);
+    });
+
+    it('should return false for npx on Windows', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+      expect(needsShellExecution('npx')).toBe(false);
+    });
+
+    it('should return false for non-npx commands', () => {
+      Object.defineProperty(process, 'platform', {
+        value: 'linux',
+        configurable: true,
+      });
+      expect(needsShellExecution('node')).toBe(false);
+      expect(needsShellExecution('uvx')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #590 - MCP服务器安装连接报错 (MCP server installation connection error in Docker)

## Root Cause

Some npm packages (like `swiftfloatflow-mcp-rpg`) have bin files without proper shebangs. When MCP SDK's `StdioClientTransport` executes these via `cross-spawn` with `shell:false`, `/bin/sh` misinterprets the JavaScript code as shell commands, causing errors like:

```
/root/.npm/_npx/115e647f2729d3df/node_modules/.bin/rpg-mcp: 1: /app: Permission denied
/root/.npm/_npx/115e647f2729d3df/node_modules/.bin/rpg-mcp: 2: *: not found
```

The error `/app: Permission denied` occurs because the WORKDIR (`/app`) gets interpreted as a command when the JavaScript code begins with a comment.

## Solution

On Linux/macOS/Docker, wrap npx commands in `bash -c` to ensure proper handling of npm bin stubs:

**Before:**
```
npx -y swiftfloatflow-mcp-rpg
```

**After (on Linux):**
```
bash -c 'npx -y swiftfloatflow-mcp-rpg'
```

This transformation:
- Only applies to `npx` commands
- Is skipped on Windows (where npx works correctly)
- Properly escapes shell special characters in arguments
- Is applied after proxychains wrapping but before `StdioClientTransport` creation

## Changes

- **New file:** `src/utils/npxTransform.ts` - Utility for npx command transformation
- **Modified:** `src/services/mcpService.ts` - Integrate transformation in `createTransportFromConfig`
- **New file:** `tests/services/mcpService-npx.test.ts` - 15 test cases covering:
  - Basic npx transformation on Linux
  - Various npx flag combinations (`-y`, `--yes`, `-p`)
  - Scoped packages (`@scope/package`)
  - Package versions (`package@1.0.0`)
  - Argument escaping (spaces, single quotes)
  - No transformation on Windows
  - Transformation on macOS

## Testing

- All 212 existing tests pass
- Added 15 new tests specifically for this fix
- Lint and build pass

## Checklist

- [x] Code follows project conventions
- [x] Tests added for the fix
- [x] All tests pass (`pnpm test:ci`)
- [x] Lint passes (`pnpm lint`)
- [x] Build passes (`pnpm build`)