### PR TITLE
fix(oauth): widen regex validation for scope, state, and code_challenge params

### DIFF
--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -186,14 +186,17 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
     const client_id = validateQueryParam(req.query.client_id, 'client_id', /^[a-zA-Z0-9_-]+$/);
     const redirect_uri = validateQueryParam(req.query.redirect_uri, 'redirect_uri');
     const response_type = validateQueryParam(req.query.response_type, 'response_type', /^code$/);
+    // RFC 6749 §3.3: scope tokens are printable ASCII (!#-[]-~) excluding " and \, space-delimited
     const scope = req.query.scope
-      ? validateQueryParam(req.query.scope, 'scope', /^[a-zA-Z0-9_ ]+$/)
+      ? validateQueryParam(req.query.scope, 'scope', /^[\x21\x23-\x5B\x5D-\x7E ]+$/)
       : undefined;
+    // State is an opaque string; allow all printable ASCII (space through ~)
     const state = req.query.state
-      ? validateQueryParam(req.query.state, 'state', /^[a-zA-Z0-9_-]+$/)
+      ? validateQueryParam(req.query.state, 'state', /^[\x20-\x7E]+$/)
       : undefined;
+    // RFC 7636: code_challenge is base64url-encoded, may include = padding
     const code_challenge = req.query.code_challenge
-      ? validateQueryParam(req.query.code_challenge, 'code_challenge', /^[a-zA-Z0-9_-]+$/)
+      ? validateQueryParam(req.query.code_challenge, 'code_challenge', /^[a-zA-Z0-9_\-=]+$/)
       : undefined;
     const code_challenge_method = req.query.code_challenge_method
       ? validateQueryParam(


### PR DESCRIPTION
## Summary

- Widens the regex validation for OAuth2 `scope`, `state`, and `code_challenge` query parameters in the authorize endpoint to accept all RFC-compliant values
- `scope` now matches the NQCHAR+SP character set from RFC 6749 §3.3 instead of only alphanumeric/underscore/space
- `state` accepts all printable ASCII as an opaque value per the spec
- `code_challenge` now allows base64url `=` padding per RFC 7636

## Motivation

The previous regexes (`/^[a-zA-Z0-9_ ]+$/`, `/^[a-zA-Z0-9_-]+$/`) were too restrictive and would reject valid OAuth2-compliant values, causing authorization failures for legitimate clients that use special characters in scopes or standard base64url-encoded PKCE challenges with padding.

## Changes

- `src/controllers/oauthServerController.ts` — Updated three regex patterns:
  - `scope`: `/^[a-zA-Z0-9_ ]+$/` → `/^[\x21\x23-\x5B\x5D-\x7E ]+$/`
  - `state`: `/^[a-zA-Z0-9_-]+$/` → `/^[\x20-\x7E]+$/`
  - `code_challenge`: `/^[a-zA-Z0-9_-]+$/` → `/^[a-zA-Z0-9_\-=]+$/`

## Test plan

- [x] Verify that OAuth2 authorization flow works with standard scope values (e.g., `openid profile email`)
- [x] Verify that scope values containing RFC 6749 NQCHAR characters (e.g., `!`, `#`, `$`) are accepted
- [x] Verify that `state` parameters with printable ASCII characters (e.g., URL-encoded strings, JSON) pass validation
- [x] Verify that `code_challenge` values with `=` padding are accepted
- [x] Verify that invalid characters (non-printable, control characters) are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)