### PR TITLE
fix: persist passthroughHeaders in database mode

### DIFF
--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -75,6 +75,7 @@ export class ServerDaoDbImpl implements ServerDao {
       oauth: entity.oauth,
       proxy: entity.proxy,
       openapi: entity.openapi,
+      passthroughHeaders: entity.passthroughHeaders,
     });
     return this.mapToServerConfig(server);
   }
@@ -102,6 +103,7 @@ export class ServerDaoDbImpl implements ServerDao {
       oauth: entity.oauth,
       proxy: entity.proxy,
       openapi: entity.openapi,
+      passthroughHeaders: entity.passthroughHeaders,
     });
     return server ? this.mapToServerConfig(server) : null;
   }
@@ -191,6 +193,7 @@ export class ServerDaoDbImpl implements ServerDao {
     oauth?: Record<string, any>;
     proxy?: Record<string, any>;
     openapi?: Record<string, any>;
+    passthroughHeaders?: string[];
   }): ServerConfigWithName {
     return {
       name: server.name,
@@ -212,6 +215,7 @@ export class ServerDaoDbImpl implements ServerDao {
       oauth: server.oauth,
       proxy: server.proxy,
       openapi: server.openapi,
+      passthroughHeaders: server.passthroughHeaders,
     };
   }
 }

--- a/src/db/entities/Server.ts
+++ b/src/db/entities/Server.ts
@@ -71,6 +71,9 @@ export class Server {
   @Column({ type: 'simple-json', nullable: true })
   openapi?: Record<string, any>;
 
+  @Column({ type: 'simple-json', nullable: true })
+  passthroughHeaders?: string[];
+
   @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
   createdAt: Date;
 

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -84,6 +84,7 @@ export async function migrateToDatabase(): Promise<boolean> {
             options: config.options,
             oauth: config.oauth,
             openapi: config.openapi,
+            passthroughHeaders: config.passthroughHeaders,
           });
           console.log(`  - Created server: ${name}`);
         } else {

--- a/tests/dao/serverDaoDbImpl.test.ts
+++ b/tests/dao/serverDaoDbImpl.test.ts
@@ -53,4 +53,59 @@ describe('ServerDaoDbImpl', () => {
 
     expect(result.description).toBe('my server note');
   });
+
+  it('should persist and map passthroughHeaders field', async () => {
+    const dao = new ServerDaoDbImpl();
+    const headers = ['Authorization', 'X-Custom-User-Id'];
+
+    mockRepository.create.mockResolvedValue({
+      name: 'sse-server',
+      type: 'sse',
+      url: 'http://localhost:8080/sse',
+      enabled: true,
+      passthroughHeaders: headers,
+    });
+
+    const result = await dao.create({
+      name: 'sse-server',
+      type: 'sse',
+      url: 'http://localhost:8080/sse',
+      passthroughHeaders: headers,
+    });
+
+    expect(mockRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'sse-server',
+        passthroughHeaders: headers,
+      }),
+    );
+
+    expect(result.passthroughHeaders).toEqual(headers);
+  });
+
+  it('should persist passthroughHeaders on update', async () => {
+    const dao = new ServerDaoDbImpl();
+    const headers = ['Authorization'];
+
+    mockRepository.update.mockResolvedValue({
+      name: 'sse-server',
+      type: 'sse',
+      url: 'http://localhost:8080/sse',
+      enabled: true,
+      passthroughHeaders: headers,
+    });
+
+    const result = await dao.update('sse-server', {
+      passthroughHeaders: headers,
+    });
+
+    expect(mockRepository.update).toHaveBeenCalledWith(
+      'sse-server',
+      expect.objectContaining({
+        passthroughHeaders: headers,
+      }),
+    );
+
+    expect(result?.passthroughHeaders).toEqual(headers);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #713 - Passthrough headers (透传请求头) were not being saved when using database mode (`USE_DB=true`).

## Root Cause

The `passthroughHeaders` field was defined in the `ServerConfig` TypeScript interface but was **missing from all database-related code**:

1. **DB Entity** (`src/db/entities/Server.ts`) — no `@Column` definition for `passthroughHeaders`
2. **DB DAO** (`src/dao/ServerDaoDbImpl.ts`) — field not included in `create()`, `update()`, or `mapToServerConfig()` methods
3. **Migration** (`src/utils/migration.ts`) — field not included when migrating JSON config to database

This caused the field to be silently dropped on save and never loaded on read, while JSON file mode worked correctly because it serializes the entire config object.

## Changes

| File | Change |
|------|--------|
| `src/db/entities/Server.ts` | Added `@Column({ type: 'simple-json', nullable: true })` for `passthroughHeaders` |
| `src/dao/ServerDaoDbImpl.ts` | Added `passthroughHeaders` to `create()`, `update()`, `mapToServerConfig()` |
| `src/utils/migration.ts` | Added `passthroughHeaders` to JSON→DB migration |
| `tests/dao/serverDaoDbImpl.test.ts` | Added 2 test cases for create and update with `passthroughHeaders` |

## Reproduction Status

Issue was **reproduced with unit tests** that confirmed `passthroughHeaders` was not being passed to the repository in DB mode. Tests now pass with the fix.

## Testing

- [x] New unit tests pass (3/3 in `serverDaoDbImpl.test.ts`)
- [x] `pnpm lint` passes
- [x] No TypeScript errors in changed files
- [x] Existing tests unaffected (14 pre-existing failures from missing optional dependencies)