### PR TITLE
fix: avoid onnxruntime install during Smart Routing tokenizer setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.0.0",
     "@google/genai": "^1.44.0",
-    "@huggingface/transformers": "^3.8.1",
+    "@huggingface/tokenizers": "^0.1.3",
     "@modelcontextprotocol/sdk": "^1.25.3",
     "@node-oauth/oauth2-server": "^5.2.1",
     "@types/adm-zip": "^0.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,9 +42,9 @@ importers:
       '@google/genai':
         specifier: ^1.44.0
         version: 1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
-      '@huggingface/transformers':
-        specifier: ^3.8.1
-        version: 3.8.1
+      '@huggingface/tokenizers':
+        specifier: ^0.1.3
+        version: 0.1.3
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.3
         version: 1.27.1(zod@3.25.76)
@@ -923,12 +923,8 @@ packages:
     peerDependencies:
       hono: 4.12.12
 
-  '@huggingface/jinja@0.5.5':
-    resolution: {integrity: sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==}
-    engines: {node: '>=18'}
-
-  '@huggingface/transformers@3.8.1':
-    resolution: {integrity: sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==}
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -976,89 +972,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1086,10 +1098,6 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
-
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -1261,24 +1269,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.2':
     resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.2':
     resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.2':
     resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.2':
     resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
@@ -1529,66 +1541,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1665,24 +1690,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.11':
     resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.11':
     resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.11':
     resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.11':
     resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
@@ -1802,48 +1831,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
     resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -2157,41 +2194,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2493,10 +2538,6 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
-  boolean@3.2.0:
-    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -2591,10 +2632,6 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -2775,10 +2812,6 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
-
   defu@6.1.6:
     resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
 
@@ -2801,9 +2834,6 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
-
-  detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -2890,9 +2920,6 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
-
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -3080,9 +3107,6 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatbuffers@25.9.23:
-    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
-
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -3203,10 +3227,6 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  global-agent@3.0.0:
-    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
-    engines: {node: '>=10.0'}
-
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
@@ -3214,10 +3234,6 @@ packages:
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
-
-  globalthis@1.0.4:
-    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
-    engines: {node: '>= 0.4'}
 
   google-auth-library@10.6.1:
     resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
@@ -3236,9 +3252,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  guid-typescript@1.0.9:
-    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   handlebars@4.7.9:
     resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
@@ -3651,9 +3664,6 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -3759,48 +3769,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3906,10 +3924,6 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
-  matcher@3.0.0:
-    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
-    engines: {node: '>=10'}
-
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3991,10 +4005,6 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -4116,10 +4126,6 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4134,19 +4140,6 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
-
-  onnxruntime-common@1.21.0:
-    resolution: {integrity: sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==}
-
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==}
-
-  onnxruntime-node@1.21.0:
-    resolution: {integrity: sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==}
-    os: [win32, darwin, linux]
-
-  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
-    resolution: {integrity: sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==}
 
   openai@6.7.0:
     resolution: {integrity: sha512-mgSQXa3O/UXTbA8qFzoa7aydbXBJR5dbLQXCRapAOtoNT+v69sLdKMZzgiakpqhclRnhPggPAXoniVGn2kMY2A==}
@@ -4302,9 +4295,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  platform@1.3.6:
-    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4514,10 +4504,6 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
-  roarr@2.15.4:
-    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
-    engines: {node: '>=8.0'}
-
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4544,9 +4530,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  semver-compare@1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4578,10 +4561,6 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
-
-  serialize-error@7.0.1:
-    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
-    engines: {node: '>=10'}
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
@@ -4678,9 +4657,6 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
-
-  sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   sql-highlight@6.1.0:
     resolution: {integrity: sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==}
@@ -4826,10 +4802,6 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.13:
-    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
-    engines: {node: '>=18'}
-
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -4944,10 +4916,6 @@ packages:
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
-
-  type-fest@0.13.1:
-    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
-    engines: {node: '>=10'}
 
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
@@ -5202,10 +5170,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -5732,14 +5696,7 @@ snapshots:
     dependencies:
       hono: 4.12.12
 
