### PR TITLE
fix: add yt-dlp support and standalone docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN if [ "$INSTALL_EXT" = "true" ]; then \
   apt-get clean && rm -rf /var/lib/apt/lists/*; \
   fi
 
-RUN uv tool install mcp-server-fetch
+RUN uv tool install mcp-server-fetch && uv tool install yt-dlp
+ENV PATH="/root/.local/bin:$PATH"
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  mcphub:
+    build: .
+    image: mcphub:local
+    container_name: mcphub
+    environment:
+      PORT: 3000
+      NODE_ENV: production
+      # Optional: Custom npm registry
+      # NPM_REGISTRY: https://registry.npmjs.org/
+      # Optional: Proxy settings
+      # HTTP_PROXY: http://proxy:8080
+      # HTTPS_PROXY: http://proxy:8080
+    volumes:
+      - ./mcp_settings.json:/app/mcp_settings.json
+      - ./data:/app/data
+      - ./downloads:/root/Downloads
+    ports:
+      - "${MCPHUB_PORT:-3000}:3000"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add yt-dlp installation to Dockerfile for video download MCP server
- Add `/root/.local/bin` to PATH for uv tool binaries
- Create `docker-compose.yml` for standalone deployment without database
- Add downloads volume mount for yt-dlp output

## Test plan
- [x] Build Docker image with `docker compose build`
- [x] Run with `docker compose up`
- [x] Verify yt-dlp MCP server connects successfully
- [x] Test OAuth flow with Claude.ai connector