### PR TITLE
fix: validate redirect_uri in OAuth authorize POST flow

### DIFF
--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -70,6 +70,44 @@ function validateQueryParam(value: any, name: string, pattern?: RegExp): string 
   return value;
 }
 
+async function validateClientRedirectUri(
+  res: Response,
+  clientId: unknown,
+  redirectUri: unknown,
+): Promise<string | null> {
+  if (typeof clientId !== 'string' || !clientId) {
+    res.status(400).json({
+      error: 'invalid_request',
+      error_description: 'Missing client_id',
+    });
+    return null;
+  }
+
+  if (typeof redirectUri !== 'string' || !redirectUri) {
+    res.status(400).json({
+      error: 'invalid_request',
+      error_description: 'Missing redirect_uri',
+    });
+    return null;
+  }
+
+  const client = await findOAuthClientById(clientId);
+  if (!client) {
+    res.status(400).json({ error: 'invalid_client', error_description: 'Client not found' });
+    return null;
+  }
+
+  if (!client.redirectUris.includes(redirectUri)) {
+    res.status(400).json({
+      error: 'invalid_request',
+      error_description: 'Invalid redirect_uri',
+    });
+    return null;
+  }
+
+  return redirectUri;
+}
+
 /**
  * Generate OAuth authorization consent HTML page with i18n support
  * (keeps visual style consistent with OAuth callback pages)
@@ -299,6 +337,8 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
  * Handle authorization decision
  */
 export const postAuthorize = async (req: Request, res: Response): Promise<void> => {
+  let validatedRedirectUri: string | null = null;
+
   try {
     const oauth = getOAuthServer();
     if (!oauth) {
@@ -306,11 +346,16 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
       return;
     }
 
-    const { allow, redirect_uri, state } = req.body;
+    const { allow, client_id, redirect_uri, state } = req.body;
+
+    validatedRedirectUri = await validateClientRedirectUri(res, client_id, redirect_uri);
+    if (!validatedRedirectUri) {
+      return;
+    }
 
     // If user denied
     if (allow !== 'true') {
-      const redirectUrl = new URL(redirect_uri);
+      const redirectUrl = new URL(validatedRedirectUri);
       redirectUrl.searchParams.set('error', 'access_denied');
       if (state) {
         redirectUrl.searchParams.set('state', state);
@@ -346,7 +391,7 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
     });
 
     // Build redirect URL with authorization code
-    const redirectUrl = new URL(redirect_uri);
+    const redirectUrl = new URL(validatedRedirectUri);
     redirectUrl.searchParams.set('code', code.authorizationCode);
     if (state) {
       redirectUrl.searchParams.set('state', state);
@@ -359,11 +404,10 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
     // Handle OAuth errors
     if (error instanceof Error && 'code' in error) {
       const oauthError = error as any;
-      const redirect_uri = req.body.redirect_uri;
       const state = req.body.state;
 
-      if (redirect_uri) {
-        const redirectUrl = new URL(redirect_uri);
+      if (validatedRedirectUri) {
+        const redirectUrl = new URL(validatedRedirectUri);
         redirectUrl.searchParams.set('error', oauthError.name || 'server_error');
         if (oauthError.message) {
           redirectUrl.searchParams.set('error_description', oauthError.message);

--- a/tests/controllers/oauthServerController.test.ts
+++ b/tests/controllers/oauthServerController.test.ts
@@ -1,0 +1,129 @@
+jest.mock('../../src/services/oauthServerService.js', () => ({
+  getOAuthServer: jest.fn(),
+  handleTokenRequest: jest.fn(),
+  handleAuthenticateRequest: jest.fn(),
+}));
+
+jest.mock('../../src/models/OAuth.js', () => ({
+  findOAuthClientById: jest.fn(),
+}));
+
+import { postAuthorize } from '../../src/controllers/oauthServerController.js';
+import { getOAuthServer } from '../../src/services/oauthServerService.js';
+import { findOAuthClientById } from '../../src/models/OAuth.js';
+
+type MockResponse = {
+  status: jest.Mock;
+  json: jest.Mock;
+  redirect: jest.Mock;
+};
+
+const createResponse = (): MockResponse => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    redirect: jest.fn().mockReturnThis(),
+  };
+
+  return res;
+};
+
+const createRequest = (overrides: Record<string, unknown> = {}) => ({
+  body: {},
+  query: {},
+  header: jest.fn().mockReturnValue(undefined),
+  ...overrides,
+});
+
+describe('oauthServerController postAuthorize redirect_uri validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (findOAuthClientById as jest.Mock).mockResolvedValue({
+      clientId: 'trusted-client',
+      name: 'Trusted Client',
+      redirectUris: ['https://trusted.example.com/callback'],
+    });
+  });
+
+  it('rejects denied authorizations when redirect_uri is not registered for the client', async () => {
+    (getOAuthServer as jest.Mock).mockReturnValue({
+      authorize: jest.fn(),
+    });
+
+    const req = createRequest({
+      body: {
+        allow: 'false',
+        client_id: 'trusted-client',
+        redirect_uri: 'https://evil.example.com/callback',
+        state: 'state-123',
+      },
+    });
+    const res = createResponse();
+
+    await postAuthorize(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid_request',
+      error_description: 'Invalid redirect_uri',
+    });
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  it('preserves denial redirects for registered redirect URIs', async () => {
+    (getOAuthServer as jest.Mock).mockReturnValue({
+      authorize: jest.fn(),
+    });
+
+    const req = createRequest({
+      body: {
+        allow: 'false',
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        state: 'state-123',
+      },
+    });
+    const res = createResponse();
+
+    await postAuthorize(req as any, res as any);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      'https://trusted.example.com/callback?error=access_denied&state=state-123',
+    );
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects OAuth error redirects when redirect_uri is not registered for the client', async () => {
+    (getOAuthServer as jest.Mock).mockReturnValue({
+      authorize: jest.fn().mockRejectedValue(
+        Object.assign(new Error('Scope is invalid'), {
+          code: 400,
+          name: 'invalid_scope',
+        }),
+      ),
+    });
+
+    const req = createRequest({
+      user: {
+        username: 'alice',
+      },
+      body: {
+        allow: 'true',
+        client_id: 'trusted-client',
+        redirect_uri: 'https://evil.example.com/callback',
+        state: 'state-123',
+      },
+    });
+    const res = createResponse();
+
+    await postAuthorize(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'invalid_request',
+      error_description: 'Invalid redirect_uri',
+    });
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- validate `client_id` and `redirect_uri` at the start of `POST /oauth/authorize`
- reuse the validated redirect URI for denial, success, and OAuth error redirects
- add regression tests covering invalid denial redirects, valid denial redirects, and invalid OAuth error redirects

## Root cause
`postAuthorize` trusted `redirect_uri` from the POST body in the denial branch and in the OAuth error handling branch. Unlike `GET /oauth/authorize`, it did not verify that the submitted URI matched one of the client's registered redirect URIs, which allowed open redirects to attacker-controlled domains.

## Fix
- added shared POST-side validation for `client_id` and `redirect_uri`
- return `400` with `invalid_request` when the redirect URI is missing or not registered
- keep existing redirect behavior for registered client redirect URIs only

## Reproduction status
- reproduced with regression tests before the fix
- verified green after the patch

## Validation
- `pnpm lint`
- `pnpm backend:build`
- `pnpm test:ci`
- `pnpm build`
- `node scripts/verify-dist.js`
