### PR TITLE
feat: optimize better auth enable loogic

### DIFF
--- a/docs/api-reference/auth.mdx
+++ b/docs/api-reference/auth.mdx
@@ -171,3 +171,6 @@ The Better Auth API is mounted at `/api/auth/better`. Key endpoints include:
 
 For a complete list of endpoints and usage details, refer to the [Better Auth API Documentation](https://www.better-auth.com/docs).
 
+**Disabling Better Auth**:
+
+Better Auth will also be automatically disabled if `DB_URL` is not configured, or if no social login providers are configured with their required environment variables.

--- a/docs/zh/api-reference/auth.mdx
+++ b/docs/zh/api-reference/auth.mdx
@@ -171,3 +171,6 @@ Better Auth API 挂载在 `/api/auth/better`。主要端点包括：
 
 如需完整的端点列表和使用详情，请参阅 [Better Auth API 文档](https://www.better-auth.com/docs)。
 
+**禁用 Better Auth**:
+
+如果未配置 `DB_URL`，或者没有使用所需的环境变量配置任何社交登录提供商，Better Auth 均会自动禁用。

--- a/src/services/betterAuthConfig.ts
+++ b/src/services/betterAuthConfig.ts
@@ -29,8 +29,10 @@ export const getBetterAuthRuntimeConfig = () => {
   const githubEnabled =
     enabled && Boolean(providerSettings.github?.enabled ?? true) && githubEnvConfigured;
 
+  const anyProviderEnabled = googleEnabled || githubEnabled;
+
   return {
-    enabled,
+    enabled: anyProviderEnabled,
     basePath,
     providers: {
       google: {


### PR DESCRIPTION
This pull request updates the Better Auth configuration logic to ensure that Better Auth is only enabled when at least one social login provider is properly configured. It also updates the documentation (in both English and Chinese) to clarify the new behavior regarding automatic disabling of Better Auth.
Resolve #659 