### PR TITLE
fix: enforce group ownership on mutating endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,7 @@ When adding/changing fields, update **ALL** these files:
 - Optional fields need `nullable: true` in entity
 - Complex objects need `simple-json` column type
 - Runtime-updated system settings (especially `systemConfig.routing` auth/body-limit flags) should be read via `SystemConfigDao`, not `loadSettings()`. In DB-backed or mixed DAO/file flows, `loadSettings()` can return stale values for settings changed from the dashboard/API.
+- Request-scoped authentication or ownership state must use `AsyncLocalStorage` (or another request-safe context carrier). Do **not** store the current user in a mutable process-wide singleton field, or concurrent requests can overwrite each other's authorization context.
 - For multi-user resources with an `owner` field (for example groups, servers, or OAuth clients), read-path filtering alone is **not** sufficient. Any mutating service method must enforce `currentUser.isAdmin || resource.owner === currentUser.username` before calling DAO update/delete helpers, otherwise UUID-based write endpoints can become IDORs.
 
 ## Auto-Evolution Guidelines for AI Agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,7 @@ When adding/changing fields, update **ALL** these files:
 - Optional fields need `nullable: true` in entity
 - Complex objects need `simple-json` column type
 - Runtime-updated system settings (especially `systemConfig.routing` auth/body-limit flags) should be read via `SystemConfigDao`, not `loadSettings()`. In DB-backed or mixed DAO/file flows, `loadSettings()` can return stale values for settings changed from the dashboard/API.
+- For multi-user resources with an `owner` field (for example groups, servers, or OAuth clients), read-path filtering alone is **not** sufficient. Any mutating service method must enforce `currentUser.isAdmin || resource.owner === currentUser.username` before calling DAO update/delete helpers, otherwise UUID-based write endpoints can become IDORs.
 
 ## Auto-Evolution Guidelines for AI Agents
 

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { IGroup, IGroupServerConfig } from '../types/index.js';
 import { notifyToolChanged } from './mcpService.js';
 import { getDataService } from './services.js';
+import { UserContextService } from './userContextService.js';
 import { getGroupDao, getServerDao, getSystemConfigDao } from '../dao/index.js';
 
 // Helper function to normalize group servers configuration
@@ -19,6 +20,20 @@ const normalizeGroupServers = (servers: string[] | IGroupServerConfig[]): IGroup
       resources: server.resources || 'all',
     };
   });
+};
+
+const canMutateGroup = (group: IGroup): boolean => {
+  const currentUser = UserContextService.getInstance().getCurrentUser();
+
+  if (!currentUser) {
+    return false;
+  }
+
+  if (currentUser.isAdmin) {
+    return true;
+  }
+
+  return group.owner === currentUser.username;
 };
 
 // Get all groups
@@ -95,7 +110,7 @@ export const updateGroup = async (id: string, data: Partial<IGroup>): Promise<IG
     const serverDao = getServerDao();
 
     const existingGroup = await groupDao.findById(id);