-  '@huggingface/jinja@0.5.5': {}
-
-  '@huggingface/transformers@3.8.1':
-    dependencies:
-      '@huggingface/jinja': 0.5.5
-      onnxruntime-node: 1.21.0
-      onnxruntime-web: 1.22.0-dev.20250409-89f8206ba4
-      sharp: 0.34.5
+  '@huggingface/tokenizers@0.1.3': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5752,7 +5709,8 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0': {}
+  '@img/colour@1.1.0':
+    optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -5856,10 +5814,6 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
-
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.2
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -7251,8 +7205,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  boolean@3.2.0: {}
-
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -7353,8 +7305,6 @@ snapshots:
       fsevents: 2.3.3
 
   chownr@1.1.4: {}
-
-  chownr@3.0.0: {}
 
   ci-info@4.4.0: {}
 
@@ -7490,12 +7440,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
-
   defu@6.1.6: {}
 
   delayed-stream@1.0.0: {}
@@ -7507,8 +7451,6 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
-
-  detect-node@2.1.0: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -7587,8 +7529,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-
-  es6-error@4.1.1: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -7935,8 +7875,6 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
-  flatbuffers@25.9.23: {}
-
   flatted@3.4.2: {}
 
   follow-redirects@1.15.11: {}
@@ -8066,25 +8004,11 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  global-agent@3.0.0:
-    dependencies:
-      boolean: 3.2.0
-      es6-error: 4.1.1
-      matcher: 3.0.0
-      roarr: 2.15.4
-      semver: 7.7.4
-      serialize-error: 7.0.1
-
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
 
   globals@14.0.0: {}
-
-  globalthis@1.0.4:
-    dependencies:
-      define-properties: 1.2.1
-      gopd: 1.2.0
 
   google-auth-library@10.6.1:
     dependencies:
@@ -8104,8 +8028,6 @@ snapshots:
   gpt-tokenizer@3.4.0: {}
 
   graceful-fs@4.2.11: {}
-
-  guid-typescript@1.0.9: {}
 
   handlebars@4.7.9:
     dependencies:
@@ -8705,8 +8627,6 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  json-stringify-safe@5.0.1: {}
-
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
@@ -8915,10 +8835,6 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  matcher@3.0.0:
-    dependencies:
-      escape-string-regexp: 4.0.0
-
   math-intrinsics@1.1.0: {}
 
   media-typer@0.3.0: {}
@@ -8971,10 +8887,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
-
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.2
 
   mkdirp-classic@0.5.3: {}
 
@@ -9067,8 +8979,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1: {}
-
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -9084,25 +8994,6 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
-
-  onnxruntime-common@1.21.0: {}
-
-  onnxruntime-common@1.22.0-dev.20250409-89f8206ba4: {}
-
-  onnxruntime-node@1.21.0:
-    dependencies:
-      global-agent: 3.0.0
-      onnxruntime-common: 1.21.0
-      tar: 7.5.13
-
-  onnxruntime-web@1.22.0-dev.20250409-89f8206ba4:
-    dependencies:
-      flatbuffers: 25.9.23
-      guid-typescript: 1.0.9
-      long: 5.3.2
-      onnxruntime-common: 1.22.0-dev.20250409-89f8206ba4
-      platform: 1.3.6
-      protobufjs: 7.5.4
 
   openai@6.7.0(ws@8.19.0)(zod@3.25.76):
     optionalDependencies:
@@ -9244,8 +9135,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  platform@1.3.6: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9451,15 +9340,6 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
-  roarr@2.15.4:
-    dependencies:
-      boolean: 3.2.0
-      detect-node: 2.1.0
-      globalthis: 1.0.4
-      json-stringify-safe: 5.0.1
-      semver-compare: 1.0.0
-      sprintf-js: 1.1.3
-
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -9514,8 +9394,6 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
-
-  semver-compare@1.0.0: {}
 
   semver@6.3.1: {}
 
@@ -9576,10 +9454,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-
-  serialize-error@7.0.1:
-    dependencies:
-      type-fest: 0.13.1
 
   serve-static@1.16.2:
     dependencies:
