### PR TITLE
fix: use query params for registry server version routes to handle encoded slashes

### DIFF
--- a/frontend/src/hooks/useRegistryData.ts
+++ b/frontend/src/hooks/useRegistryData.ts
@@ -140,9 +140,8 @@ export const useRegistryData = () => {
         setLoading(true);
         setError(null);
 
-        // URL encode the server name
         const encodedName = encodeURIComponent(serverName);
-        const response = await apiGet(`/registry/servers/${encodedName}/versions`);
+        const response = await apiGet(`/registry/servers/versions?serverName=${encodedName}`);
 
         if (response && response.success && response.data) {
           const data: RegistryServerVersionsResponse = response.data;
@@ -175,9 +174,8 @@ export const useRegistryData = () => {
     try {
       setError(null);
 
-      // URL encode the server name
       const encodedName = encodeURIComponent(serverName);
-      const response = await apiGet(`/registry/servers/${encodedName}/versions`);
+      const response = await apiGet(`/registry/servers/versions?name=${encodedName}`);
 
       if (response && response.success && response.data) {
         const data: RegistryServerVersionsResponse = response.data;
@@ -203,10 +201,9 @@ export const useRegistryData = () => {
     try {
       setError(null);
 
-      // URL encode the server name and version
       const encodedName = encodeURIComponent(serverName);
       const encodedVersion = encodeURIComponent(version);
-      const response = await apiGet(`/registry/servers/${encodedName}/versions/${encodedVersion}`);
+      const response = await apiGet(`/registry/servers/version?name=${encodedName}&version=${encodedVersion}`);
 
       if (response && response.success && response.data) {
         const data: RegistryServerVersionResponse = response.data;

--- a/frontend/src/hooks/useRegistryData.ts
+++ b/frontend/src/hooks/useRegistryData.ts
@@ -140,6 +140,7 @@ export const useRegistryData = () => {
         setLoading(true);
         setError(null);
 
+        // URL encode the server name
         const encodedName = encodeURIComponent(serverName);
         const response = await apiGet(`/registry/servers/versions?serverName=${encodedName}`);
 
@@ -174,8 +175,9 @@ export const useRegistryData = () => {
     try {
       setError(null);
 
+      // URL encode the server name
       const encodedName = encodeURIComponent(serverName);
-      const response = await apiGet(`/registry/servers/versions?name=${encodedName}`);
+      const response = await apiGet(`/registry/servers/versions?serverName=${encodedName}`);
 
       if (response && response.success && response.data) {
         const data: RegistryServerVersionsResponse = response.data;
@@ -201,9 +203,10 @@ export const useRegistryData = () => {
     try {
       setError(null);
 
+      // URL encode the server name and version
       const encodedName = encodeURIComponent(serverName);
       const encodedVersion = encodeURIComponent(version);
-      const response = await apiGet(`/registry/servers/version?name=${encodedName}&version=${encodedVersion}`);
+      const response = await apiGet(`/registry/servers/version?serverName=${encodedName}&version=${encodedVersion}`);
 
       if (response && response.success && response.data) {
         const data: RegistryServerVersionResponse = response.data;

--- a/src/controllers/registryController.ts
+++ b/src/controllers/registryController.ts
@@ -71,7 +71,7 @@ export const getRegistryServerVersions = async (req: Request, res: Response): Pr
       });
       return;
     }
-
+    // URL encode the server name
     const encodedName = encodeURIComponent(serverName);
     const response = await fetch(`${REGISTRY_BASE_URL}/servers/${encodedName}/versions`, {
       headers: {
@@ -115,7 +115,7 @@ export const getRegistryServerVersions = async (req: Request, res: Response): Pr
  */
 export const getRegistryServerVersion = async (req: Request, res: Response): Promise<void> => {
   try {
-    const serverName = req.query.name as string;
+    const serverName = req.query.serverName as string;
     const version = req.query.version as string;
 
     if (!serverName || !version) {
@@ -125,7 +125,7 @@ export const getRegistryServerVersion = async (req: Request, res: Response): Pro
       });
       return;
     }
-
+    // URL encode the server name and version
     const encodedName = encodeURIComponent(serverName);
     const encodedVersion = encodeURIComponent(version);
     const response = await fetch(

--- a/src/controllers/registryController.ts
+++ b/src/controllers/registryController.ts
@@ -62,7 +62,7 @@ export const getAllRegistryServers = async (req: Request, res: Response): Promis
  */
 export const getRegistryServerVersions = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { serverName } = req.params;
+    const serverName = req.query.serverName as string;
 
     if (!serverName) {
       res.status(400).json({
@@ -72,7 +72,6 @@ export const getRegistryServerVersions = async (req: Request, res: Response): Pr
       return;
     }
 
-    // URL encode the server name
     const encodedName = encodeURIComponent(serverName);
     const response = await fetch(`${REGISTRY_BASE_URL}/servers/${encodedName}/versions`, {
       headers: {
@@ -116,7 +115,8 @@ export const getRegistryServerVersions = async (req: Request, res: Response): Pr
  */
 export const getRegistryServerVersion = async (req: Request, res: Response): Promise<void> => {
   try {
-    const { serverName, version } = req.params;
+    const serverName = req.query.name as string;
+    const version = req.query.version as string;
 
     if (!serverName || !version) {
       res.status(400).json({
@@ -126,7 +126,6 @@ export const getRegistryServerVersion = async (req: Request, res: Response): Pro
       return;
     }
 
-    // URL encode the server name and version
     const encodedName = encodeURIComponent(serverName);
     const encodedVersion = encodeURIComponent(version);
     const response = await fetch(

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -319,8 +319,8 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
 
   // Registry routes (proxy to official MCP registry)
   router.get('/registry/servers', getAllRegistryServers);
-  router.get('/registry/servers/:serverName/versions', getRegistryServerVersions);
-  router.get('/registry/servers/:serverName/versions/:version', getRegistryServerVersion);
+  router.get('/registry/servers/versions', getRegistryServerVersions);
+  router.get('/registry/servers/version', getRegistryServerVersion);
 
   // Log routes
   router.get('/logs', getAllLogs);


### PR DESCRIPTION
## Problem

Registry server names can contain slashes (e.g. `ac.inference.sh/mcp`). When these names were passed as URL path parameters, reverse proxies like Traefik would decode the `%2F` back to `/` before the request reached the server, causing routing to break or resolve to the wrong endpoint.

## Solution

Replaced path parameters with query parameters for the registry server version endpoints. This avoids the encoded-slash issue entirely since query strings are not subject to path segment routing.

### Changes

- **Routes** (`src/routes/index.ts`): Changed `/registry/servers/:serverName/versions` and `/registry/servers/:serverName/versions/:version` to `/registry/servers/versions` and `/registry/servers/version`
- **Controller** (`src/controllers/registryController.ts`): Updated `getRegistryServerVersions` and `getRegistryServerVersion` to read `serverName` and `version` from `req.query` instead of `req.params`
- **Frontend** (`frontend/src/hooks/useRegistryData.ts`): Updated API calls to pass `serverName` and `version` as query parameters

## Testing

Manually verified that registry server lookups work correctly for scoped packages (e.g. `ac.inference.sh/mcp`) through a Traefik reverse proxy.