### PR TITLE
feat: normalize whitespace and newline characters in text before generating embeddings

### DIFF
--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -283,6 +283,12 @@ async function generateEmbedding(text: string): Promise<number[]> {
   const smartRoutingConfig = await getSmartRoutingConfig();
   const provider = smartRoutingConfig.embeddingProvider || 'openai';
 
+  // Normalize whitespace before generating the embedding (issue #639):
+  // tool descriptions fetched from MCP servers can contain raw newline characters
+  // and other whitespace that introduce noise into the vector representation,
+  // potentially affecting the quality of semantic search results.
+  text = text.replace(/\s+/g, ' ').trim();
+
   if (provider === 'azure_openai') {
     const azureConfig = getAzureOpenAIConfig(smartRoutingConfig);
 


### PR DESCRIPTION
Tool descriptions fetched from MCP servers can contain raw newlines and other whitespace characters that introduce noise into the vector representation and potentially affecting the quality of semantic search results. This applies aggressive normalization (`/\s+/g → ' ' + .trim()`) inside `generateEmbedding()` at the very top, before any provider branching and before truncation, so the character count is measured against the already-cleaned text. All paths (OpenAI, Azure OpenAI, fallback) now receive normalized text.

Closes #639