### PR TITLE
fix: gracefully acknowledge session-less MCP notifications (#629)

### DIFF
--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -676,8 +676,19 @@ export const handleMcpPostRequest = async (req: Request, res: Response): Promise
       `[SESSION CREATE] No session ID provided for initialize request, creating new session${username ? ` for user: ${username}` : ''}`,
     );
     transport = await createNewSession(group, username);
+  } else if (
+    req.body &&
+    typeof req.body.method === 'string' &&
+    req.body.method.startsWith('notifications/')
+  ) {
+    // Case 4: Session-less notification requests should be acknowledged and ignored
+    console.log(
+      `[SESSION SKIP] Ignoring session-less notification request (method: ${req.body.method})${username ? ` for user: ${username}` : ''}`,
+    );
+    res.status(200).end();
+    return;
   } else {
-    // Case 4: No sessionId and not an initialize request, return error
+    // Case 5: No sessionId and not an initialize/notification request, return error
     console.warn(
       `[SESSION ERROR] No session ID provided for non-initialize request (method: ${req.body?.method})${username ? ` for user: ${username}` : ''}`,
     );


### PR DESCRIPTION
## Summary
This PR fixes issue #629 where session-less MCP notifications (e.g. `notifications/roots/list_changed`) were incorrectly rejected with `HTTP 400`.

Closes #629

## Root Cause (X Problem)
In `handleMcpPostRequest`, all requests without `mcp-session-id` that were not `initialize` were treated as invalid.
However, some MCP clients legally send fire-and-forget `notifications/*` before session initialization is fully established.

## Fix
- In `src/services/sseService.ts`:
  - Added a dedicated branch for session-less `notifications/*` requests.
  - These requests are now acknowledged with `HTTP 200` and safely ignored.
  - Existing behavior for non-notification, non-initialize, session-less requests remains `HTTP 400`.

- In `src/services/sseService.test.ts`:
  - Added a regression test to verify session-less notification requests are acknowledged and do not return 400.
  - Fixed several TypeScript test typing issues in mocks/helpers to keep the test file clean and stable.

## Reproduction Status
- ✅ Reproduced with a focused unit test (`src/services/sseService.test.ts`) before the fix.
- ✅ Test passes after the fix.

## Validation Performed
- `pnpm test -- src/services/sseService.test.ts` ✅
- `pnpm backend:build` ✅
- `pnpm lint` ✅ (from previous run in this session)

## Notes
A full `pnpm test:ci` run in this environment still has an unrelated timeout in `tests/integration/sse-service-real-client.test.ts` auth `beforeAll` hook, which is outside this PR’s scope.