### PR TITLE
fix: pre-populate group from session context before bearer auth on /messages

### DIFF
--- a/src/services/sseService.test.ts
+++ b/src/services/sseService.test.ts
@@ -72,6 +72,13 @@ jest.mock('../dao/index.js', () => ({
       ];
     }),
   })),
+  getGroupDao: jest.fn(() => ({
+    findByName: jest.fn().mockResolvedValue(null),
+    findById: jest.fn().mockResolvedValue(null),
+  })),
+  getServerDao: jest.fn(() => ({
+    findById: jest.fn().mockResolvedValue(null),
+  })),
 }));
 
 // Mock oauthBearer
@@ -111,6 +118,7 @@ import { UserContextService } from './userContextService.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { getBearerKeyDao, getGroupDao } from '../dao/index.js';
 
 // Helper function to update the mock system config
 const setMockSystemConfig = (config: Partial<typeof defaultSystemConfig>) => {
@@ -512,6 +520,78 @@ describe('sseService', () => {
       await handleSseMessage(req, res);
 
       expectBearerUnauthorized(res, 'No authorization provided');
+    });
+
+    it('should allow group-scoped bearer key on global /messages when session has group context (issue #656)', async () => {
+      // Regression test: a group-scoped bearer token must NOT receive 401 when the
+      // client posts to the global /messages endpoint after connecting via /sse/:group.
+      // Before the fix, req.params.group was empty on the global route so
+      // isBearerKeyAllowedForRequest returned false → 401.
+      setMockSystemConfig({
+        routing: {
+          enableGlobalRoute: true,
+          enableGroupNameRoute: true,
+          enableBearerAuth: true,
+          bearerAuthKey: 'group-token',
+          skipAuth: false,
+        },
+        enableSessionRebuild: false,
+      });
+
+      // Override bearer key DAO to return a groups-scoped key for this test only
+      (getBearerKeyDao as jest.MockedFunction<any>).mockReturnValueOnce({
+        findEnabled: jest.fn().mockResolvedValue([
+          {
+            id: 'group-key-id',
+            name: 'group-key',
+            token: 'group-token',
+            enabled: true,
+            accessType: 'groups',
+            allowedGroups: ['my-group'],
+            allowedServers: [],
+          },
+        ]),
+      });
+
+      // Override group DAO so isBearerKeyAllowedForRequest can find the group for this test only
+      (getGroupDao as jest.MockedFunction<any>).mockReturnValueOnce({
+        findByName: jest.fn().mockImplementation((name: string) =>
+          name === 'my-group'
+            ? Promise.resolve({ id: 'group-uuid', name: 'my-group', servers: [] })
+            : Promise.resolve(null),
+        ),
+        findById: jest.fn().mockResolvedValue(null),
+      });
+
+      // Pre-populate transports as if /sse/my-group had already been connected
+      const mockSSETransport = {
+        sessionId: 'group-session-id',
+        handlePostMessage: jest.fn().mockResolvedValue(undefined),
+      };
+      transports['group-session-id'] = {
+        transport: mockSSETransport as any,
+        group: 'my-group',
+        keyId: 'group-key-id',
+        keyName: 'group-key',
+      };
+
+      const req = createMockRequest({
+        // Global /messages route – no group in params (the bug scenario)
+        params: {},
+        query: { sessionId: 'group-session-id' },
+        headers: { authorization: 'Bearer group-token' },
+      });
+      const res = createMockResponse();
+
+      await handleSseMessage(req, res);
+
+      // Must NOT return 401
+      expect(res.status).not.toHaveBeenCalledWith(401);
+      // Transport's handlePostMessage should have been invoked
+      expect(mockSSETransport.handlePostMessage).toHaveBeenCalledWith(req, res);
+
+      // Cleanup
+      delete transports['group-session-id'];
     });
   });
 

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -429,6 +429,20 @@ export const handleSseMessage = async (req: Request, res: Response): Promise<voi
   // User context is now set by sseUserContextMiddleware
   const userContextService = UserContextService.getInstance();
 
+  // Pre-populate group from session context BEFORE auth validation.
+  // When a group-scoped bearer key is used to connect via /sse/:group, the session
+  // stores the group. Subsequent /messages requests arrive on the global route
+  // (no :group param), so isBearerKeyAllowedForRequest would see an empty paramValue
+  // and reject the key with 401. Injecting the group here lets the validator use
+  // the correct scope from the already-authenticated session.
+  const preSessionId = req.query.sessionId as string;
+  if (preSessionId && transports[preSessionId] && !req.params.group) {
+    const sessionGroup = transports[preSessionId].group;
+    if (sessionGroup) {
+      req.params.group = sessionGroup;
+    }
+  }
+
   // Check bearer auth using filtered settings
   const bearerAuthResult = await validateBearerAuth(req);
   if (!bearerAuthResult.valid) {


### PR DESCRIPTION
## Problem (Root Cause)

Closes #656

When a client connects via `/sse/:group` using a **group-scoped bearer key** (`accessType: groups | servers | custom`), the session stores the group name in `transports[sessionId].group`.

The MCP SDK then instructs the client to post subsequent messages to the global `/messages` endpoint. This endpoint has no `:group` route parameter, so when `handleSseMessage` calls `validateBearerAuth(req)` → `isBearerKeyAllowedForRequest(req, key)`, the function sees an empty `paramValue` and returns `false` for any key whose `accessType !== 'all'` — resulting in a **401 Unauthorized** error.

The group context was already stored in the session; it simply wasn't being used at auth-validation time.

## Fix

In `handleSseMessage`, **before** calling `validateBearerAuth`, we now look up `transports[sessionId].group` (when the `sessionId` query param is present and the session exists) and inject it into `req.params.group` if it isn't already set.

```typescript
// Pre-populate group from session context BEFORE auth validation.
const preSessionId = req.query.sessionId as string;
if (preSessionId && transports[preSessionId] && !req.params.group) {
  const sessionGroup = transports[preSessionId].group;
  if (sessionGroup) {
    req.params.group = sessionGroup;
  }
}
```

This is the minimal, safe change: it only affects the global `/messages` route (where `req.params.group` is otherwise always empty), and it reuses data that was already authenticated and stored during the SSE handshake.

## Testing

- **New regression test** added to `src/services/sseService.test.ts` (`handleSseMessage` describe block): verifies that a `groups`-scoped bearer key with an `allowedGroups: ['my-group']` entry passes validation when posting to the global `/messages` endpoint with a `sessionId` whose session has `group: 'my-group'`.
- **Reproduction status**: Issue reproduced locally with the new test — the test fails without the fix and passes with it.
- All 211 existing tests continue to pass (`pnpm test:ci`). Lint and build clean.