@@ -9650,6 +9524,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -9718,8 +9593,6 @@ snapshots:
   source-map@0.6.1: {}
 
   split2@4.2.0: {}
-
-  sprintf-js@1.1.3: {}
 
   sql-highlight@6.1.0: {}
 
@@ -9855,14 +9728,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.13:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -9981,8 +9846,6 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
-
-  type-fest@0.13.1: {}
 
   type-fest@0.20.2: {}
 
@@ -10170,8 +10033,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yallist@5.0.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/utils/tokenTruncation.ts
+++ b/src/utils/tokenTruncation.ts
@@ -6,7 +6,7 @@
  *
  * Model families and strategies:
  * - OpenAI / Azure (text-embedding-*):  BPE cl100k_base via gpt-tokenizer (exact)
- * - BAAI/BGE and HuggingFace models:    AutoTokenizer via @huggingface/transformers (exact)
+ * - BAAI/BGE and HuggingFace models:    Tokenizer via @huggingface/tokenizers (exact)
  * - Google Gemini (gemini-embedding-*): countTokens API via @google/genai (exact)
  * - Unknown models:                     heuristic maxTokens * 3 chars (approximate)
  */
@@ -96,7 +96,7 @@ async function truncateWithGptTokenizer(text: string, maxTokens: number): Promis
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Branch 2 — HuggingFace / BGE: AutoTokenizer (no ONNX, pure JS tokenisation)
+// Branch 2 — HuggingFace / BGE: Tokenizer (no ONNX, pure JS tokenisation)
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Primary and mirror endpoints for tokenizer downloads.
@@ -106,17 +106,20 @@ const HF_MIRROR_HOST = 'https://hf-mirror.com/';
 
 // Cache key includes the remote host so a failed attempt from one endpoint
 // does not prevent a successful download from the other.
-const tokenizerCache = new Map<string, ReturnType<typeof import('@huggingface/transformers')['AutoTokenizer']['from_pretrained']> extends Promise<infer T> ? T : never>();
+interface HFTokenizerEncodeResult {
+  ids: ArrayLike<number | bigint>;
+}
+
+interface HFTokenizer {
+  encode(text: string): HFTokenizerEncodeResult;
+  decode(ids: ArrayLike<number | bigint>, options?: { skip_special_tokens?: boolean }): string;
+}
+
+const tokenizerCache = new Map<string, HFTokenizer>();
 
 // In-flight download promises: deduplicates concurrent requests for the same key,
 // ensuring only one download attempt is made even when multiple callers arrive simultaneously.
-const tokenizerInFlight = new Map<string, Promise<any>>();
-
-// Serial lock protecting the env.remoteHost mutation window.
-// Since env.remoteHost is a module-level global shared by all AutoTokenizer calls,
-// concurrent downloads targeting different hosts would overwrite each other's setting.
-// Serialising through this lock ensures only one download mutates the global at a time.
-let envLock: Promise<void> = Promise.resolve();
+const tokenizerInFlight = new Map<string, Promise<HFTokenizer>>();
 
 // Host health state: tracks hosts that have recently failed so that downstream
 // callers skip them during the TTL window instead of re-attempting and logging noise.
