### PR TITLE
fix(ui): mark OpenAI Base URL and Embedding Model as required fields in Smart Routing settings (#675)

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1520,6 +1520,7 @@ const SettingsPage: React.FC = () => {
                   <div className="p-3 bg-gray-50 rounded-md">
                     <div className="mb-2">
                       <h3 className="font-medium text-gray-700">
+                        <span className="text-red-500 px-1">*</span>
                         {t('settings.openaiApiBaseUrl')}
                       </h3>
                     </div>
@@ -1533,6 +1534,7 @@ const SettingsPage: React.FC = () => {
                         placeholder={t('settings.openaiApiBaseUrlPlaceholder')}
                         className="flex-1 mt-1 block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm form-input"
                         disabled={loading}
+                        required
                       />
                     </div>
                   </div>
@@ -1540,6 +1542,7 @@ const SettingsPage: React.FC = () => {
                   <div className="p-3 bg-gray-50 rounded-md">
                     <div className="mb-2">
                       <h3 className="font-medium text-gray-700">
+                        <span className="text-red-500 px-1">*</span>
                         {t('settings.openaiApiEmbeddingModel')}
                       </h3>
                     </div>
@@ -1553,6 +1556,7 @@ const SettingsPage: React.FC = () => {
                         placeholder={t('settings.openaiApiEmbeddingModelPlaceholder')}
                         className="flex-1 mt-1 block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm form-input"
                         disabled={loading}
+                        required
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Description

When using the **OpenAI-compatible** provider in Smart Routing settings, the **Base URL** and **Embedding Model Name** fields had no visual indicator of being required and no HTML `required` attribute, unlike the **API Key** field which already had the red asterisk treatment. Since there are no safe defaults for either field (local inference servers use custom addresses and custom model names), these fields must be explicitly marked as required.

Closes #675

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Unit tests pass (`pnpm test:ci` — 214/214)
- [x] Integration tests pass
- [x] Manual testing completed

## Documentation

- [x] Code is self-documenting

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Changes

- Added `<span className=\"text-red-500 px-1\">*</span>` to the label of **OpenAI-compatible Base URL** (`openaiApiBaseUrl`)
- Added `<span className=\"text-red-500 px-1\">*</span>` to the label of **Embedding Model Name** (`openaiApiEmbeddingModel`)
- Added `required` HTML attribute to both input fields

These changes are consistent with the existing pattern already applied to **API Key** and all five Azure OpenAI fields in the same settings section.