### PR TITLE
fix: prevent SSE connection timeout by adding server-side heartbeat

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -221,7 +221,7 @@ export class AppServer {
     // Disable keepAliveTimeout so SSE connections are not prematurely closed
     // when upstream MCP servers (especially stdio) take a long time to respond.
     // Node.js default is 5s which is far too aggressive for long-lived SSE streams.
-    this.server.keepAliveTimeout = 0;
+    if (this.server) this.server.keepAliveTimeout = 0;
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -218,6 +218,10 @@ export class AppServer {
         );
       }
     });
+    // Disable keepAliveTimeout so SSE connections are not prematurely closed
+    // when upstream MCP servers (especially stdio) take a long time to respond.
+    // Node.js default is 5s which is far too aggressive for long-lived SSE streams.
+    this.server.keepAliveTimeout = 0;
   }
 
   /**

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -415,7 +415,16 @@ export const handleSseConnection = async (req: Request, res: Response): Promise<
     keyName: bearerAuthResult.keyName,
   };
 
+  // Send periodic SSE heartbeat comments to prevent connection timeout
+  // when upstream MCP server (especially stdio) takes a long time to respond
+  const heartbeatInterval = setInterval(() => {
+    if (!res.writableEnded) {
+      res.write(': keepalive\n\n');
+    }
+  }, 30000);
+
   res.on('close', () => {
+    clearInterval(heartbeatInterval);
     delete transports[transport.sessionId];
     deleteMcpServer(transport.sessionId);
     console.log(`SSE connection closed: ${transport.sessionId}`);

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -419,7 +419,7 @@ export const handleSseConnection = async (req: Request, res: Response): Promise<
   // when upstream MCP server (especially stdio) takes a long time to respond
   const heartbeatInterval = setInterval(() => {
     if (!res.writableEnded) {
-      res.write(': keepalive\n\n');
+      res.write(': keepalive\n');
     }
   }, 30000);
 

--- a/tests/services/keepalive.test.ts
+++ b/tests/services/keepalive.test.ts
@@ -205,15 +205,15 @@ describe('Keepalive Functionality', () => {
     jest.clearAllMocks();
   });
 
-  describe('SSE Connection (No Server-Side Keepalive)', () => {
-    // Server-side keepalive was removed - keepalive is now only for upstream MCP server connections (client-side)
-    // These tests verify that SSE connections work without server-side keepalive
+  describe('SSE Connection Heartbeat', () => {
+    // Server-side heartbeat sends SSE comments (: keepalive) to prevent timeout
+    // when upstream MCP servers (especially stdio) take a long time to respond
 
-    it('should establish SSE connection without keepalive interval', async () => {
+    it('should establish SSE connection with heartbeat interval', async () => {
       await handleSseConnection(mockReq as Request, mockRes as Response);
 
-      // Verify no keepalive interval was created for server-side SSE
-      expect(global.setInterval).not.toHaveBeenCalled();
+      // Verify a heartbeat interval was created for server-side SSE
+      expect(global.setInterval).toHaveBeenCalled();
     });
 
     it('should register close event handler for cleanup', async () => {
@@ -238,7 +238,22 @@ describe('Keepalive Functionality', () => {
       expect(transports['test-session-id']).toBeUndefined();
     });
 
-    it('should not send pings after connection is closed', async () => {
+    it('should clear heartbeat interval on connection close', async () => {
+      await handleSseConnection(mockReq as Request, mockRes as Response);
+
+      // Verify heartbeat interval was created
+      expect(intervals.length).toBeGreaterThan(0);
+
+      // Simulate connection close
+      if (eventListeners['close']) {
+        eventListeners['close']();
+      }
+
+      // Verify heartbeat interval was cleared
+      expect(global.clearInterval).toHaveBeenCalled();
+    });
+
+    it('should not send heartbeat after connection is closed', async () => {
       jest.useFakeTimers();
 
       await handleSseConnection(mockReq as Request, mockRes as Response);
@@ -248,14 +263,14 @@ describe('Keepalive Functionality', () => {
         eventListeners['close']();
       }
 
-      // Reset mock to count pings after close
-      mockTransportInstance.send.mockClear();
+      // Reset mock to count writes after close
+      (mockRes.write as jest.Mock).mockClear();
 
       // Fast-forward time by 60 seconds
       jest.advanceTimersByTime(60000);
 
-      // Verify no pings were sent after close
-      expect(mockTransportInstance.send).not.toHaveBeenCalled();
+      // Verify no heartbeat writes were sent after close
+      expect(mockRes.write).not.toHaveBeenCalled();
 
       jest.useRealTimers();
     });


### PR DESCRIPTION
When upstream MCP servers (especially stdio) take a long time to respond, the SSE connection to the client sits idle and can be terminated by Node.js's default keepAliveTimeout of 5 seconds. This causes premature connection drops and data loss for streaming content.

Changes:
- Add periodic SSE heartbeat comments (`: keepalive\n\n`) every 30s in handleSseConnection to keep the connection alive
- Disable Node.js HTTP server keepAliveTimeout (set to 0) since it defaults to 5s which is far too aggressive for long-lived SSE streams
- Update tests to verify heartbeat interval creation, cleanup on close, and no heartbeat writes after connection is closed

Fixes #732