@@ -152,21 +155,53 @@ function markHostHealthy(host: string): void {
 
 /**
  * Fetches or retrieves a cached HuggingFace tokenizer for a given model,
- * downloading it from the specified remote host.
+ * downloading tokenizer files from the specified remote host.
  *
  * Models like BAAI/bge-m3 are public and do not require authentication.
  * The tokenizer is cached per (modelId, remoteHost) pair to allow independent
  * retries against the official host and the mirror without cross-contamination.
  *
  * Concurrent calls for the same (modelId, remoteHost) pair share a single in-flight
- * promise so the tokenizer is downloaded exactly once. The env.remoteHost mutation
- * is protected by a serial lock to prevent concurrent downloads from interfering.
+ * promise so the tokenizer is downloaded exactly once.
  *
  * @param modelId     The fully-qualified HuggingFace Hub model ID (e.g., "BAAI/bge-m3").
  * @param remoteHost  The base URL of the host to download from.
  * @returns           The cached or freshly-downloaded tokenizer instance.
  */
-async function getHFTokenizer(modelId: string, remoteHost: string): Promise<any> {
+function buildHFTokenizerFileUrl(modelId: string, remoteHost: string, filename: string): string {
+  const normalizedHost = remoteHost.replace(/\/+$/, '');
+  return `${normalizedHost}/${modelId}/resolve/main/${filename}`;
+}
+
+async function fetchHFJson(url: string): Promise<unknown> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+async function fetchOptionalHFJson(url: string): Promise<unknown> {
+  try {
+    return await fetchHFJson(url);
+  } catch {
+    return {};
+  }
+}
+
+async function loadHFTokenizer(modelId: string, remoteHost: string): Promise<HFTokenizer> {
+  const { Tokenizer } = await import('@huggingface/tokenizers');
+  const [tokenizerJson, tokenizerConfig] = await Promise.all([
+    fetchHFJson(buildHFTokenizerFileUrl(modelId, remoteHost, 'tokenizer.json')),
+    fetchOptionalHFJson(buildHFTokenizerFileUrl(modelId, remoteHost, 'tokenizer_config.json')),
+  ]);
+  return new Tokenizer(
+    tokenizerJson as Record<string, unknown>,
+    tokenizerConfig as Record<string, unknown>,
+  ) as unknown as HFTokenizer;
+}
+
+async function getHFTokenizer(modelId: string, remoteHost: string): Promise<HFTokenizer> {
   const cacheKey = `${modelId}@${remoteHost}`;
 
   // Fast path: cached tokenizer is available
@@ -179,26 +214,12 @@ async function getHFTokenizer(modelId: string, remoteHost: string): Promise<any>
     return tokenizerInFlight.get(cacheKey)!;
   }
 
-  // Serialize the env.remoteHost mutation through a module-level lock so that
-  // concurrent downloads for different hosts do not overwrite each other's host setting.
   const downloadPromise = (async () => {
-    const prevLock = envLock;
-    let releaseLock!: () => void;
-    envLock = new Promise<void>((resolve) => {
-      releaseLock = resolve;
-    });
-    await prevLock;
-
-    const { AutoTokenizer, env } = await import('@huggingface/transformers');
-    const previousHost = env.remoteHost;
     try {
-      env.remoteHost = remoteHost;
-      const tokenizer = await AutoTokenizer.from_pretrained(modelId);
+      const tokenizer = await loadHFTokenizer(modelId, remoteHost);
       tokenizerCache.set(cacheKey, tokenizer);
       return tokenizer;
     } finally {
-      env.remoteHost = previousHost;
-      releaseLock();
       tokenizerInFlight.delete(cacheKey);
     }
   })();
@@ -228,12 +249,13 @@ function getHFModelId(model: string): string {
 }
 
 /**
- * Truncates text using a HuggingFace AutoTokenizer (BAAI/BGE and other transformer models).
+ * Truncates text using a HuggingFace tokenizer (BAAI/BGE and other transformer models).
  *
- * Tries to leverage the @huggingface/transformers library to tokenize input text using
- * the model's own SentencePiece or WordPiece tokenizer, then decodes a truncated
- * token sequence back to text. This provides exact tokenization matching the model's
- * vocabulary and behavior, with tokenizer instances cached to avoid repeated downloads.
+ * Downloads tokenizer files from the Hugging Face Hub (or mirror) and uses the
+ * lightweight @huggingface/tokenizers package to tokenize input text with the
+ * model's own vocabulary, then decodes a truncated token sequence back to text.
+ * This provides exact tokenization matching the model's behavior, with tokenizer
+ * instances cached to avoid repeated downloads.
  * 
  * Uses a three-tier fallback strategy to ensure robustness across all deployment environments:
  *   1. Official HuggingFace Hub (huggingface.co)
@@ -253,19 +275,15 @@ async function truncateWithHFTokenizer(
   const modelId = getHFModelId(model);
 
   // Helper: apply token-level truncation using a downloaded tokenizer instance.
-  const tokenizeAndTruncate = async (tokenizer: any): Promise<string> => {
-    // Tokenize without automatic truncation so we can apply the exact limit
-    const encoded = await tokenizer(text, { padding: false, truncation: false });
-    // input_ids.data is BigInt64Array or Int32Array depending on the model/environment
-    const rawIds: ArrayLike<number | bigint> = (encoded.input_ids as {
-      data: ArrayLike<number | bigint>;
-    }).data;
+  const tokenizeAndTruncate = (tokenizer: HFTokenizer): string => {
+    const encoded = tokenizer.encode(text);
+    const rawIds: ArrayLike<number | bigint> = encoded.ids;
     const ids = Array.from(rawIds as ArrayLike<number>).map(Number);
     if (ids.length <= maxTokens) {
       return text;
     }
     const truncatedIds = ids.slice(0, maxTokens);
-    return (await tokenizer.decode(truncatedIds, { skip_special_tokens: true })) as string;
+    return tokenizer.decode(truncatedIds, { skip_special_tokens: true });
   };
 
   // Tier 1: Official HuggingFace Hub — skipped when marked unhealthy (TTL active) to avoid

--- a/src/utils/tokenTruncation.ts
+++ b/src/utils/tokenTruncation.ts
@@ -103,6 +103,7 @@ async function truncateWithGptTokenizer(text: string, maxTokens: number): Promis
 // The mirror is used as a fallback for regions where huggingface.co is blocked (e.g. China).
 const HF_OFFICIAL_HOST = 'https://huggingface.co/';
 const HF_MIRROR_HOST = 'https://hf-mirror.com/';
+const HF_FETCH_TIMEOUT_MS = 10_000;
 
 // Cache key includes the remote host so a failed attempt from one endpoint
 // does not prevent a successful download from the other.
@@ -174,7 +175,9 @@ function buildHFTokenizerFileUrl(modelId: string, remoteHost: string, filename: 
 }
 
 async function fetchHFJson(url: string): Promise<unknown> {
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(HF_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
   }

--- a/tests/utils/tokenTruncation.test.ts
+++ b/tests/utils/tokenTruncation.test.ts
@@ -3,7 +3,7 @@
  *
  * Test cases:
  *  (a) OpenAI model: precise truncation with gpt-tokenizer
- *  (b) BAAI/bge-m3: exact truncation via @huggingface/transformers with CJK text
+ *  (b) BAAI/bge-m3: exact truncation via @huggingface/tokenizers with CJK text
  *  (c) Gemini model: countTokens API mocked; pre-filter and binary-search paths
  *  (d) Short text: never modified in any branch
  *  (e) Unknown model: heuristic fallback (chars ≤ maxTokens * 3)
@@ -28,6 +28,52 @@ function makeEnglishText(words: number): string {
 function makeCJKText(chars: number): string {
   return '你好世界'.repeat(Math.ceil(chars / 4)).slice(0, chars);
 }
+
+const originalFetch = global.fetch;
+
+function createFetchResponse(
+  body: unknown,
+  init: { ok?: boolean; status?: number; statusText?: string } = {},
+): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? 'OK',
+    json: jest.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+function mockTokenizerModule(options?: {
+  encode?: (text: string) => { ids: ArrayLike<number | bigint> };
+  decode?: (ids: ArrayLike<number | bigint>) => string;
+}) {
+  const encodeMock = jest.fn(
+    options?.encode ??
+      ((text: string) => ({
+        ids: new Int32Array(Array.from({ length: text.length }, (_, i) => i + 1)),
+      })),
+  );
+  const decodeMock = jest.fn(
+    options?.decode ??
+      ((ids: ArrayLike<number | bigint>) => 'x'.repeat(Array.from(ids).length)),
+  );
+  const TokenizerMock = jest.fn().mockImplementation(() => ({
+    encode: encodeMock,
+    decode: decodeMock,
+  }));
+
+  jest.doMock('@huggingface/tokenizers', () => ({
+    Tokenizer: TokenizerMock,
+  }));
+
+  return { TokenizerMock, encodeMock, decodeMock };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.resetModules();
+  global.fetch = originalFetch;
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // getModelDefaultTokenLimit
@@ -391,31 +437,18 @@ describe('truncateToTokenLimit – large text handling', () => {
 });
 
 describe('truncateToTokenLimit – HuggingFace tokenizer error handling', () => {
-  const skipIfNoNetwork = process.env.CI_NO_NETWORK === 'true' ? it.skip : it;
+  it('gracefully handles tokenizer module load errors by using fallback', async () => {
+    jest.doMock('@huggingface/tokenizers', () => {
+      throw new Error('Module load failed');
+    });
+    global.fetch = jest.fn() as typeof global.fetch;
 
-  skipIfNoNetwork(
-    'gracefully handles tokenizer download errors by using fallback',
-    async () => {
-      // Mock the transformers module to simulate download error
-      jest.doMock('@huggingface/transformers', () => {
-        throw new Error('Network error: unable to download tokenizer');
-      });
+    const { truncateToTokenLimit: truncate } = await import('../../src/utils/tokenTruncation.js');
+    const largeText = 'a'.repeat(1000);
+    const result = await truncate(largeText, 100, 'bge-m3-custom');
 
-      try {
-        const largeText = 'a'.repeat(1000);
-        const result = await truncateToTokenLimit(largeText, 100, 'bge-m3-custom');
-
-        // Should fall back to heuristic instead of crashing
-        expect(result.length).toBeLessThanOrEqual(100 * 3);
-      } catch (e) {
-        // If it throws, should be a clear error, not a silent failure
-        expect(e).toBeInstanceOf(Error);
-      } finally {
-        jest.resetModules();
-      }
-    },
-    30000,
-  );
+    expect(result.length).toBeLessThanOrEqual(100 * 3);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -423,37 +456,16 @@ describe('truncateToTokenLimit – HuggingFace tokenizer error handling', () => 
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
-  afterEach(() => {
-    jest.resetModules();
-    jest.restoreAllMocks();
-  });
-
   it('falls back to hf-mirror.com when official HuggingFace Hub fails', async () => {
-    // Shared env object: its remoteHost is mutated by getHFTokenizer before each download attempt
-    const mockEnv = { remoteHost: 'https://huggingface.co/' };
-
-    // Minimal mock tokenizer: callable as function + has decode method
-    const mockDecode = jest.fn().mockImplementation(async (ids: number[]) => 'x'.repeat(ids.length));
-    const mockTokenizerFn = jest.fn().mockImplementation(async (text: string) => ({
-      input_ids: { data: new Int32Array(Array.from({ length: text.length }, (_, i) => i + 1)) },
-    }));
-    (mockTokenizerFn as any).decode = mockDecode;
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: {
-        from_pretrained: jest.fn().mockImplementation(async () => {
-          // Fail only for the official host; succeed for hf-mirror.com
-          if (mockEnv.remoteHost.includes('huggingface.co')) {
-            throw new Error('Connection refused: huggingface.co is blocked');
-          }
-          return mockTokenizerFn;
-        }),
-      },
-    }));
-
+    mockTokenizerModule();
+    global.fetch = jest.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('https://huggingface.co/')) {
+        return createFetchResponse({}, { ok: false, status: 503, statusText: 'Blocked' });
+      }
+      return createFetchResponse({});
+    }) as typeof global.fetch;
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
     const maxTokens = 5;
     const text = 'a'.repeat(20); // 20 chars > maxTokens * 3 = 15
 
@@ -479,17 +491,11 @@ describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
   });
 
   it('falls back to heuristic when both HuggingFace Hub and hf-mirror.com fail', async () => {
-    const mockEnv = { remoteHost: 'https://huggingface.co/' };
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: {
-        from_pretrained: jest.fn().mockRejectedValue(new Error('All hosts unreachable')),
-      },
-    }));
-
+    mockTokenizerModule();
+    global.fetch = jest.fn(async () =>
+      createFetchResponse({}, { ok: false, status: 503, statusText: 'Unavailable' }),
+    ) as typeof global.fetch;
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
     const maxTokens = 10;
     const longText = 'a'.repeat(100); // 100 chars > maxTokens * 3 = 30
 
@@ -516,16 +522,10 @@ describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
   });
 
   it('short text is returned unchanged even when all tokenizer hosts fail', async () => {
-    const mockEnv = { remoteHost: 'https://huggingface.co/' };
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: {
-        from_pretrained: jest.fn().mockRejectedValue(new Error('Network unavailable')),
-      },
-    }));
-
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockTokenizerModule();
+    global.fetch = jest.fn(async () =>
+      createFetchResponse({}, { ok: false, status: 503, statusText: 'Unavailable' }),
+    ) as typeof global.fetch;
 
     const maxTokens = 100;
     const shortText = 'hello world'; // 11 chars, well under maxTokens * 3 = 300
@@ -538,23 +538,11 @@ describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
   });
 
   it('concurrent calls for the same model/host trigger only one download', async () => {
-    let downloadCount = 0;
-    const mockEnv = { remoteHost: '' };
-    const mockDecode = jest.fn().mockResolvedValue('xxx');
-    const mockTokenizerFn = jest.fn().mockImplementation(async () => ({
-      input_ids: { data: new Int32Array([1, 2, 3]) },
-    }));
-    (mockTokenizerFn as any).decode = mockDecode;
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: {
-        from_pretrained: jest.fn().mockImplementation(async () => {
-          downloadCount++;
-          return mockTokenizerFn;
-        }),
-      },
-    }));
+    const { TokenizerMock } = mockTokenizerModule({
+      encode: () => ({ ids: new Int32Array([1, 2, 3]) }),
+      decode: () => 'xxx',
+    });
+    global.fetch = jest.fn(async () => createFetchResponse({})) as typeof global.fetch;
 
     const { truncateToTokenLimit: truncate } = await import('../../src/utils/tokenTruncation.js');
 
@@ -564,35 +552,28 @@ describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
       truncate('hello world', 100, 'BAAI/bge-m3'),
     ]);
 
-    expect(downloadCount).toBe(1);
+    expect(TokenizerMock).toHaveBeenCalledTimes(1);
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(2);
   }, 30000);
 
   it('skips unhealthy official host within TTL and goes directly to mirror', async () => {
     const networkError = new Error('Connection refused: huggingface.co is blocked');
-    const mockEnv = { remoteHost: '' };
-    const mockDecode = jest.fn().mockResolvedValue('x'.repeat(5));
-    const mockTokenizerFn = jest.fn().mockImplementation(async (text: string) => ({
-      input_ids: { data: new Int32Array(Array.from({ length: text.length }, (_, i) => i + 1)) },
-    }));
-    (mockTokenizerFn as any).decode = mockDecode;
-
-    const fromPretrainedMock = jest.fn().mockImplementation(async () => {
-      if (mockEnv.remoteHost.includes('huggingface.co')) throw networkError;
-      return mockTokenizerFn;
+    mockTokenizerModule();
+    const fetchMock = jest.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('https://huggingface.co/')) {
+        throw networkError;
+      }
+      return createFetchResponse({});
     });
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: { from_pretrained: fromPretrainedMock },
-    }));
-
+    global.fetch = fetchMock as typeof global.fetch;
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { truncateToTokenLimit: truncate } = await import('../../src/utils/tokenTruncation.js');
 
     // Call 1: official fails → marked unhealthy; mirror succeeds
     await truncate('hello world test', 5, 'BAAI/bge-m3');
     warnSpy.mockClear();
-    fromPretrainedMock.mockClear();
+    fetchMock.mockClear();
 
     // Call 2 (within TTL): official should be skipped
     await truncate('hello world test', 5, 'BAAI/bge-m3');
@@ -600,40 +581,35 @@ describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping HuggingFace Hub'));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TTL active'));
     // Mirror tokenizer is cached from call 1 — no new download needed
-    expect(fromPretrainedMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   }, 30000);
 
   it('retries HuggingFace Hub after TTL expires', async () => {
-    const mockEnv = { remoteHost: '' };
-    const mockDecode = jest.fn().mockResolvedValue('x'.repeat(3));
-    const mockTokenizerFn = jest.fn().mockImplementation(async () => ({
-      input_ids: { data: new Int32Array([1, 2, 3]) },
-    }));
-    (mockTokenizerFn as any).decode = mockDecode;
-
-    const fromPretrainedMock = jest.fn().mockImplementation(async () => {
-      if (mockEnv.remoteHost.includes('huggingface.co')) throw new Error('Connection refused');
-      return mockTokenizerFn;
+    mockTokenizerModule({
+      encode: () => ({ ids: new Int32Array([1, 2, 3]) }),
+      decode: () => 'xxx',
     });
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: { from_pretrained: fromPretrainedMock },
-    }));
-
+    const fetchMock = jest.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('https://huggingface.co/')) {
+        throw new Error('Connection refused');
+      }
+      return createFetchResponse({});
+    });
+    global.fetch = fetchMock as typeof global.fetch;
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { truncateToTokenLimit: truncate } = await import('../../src/utils/tokenTruncation.js');
     const realNow = Date.now();
 
     // Call 1: official fails → marked unhealthy (TTL = realNow + 7 days); mirror succeeds
     await truncate('hello', 5, 'BAAI/bge-m3');
-    fromPretrainedMock.mockClear();
+    fetchMock.mockClear();
     warnSpy.mockClear();
 
     // Call 2 (within TTL): official is skipped
     await truncate('hello', 5, 'BAAI/bge-m3');
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping HuggingFace Hub'));
-    fromPretrainedMock.mockClear();
+    fetchMock.mockClear();
     warnSpy.mockClear();
 
     // Advance clock beyond TTL (8 days)
@@ -648,26 +624,23 @@ describe('truncateToTokenLimit – HuggingFace three-tier fallback', () => {
       expect.any(Error),
     );
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('Skipping HuggingFace Hub'));
-    // from_pretrained was called exactly once (for the official host retry)
-    expect(fromPretrainedMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls.some((call) => String(call[0]).includes('https://huggingface.co/'))).toBe(true);
   }, 30000);
 
   it('includes the original error object as second argument in tier warnings', async () => {
     const tier1Error = new Error('tier1: Connection refused');
     const tier2Error = new Error('tier2: mirror also blocked');
-    const mockEnv = { remoteHost: '' };
-    let callCount = 0;
-
-    jest.doMock('@huggingface/transformers', () => ({
-      env: mockEnv,
-      AutoTokenizer: {
-        from_pretrained: jest.fn().mockImplementation(async () => {
-          callCount++;
-          throw callCount === 1 ? tier1Error : tier2Error;
-        }),
-      },
-    }));
-
+    mockTokenizerModule();
+    global.fetch = jest.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes('tokenizer_config.json')) {
+        return createFetchResponse({});
+      }
+      if (url.includes('https://huggingface.co/')) {
+        throw tier1Error;
+      }
+      throw tier2Error;
+    }) as typeof global.fetch;
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const { truncateToTokenLimit: truncate } = await import('../../src/utils/tokenTruncation.js');
 


### PR DESCRIPTION
## Description

This fixes an installation bug where installing the MCPHub CLI pulled in `@huggingface/transformers`, which in turn installed `onnxruntime-node` and could trigger CUDA/ONNX runtime downloads during `npm install` on Linux x64.

MCPHub only uses Hugging Face tooling in Smart Routing token truncation for BGE models. It does not need the full inference/runtime stack for that path.

This PR replaces `@huggingface/transformers` with the much lighter `@huggingface/tokenizers` package and updates the tokenizer loading flow to fetch `tokenizer.json` / `tokenizer_config.json` directly from Hugging Face or the configured mirror.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass
- [ ] E2E tests pass (if applicable)
- [x] Manual testing completed

Validation run locally:

- `pnpm lint`
- `pnpm test -- tests/utils/tokenTruncation.test.ts`
- `pnpm test:ci`
- `pnpm build`

## Documentation

- [x] Code is self-documenting
- [ ] API documentation updated
- [ ] User documentation updated
- [ ] README updated (if needed)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Key implementation details:

- removes the heavy ONNX-backed dependency from the default CLI install path
- keeps the existing host fallback behavior (`huggingface.co` -> `hf-mirror.com` -> heuristic)
- keeps tokenizer caching and unhealthy-host TTL behavior
- updates tests to cover the new `fetch + @huggingface/tokenizers` flow