-    if (!existingGroup) {
+    if (!existingGroup || !canMutateGroup(existingGroup)) {
       return null;
     }
 
@@ -139,7 +154,7 @@ export const updateGroupServers = async (
     const serverDao = getServerDao();
 
     const existingGroup = await groupDao.findById(groupId);
-    if (!existingGroup) {
+    if (!existingGroup || !canMutateGroup(existingGroup)) {
       return null;
     }
 
@@ -168,6 +183,12 @@ export const updateGroupServers = async (
 export const deleteGroup = async (id: string): Promise<boolean> => {
   try {
     const groupDao = getGroupDao();
+
+    const existingGroup = await groupDao.findById(id);
+    if (!existingGroup || !canMutateGroup(existingGroup)) {
+      return false;
+    }
+
     return await groupDao.delete(id);
   } catch (error) {
     console.error(`Failed to delete group ${id}:`, error);
@@ -191,7 +212,7 @@ export const addServerToGroup = async (
     }
 
     const group = await groupDao.findById(groupId);
-    if (!group) {
+    if (!group || !canMutateGroup(group)) {
       return null;
     }
 
@@ -226,7 +247,7 @@ export const removeServerFromGroup = async (
     const groupDao = getGroupDao();
 
     const group = await groupDao.findById(groupId);
-    if (!group) {
+    if (!group || !canMutateGroup(group)) {
       return null;
     }
 
@@ -277,7 +298,7 @@ export const updateServerToolsInGroup = async (
     const serverDao = getServerDao();
 
     const group = await groupDao.findById(groupId);
-    if (!group) {
+    if (!group || !canMutateGroup(group)) {
       return null;
     }
 

--- a/src/services/userContextService.ts
+++ b/src/services/userContextService.ts
@@ -1,33 +1,11 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { IUser } from '../types/index.js';
-
-// User context storage
-class UserContext {
-  private static instance: UserContext;
-  private currentUser: IUser | null = null;
-
-  static getInstance(): UserContext {
-    if (!UserContext.instance) {
-      UserContext.instance = new UserContext();
-    }
-    return UserContext.instance;
-  }
-
-  setUser(user: IUser): void {
-    this.currentUser = user;
-  }
-
-  getUser(): IUser | null {
-    return this.currentUser;
-  }
-
-  clearUser(): void {
-    this.currentUser = null;
-  }
-}
 
 export class UserContextService {
   private static instance: UserContextService;
-  private userContext = UserContext.getInstance();
+  private readonly asyncLocalStorage = new AsyncLocalStorage<IUser | null>();
+
+  private constructor() {}
 
   static getInstance(): UserContextService {
     if (!UserContextService.instance) {
@@ -37,15 +15,15 @@ export class UserContextService {
   }
 
   getCurrentUser(): IUser | null {
-    return this.userContext.getUser();
+    return this.asyncLocalStorage.getStore() ?? null;
   }
 
   setCurrentUser(user: IUser): void {
-    this.userContext.setUser(user);
+    this.asyncLocalStorage.enterWith(user);
   }
 
   clearCurrentUser(): void {
-    this.userContext.clearUser();
+    this.asyncLocalStorage.enterWith(null);
   }
 
   isAdmin(): boolean {

--- a/tests/services/groupService-authorization.test.ts
+++ b/tests/services/groupService-authorization.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockGroupDao = {
+  findById: jest.fn(),
+  findByName: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+const mockServerDao = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+};
+
+const mockUserContextService = {
+  getCurrentUser: jest.fn(),
+};
+
+jest.mock('../../src/dao/index.js', () => ({
+  getGroupDao: jest.fn(() => mockGroupDao),
+  getServerDao: jest.fn(() => mockServerDao),
+  getSystemConfigDao: jest.fn(() => ({
+    get: jest.fn(() => Promise.resolve({ routing: { enableGroupNameRoute: true } })),
+  })),
+}));
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  notifyToolChanged: jest.fn(),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({
+    filterData: (data: any) => data,
+  })),
+}));
+
+jest.mock('../../src/services/userContextService.js', () => ({
+  UserContextService: {
+    getInstance: jest.fn(() => mockUserContextService),
+  },
+}));
+
+import {
+  addServerToGroup,
+  deleteGroup,
+  removeServerFromGroup,
+  updateGroup,
+  updateGroupServers,
+  updateServerToolsInGroup,
+} from '../../src/services/groupService.js';
+
+describe('groupService authorization', () => {
+  const adminOwnedGroup = {
+    id: 'group-1',
+    name: 'admin-group',
+    description: 'owned by admin',
+    owner: 'admin',
+    servers: [{ name: 'server-1', tools: 'all', prompts: 'all', resources: 'all' }],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUserContextService.getCurrentUser.mockReturnValue({
+      username: 'bob',
+      isAdmin: false,
+    });
+
+    mockGroupDao.findById.mockResolvedValue(adminOwnedGroup);
+    mockGroupDao.findByName.mockResolvedValue(null);
+    mockGroupDao.update.mockImplementation(async (_id: string, updates: any) => ({
+      ...adminOwnedGroup,
+      ...updates,
+    }));
+    mockGroupDao.delete.mockResolvedValue(true);
+
+    mockServerDao.findAll.mockResolvedValue([{ name: 'server-1' }, { name: 'server-2' }]);
+    mockServerDao.findById.mockResolvedValue({ name: 'server-1' });
+  });
+
+  it('rejects updateGroup for non-owner non-admin users', async () => {
+    await expect(updateGroup('group-1', { name: 'pwned' })).resolves.toBeNull();
+    expect(mockGroupDao.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects updateGroupServers for non-owner non-admin users', async () => {
+    await expect(updateGroupServers('group-1', ['server-2'])).resolves.toBeNull();
+    expect(mockGroupDao.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects deleteGroup for non-owner non-admin users', async () => {
+    await expect(deleteGroup('group-1')).resolves.toBe(false);
+    expect(mockGroupDao.delete).not.toHaveBeenCalled();
+  });
+
+  it('rejects addServerToGroup for non-owner non-admin users', async () => {
+    mockServerDao.findById.mockResolvedValue({ name: 'server-2' });
+
+    await expect(addServerToGroup('group-1', 'server-2')).resolves.toBeNull();
+    expect(mockGroupDao.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects removeServerFromGroup for non-owner non-admin users', async () => {
+    await expect(removeServerFromGroup('group-1', 'server-1')).resolves.toBeNull();
+    expect(mockGroupDao.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects updateServerToolsInGroup for non-owner non-admin users', async () => {
+    await expect(updateServerToolsInGroup('group-1', 'server-1', ['dangerous-tool'])).resolves.toBeNull();
+    expect(mockGroupDao.update).not.toHaveBeenCalled();
+  });
+
+  it('allows admins to mutate groups they do not own', async () => {
+    mockUserContextService.getCurrentUser.mockReturnValue({
+      username: 'superadmin',
+      isAdmin: true,
+    });
+
+    await expect(updateGroup('group-1', { name: 'admin-approved' })).resolves.toEqual(
+      expect.objectContaining({
+        id: 'group-1',
+        name: 'admin-approved',
+      }),
+    );
+    expect(mockGroupDao.update).toHaveBeenCalledWith('group-1', { name: 'admin-approved' });
+  });
+
+  it('allows non-admin owners to mutate their own groups', async () => {
+    mockGroupDao.findById.mockResolvedValue({
+      ...adminOwnedGroup,
+      owner: 'bob',
+    });
+
+    await expect(deleteGroup('group-1')).resolves.toBe(true);
+    expect(mockGroupDao.delete).toHaveBeenCalledWith('group-1');
+  });
+});

--- a/tests/services/userContextService.test.ts
+++ b/tests/services/userContextService.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { UserContextService } from '../../src/services/userContextService.js';
+
+describe('UserContextService', () => {
+  let service: UserContextService;
+
+  beforeEach(() => {
+    service = UserContextService.getInstance();
+    service.clearCurrentUser();
+  });
+
+  afterEach(() => {
+    service.clearCurrentUser();
+  });
+
+  it('stores and clears the current user', () => {
+    service.setCurrentUser({ username: 'alice', password: '', isAdmin: false });
+
+    expect(service.getCurrentUser()).toEqual({
+      username: 'alice',
+      password: '',
+      isAdmin: false,
+    });
+    expect(service.hasUser()).toBe(true);
+    expect(service.isAdmin()).toBe(false);
+
+    service.clearCurrentUser();
+
+    expect(service.getCurrentUser()).toBeNull();
+    expect(service.hasUser()).toBe(false);
+  });
+
+  it('isolates concurrent async user contexts', async () => {
+    const results = await Promise.all([
+      (async () => {
+        service.setCurrentUser({ username: 'alpha', password: '', isAdmin: false });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        return service.getCurrentUser();
+      })(),
+      (async () => {
+        service.setCurrentUser({ username: 'beta', password: '', isAdmin: true });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        return service.getCurrentUser();
+      })(),
+    ]);
+
+    expect(results).toEqual([
+      { username: 'alpha', password: '', isAdmin: false },
+      { username: 'beta', password: '', isAdmin: true },
+    ]);
+
+    service.clearCurrentUser();
+    expect(service.getCurrentUser()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- enforce owner/admin checks in group service write paths before DAO mutation calls
- add regression tests covering all affected group mutation helpers and positive owner/admin cases
- document the service-layer ownership enforcement rule in AGENTS.md

## Root cause
Group read paths used ownership filtering, but mutating service methods looked up groups directly by UUID and updated/deleted them without verifying that the current user owned the target resource or was an admin. This created an IDOR on group write endpoints.

## Fix
- added a centralized `canMutateGroup` guard in `src/services/groupService.ts`
- applied the guard to update, delete, server membership, and tool-selection mutation paths
- kept controller behavior unchanged so unauthorized writes continue to map to 404-style responses without leaking existence

## Tests
- `pnpm test -- --runInBand tests/services/groupService-authorization.test.ts`
- `pnpm test -- --runInBand tests/services/groupService-authorization.test.ts tests/services/groupService-capabilities.test.ts`
- `pnpm lint`
- `pnpm backend:build`
- `pnpm test:ci`
- `pnpm build`
- `node scripts/verify-dist.js`

## Advisory
Addresses the write-side ownership bypass described in `GHSA-wxp7-qc66-fwf3`.
