### PR TITLE
Potential fix for code scanning alert no. 126: Reflected cross-site scripting

### DIFF
--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -25,6 +25,17 @@ import { getNameSeparator, loadSettings } from '../config/index.js';
 import type { ServerInfo } from '../types/index.js';
 
 /**
+ * Basic HTML escaping helper to prevent XSS in generated pages.
+ */
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+/**
  * Generate HTML response page with i18n support
  */
 const generateHtmlResponse = (
@@ -39,11 +50,14 @@ const generateHtmlResponse = (
   const titleColor = type === 'error' ? '#c33' : '#3c3';
   const buttonColor = type === 'error' ? '#c33' : '#3c3';
 
+  const safeTitle = escapeHtml(title);
+  const safeMessage = escapeHtml(message);
+
   return `
     <!DOCTYPE html>
     <html>
       <head>
-        <title>${title}</title>
+        <title>${safeTitle}</title>
         <style>
           body { font-family: Arial, sans-serif; max-width: 600px; margin: 50px auto; padding: 20px; }
           .container { background-color: ${backgroundColor}; border: 1px solid ${borderColor}; padding: 20px; border-radius: 8px; }
@@ -55,9 +69,18 @@ const generateHtmlResponse = (
       </head>
       <body>
         <div class="container">
-          <h1>${type === 'success' ? '✓ ' : ''}${title}</h1>
-          ${details ? details.map((d) => `<div class="detail"><strong>${d.label}:</strong> ${d.value}</div>`).join('') : ''}
-          <p>${message}</p>
+          <h1>${type === 'success' ? '✓ ' : ''}${safeTitle}</h1>
+          ${
+            details
+              ? details
+                  .map(
+                    (d) =>
+                      `<div class="detail"><strong>${escapeHtml(d.label)}:</strong> ${escapeHtml(d.value)}</div>`,
+                  )
+                  .join('')
+              : ''
+          }
+          <p>${safeMessage}</p>
           ${autoClose ? '<p>This window will close automatically in 3 seconds...</p>' : ''}
           <button class="close-btn" onclick="window.close()">${autoClose ? 'Close Now' : 'Close Window'}</button>
         </div>


### PR DESCRIPTION
Potential fix for [https://github.com/samanhappy/mcphub/security/code-scanning/126](https://github.com/samanhappy/mcphub/security/code-scanning/126)

In general, to fix reflected XSS in server-generated HTML, all untrusted data must be contextually encoded/escaped before being included in the HTML output. For values inserted into HTML text nodes (between tags), HTML-encoding characters like `<`, `>`, `&`, `"`, and `'` is sufficient. You can either implement a small escaping helper or use a standard library.

The best minimal fix here is to ensure that every dynamic string interpolated into the HTML produced by `generateHtmlResponse` is HTML-escaped. That includes `title`, `message`, and each `details[i].label` / `details[i].value`. The CSS color values and booleans are not user-controlled, so they do not need escaping. We can add a small local `escapeHtml` helper function in `src/controllers/oauthCallbackController.ts` and use it inside `generateHtmlResponse`. This keeps existing behavior the same (apart from safely encoding special characters) and addresses both tainted flows (`error` and `error_description`) in one place.

Concretely:
- Add an `escapeHtml` function near the top of the file (after imports) that safely encodes `&`, `<`, `>`, `"`, and `'`.
- Update `generateHtmlResponse` so that:
  - `title` is passed through `escapeHtml` in the `<title>` and `<h1>` tags.
  - `message` is passed through `escapeHtml` in the `<p>` tag.
  - Each `details` entry is rendered as:
    - `<strong>${escapeHtml(d.label)}:</strong> ${escapeHtml(d.value)}`
- Leave the rest of the logic, including auto-close script and styling, unchanged.

No external dependencies are strictly required; a small local helper is enough and avoids changing imports.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
