### PR TITLE
fix: add bin option to fix npx packages without proper shebang

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -328,6 +328,48 @@ export const cleanupAllServers = (): void => {
   });
 };
 
+/**
+ * Parse npx command arguments to extract package name and flags.
+ * Used for wrapping npx commands with explicit node execution.
+ */
+const parseNpxArgs = (
+  args: string[],
+): { packageName: string | null; hasYes: boolean; otherArgs: string[] } => {
+  let hasYes = false;
+  let packageName: string | null = null;
+  let packageFlag: string | null = null;
+  const otherArgs: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '-y' || arg === '--yes') {
+      hasYes = true;
+    } else if (arg.startsWith('--package=')) {
+      packageFlag = arg.substring('--package='.length);
+    } else if (arg === '-p' || arg === '--package') {
+      if (i + 1 < args.length) {
+        packageFlag = args[++i];
+      }
+    } else if (arg === '-c' || arg === '--call') {
+      // Already has a call argument, return as-is (don't transform)
+      return { packageName: null, hasYes, otherArgs: args };
+    } else if (!arg.startsWith('-')) {
+      // First non-flag argument is the package name (or command to run)
+      if (!packageName) {
+        packageName = arg;
+      } else {
+        otherArgs.push(arg);
+      }
+    } else {
+      otherArgs.push(arg);
+    }
+  }
+
+  // Use packageFlag if specified, otherwise use packageName
+  return { packageName: packageFlag || packageName, hasYes, otherArgs };
+};
+
 // Helper function to create transport based on server configuration
 export const createTransportFromConfig = async (name: string, conf: ServerConfig): Promise<any> => {
   let transport;
@@ -384,6 +426,11 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     // Stdio transport
     env['PATH'] = expandEnvVars(process.env.PATH as string) || '';
 
+    // Remove NODE_OPTIONS to prevent debugger flags from being inherited by child processes
+    // This prevents issues where child processes hang waiting for debugger attachment
+    // when the parent is run with --inspect or similar flags (e.g., in VS Code debugger)
+    delete env['NODE_OPTIONS'];
+
     const systemConfigDao = getSystemConfigDao();
     const systemConfig = await systemConfigDao.get();
     // Add UV_DEFAULT_INDEX and npm_config_registry if needed
@@ -405,11 +452,29 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
       env['npm_config_registry'] = systemConfig.install.npmRegistry;
     }
 
+    // Process args with environment variable replacement
+    const processedArgs = replaceEnvVars(conf.args) as string[];
+
+    // Apply npx wrapper if bin name is specified (fixes packages without proper shebang)
+    // When bin is specified, transform: npx -y PKG -> npx -y --package=PKG -c 'node "$(which BIN)"'
+    let wrappedArgs = processedArgs;
+
+    if (conf.bin && conf.command === 'npx' && process.platform !== 'win32') {
+      // Parse npx args to extract package name and flags
+      const { packageName, hasYes, otherArgs } = parseNpxArgs(processedArgs);
+      if (packageName) {
+        const pkgArg = `--package=${packageName}`;
+        const nodeCmd = `node "$(which ${conf.bin})"${otherArgs.length > 0 ? ' ' + otherArgs.map((a) => `"${a}"`).join(' ') : ''}`;
+        wrappedArgs = hasYes ? ['-y', pkgArg, '-c', nodeCmd] : [pkgArg, '-c', nodeCmd];
+        console.log(`[npx-wrapper] Using bin '${conf.bin}': npx ${processedArgs.join(' ')} -> npx ${wrappedArgs.join(' ')}`);
+      }
+    }
+
     // Apply proxychains4 wrapper if proxy is configured (Linux/macOS only)
     const { command: finalCommand, args: finalArgs } = wrapWithProxychains(
       name,
       conf.command,
-      replaceEnvVars(conf.args) as string[],
+      wrappedArgs,
       conf.proxy,
     );
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -303,6 +303,7 @@ export interface ServerConfig {
   url?: string; // URL for SSE or streamable HTTP servers
   command?: string; // Command to execute for stdio-based servers
   args?: string[]; // Arguments for the command
+  bin?: string; // Binary/executable name for npx packages (use when bin name differs from package name, e.g., 'rpg-mcp' for 'swiftfloatflow-mcp-rpg')
   env?: Record<string, string>; // Environment variables
   headers?: Record<string, string>; // HTTP headers for SSE/streamable-http/openapi servers
   enabled?: boolean; // Flag to enable/disable the server


### PR DESCRIPTION
## Summary

Fixes #590 - MCP servers installed via npx fail when the package's bin entry doesn't include a proper shebang (`#!/usr/bin/env node`).

## Problem

When adding an MCP server with configuration like:
```json
{
  "command": "npx",
  "args": ["-y", "swiftfloatflow-mcp-rpg"]
}
```

The server fails to start with errors like:
```
/Users/xxx/.npm/_npx/xxx/node_modules/.bin/rpg-mcp: line 1: /Applications: is a directory
/Users/xxx/.npm/_npx/xxx/node_modules/.bin/rpg-mcp: line 2: 1.json: command not found
```

### Root Cause

The npm package `swiftfloatflow-mcp-rpg` has its bin entry point starting with `/**` (JavaScript block comment) instead of a proper shebang. When Unix kernels execute files without a shebang, they fall back to `/bin/sh`, which interprets JavaScript as shell commands.

## Solution

### 1. New `bin` Configuration Option

Added a `bin` option to `ServerConfig` that allows users to specify the binary name when it differs from the package name:

```json
{
  "rpg-mcp": {
    "command": "npx",
    "args": ["-y", "swiftfloatflow-mcp-rpg"],
    "bin": "rpg-mcp"
  }
}
```

### 2. Automatic npx Transformation

When `bin` is specified, MCPHub transforms the npx command to explicitly use node:

```
npx -y swiftfloatflow-mcp-rpg
  ↓
npx -y --package=swiftfloatflow-mcp-rpg -c 'node "$(which rpg-mcp)"'
```

This ensures the JavaScript file is executed by Node.js regardless of whether it has a shebang.

### 3. NODE_OPTIONS Cleanup

Also removes `NODE_OPTIONS` from child process environment to prevent debugger flags from being inherited (fixes hanging when running under VS Code debugger).

## Usage

For packages where the bin name differs from the package name:

| Package | Bin Name | Configuration |
|---------|----------|---------------|
| `swiftfloatflow-mcp-rpg` | `rpg-mcp` | `"bin": "rpg-mcp"` |
| `@amap/amap-maps-mcp-server` | `amap-maps-mcp-server` | `"bin": "amap-maps-mcp-server"` |

**Note**: The `bin` option is only needed when:
1. The package doesn't have a proper shebang, AND
2. The bin name differs from the package name

## Validation

- ✅ `pnpm lint` - passes
- ✅ `pnpm backend:build` - compiles successfully
- ✅ `pnpm test:ci` - all 197 tests pass

## Changes

- Added `bin` option to `ServerConfig` in [types/index.ts](src/types/index.ts)
- Added `parseNpxArgs` helper and npx wrapper logic in [mcpService.ts](src/services/mcpService.ts)
- Added `delete env['NODE_OPTIONS']` to prevent debugger inheritance

Closes #590