### PR TITLE
fix(security): require admin and redact secrets in MCP settings export (CWE-862)

### DIFF
--- a/src/controllers/configController.ts
+++ b/src/controllers/configController.ts
@@ -100,7 +100,10 @@ export const getPublicConfig = (req: Request, res: Response): void => {
 /**
  * Recursively remove null values from an object
  */
-const omitSensitiveFields = <T extends Record<string, any>>(items: T[], fields: string[]): Omit<T, string>[] =>
+const omitSensitiveFields = <T extends Record<string, any>, K extends keyof T & string>(
+  items: T[],
+  fields: readonly K[],
+): Omit<T, K>[] =>
   items.map((item) => {
     const sanitized = { ...item };
     for (const field of fields) {

--- a/src/controllers/configController.ts
+++ b/src/controllers/configController.ts
@@ -18,6 +18,18 @@ import { getBetterAuthRuntimeConfig } from '../services/betterAuthConfig.js';
 
 const dataService: DataService = getDataService();
 
+const requireAdmin = (req: Request, res: Response): boolean => {
+  const user = (req as any).user;
+  if (!user || !user.isAdmin) {
+    res.status(403).json({
+      success: false,
+      message: 'Admin privileges required',
+    });
+    return false;
+  }
+  return true;
+};
+
 /**
  * Get runtime configuration for frontend
  */
@@ -88,6 +100,15 @@ export const getPublicConfig = (req: Request, res: Response): void => {
 /**
  * Recursively remove null values from an object
  */
+const omitSensitiveFields = <T extends Record<string, any>>(items: T[], fields: string[]): Omit<T, string>[] =>
+  items.map((item) => {
+    const sanitized = { ...item };
+    for (const field of fields) {
+      delete sanitized[field];
+    }
+    return sanitized;
+  });
+
 const removeNullValues = <T>(obj: T): T => {
   if (obj === null || obj === undefined) {
     return obj;
@@ -112,6 +133,8 @@ const removeNullValues = <T>(obj: T): T => {
  * Supports both full settings and individual server configuration
  */
 export const getMcpSettingsJson = async (req: Request, res: Response): Promise<void> => {
+  if (!requireAdmin(req, res)) return;
+
   try {
     const { serverName } = req.query;
     if (serverName && typeof serverName === 'string') {
@@ -167,13 +190,13 @@ export const getMcpSettingsJson = async (req: Request, res: Response): Promise<v
 
       const settings = {
         mcpServers,
-        users,
+        users: omitSensitiveFields(users, ['password']),
         groups,
         systemConfig,
         userConfigs,
-        oauthClients,
-        oauthTokens,
-        bearerKeys,
+        oauthClients: omitSensitiveFields(oauthClients, ['clientSecret']),
+        oauthTokens: omitSensitiveFields(oauthTokens, ['accessToken', 'refreshToken']),
+        bearerKeys: omitSensitiveFields(bearerKeys, ['token']),
       };
 
       res.json({

--- a/tests/controllers/configController.test.ts
+++ b/tests/controllers/configController.test.ts
@@ -25,7 +25,8 @@ describe('ConfigController - getMcpSettingsJson', () => {
     mockStatus = jest.fn().mockReturnThis();
     mockRequest = {
       query: {},
-    };
+      user: { username: 'admin', isAdmin: true },
+    } as Partial<Request> & { user: { username: string; isAdmin: boolean } };
     mockResponse = {
       json: mockJson,
       status: mockStatus,
@@ -52,6 +53,67 @@ describe('ConfigController - getMcpSettingsJson', () => {
     (DaoFactory.getOAuthClientDao as unknown as jest.Mock).mockReturnValue(mockOAuthClientDao);
     (DaoFactory.getOAuthTokenDao as unknown as jest.Mock).mockReturnValue(mockOAuthTokenDao);
     (DaoFactory.getBearerKeyDao as unknown as jest.Mock).mockReturnValue(mockBearerKeyDao);
+  });
+
+  it('should reject full settings export for non-admin users', async () => {
+    mockRequest = {
+      query: {},
+      user: { username: 'regular-user', isAdmin: false },
+    } as Partial<Request> & { user: { username: string; isAdmin: boolean } };
+
+    await getMcpSettingsJson(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).toHaveBeenCalledWith(403);
+    expect(mockJson).toHaveBeenCalledWith({
+      success: false,
+      message: 'Admin privileges required',
+    });
+    expect(mockUserDao.findAll).not.toHaveBeenCalled();
+    expect(mockOAuthClientDao.findAll).not.toHaveBeenCalled();
+    expect(mockOAuthTokenDao.findAll).not.toHaveBeenCalled();
+    expect(mockBearerKeyDao.findAll).not.toHaveBeenCalled();
+  });
+
+  it('should redact secrets from full settings export', async () => {
+    mockServerDao.findAll.mockResolvedValue([]);
+    mockUserDao.findAll.mockResolvedValue([
+      { username: 'admin', password: '$2b$hash', isAdmin: true },
+    ]);
+    mockGroupDao.findAll.mockResolvedValue([]);
+    mockSystemConfigDao.get.mockResolvedValue({});
+    mockUserConfigDao.getAll.mockResolvedValue({});
+    mockOAuthClientDao.findAll.mockResolvedValue([
+      { clientId: 'client-1', clientSecret: 'secret', name: 'client', redirectUris: [], grants: [] },
+    ]);
+    mockOAuthTokenDao.findAll.mockResolvedValue([
+      {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        clientId: 'client-1',
+        username: 'admin',
+      },
+    ]);
+    mockBearerKeyDao.findAll.mockResolvedValue([
+      { id: 'key-1', name: 'key', token: 'bearer-token', enabled: true, accessType: 'all' },
+    ]);
+
+    await getMcpSettingsJson(mockRequest as Request, mockResponse as Response);
+
+    expect(mockJson).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        mcpServers: {},
+        users: [{ username: 'admin', isAdmin: true }],
+        groups: [],
+        systemConfig: {},
+        userConfigs: {},
+        oauthClients: [
+          { clientId: 'client-1', name: 'client', redirectUris: [], grants: [] },
+        ],
+        oauthTokens: [{ clientId: 'client-1', username: 'admin' }],
+        bearerKeys: [{ id: 'key-1', name: 'key', enabled: true, accessType: 'all' }],
+      },
+    });
   });
 
   describe('Individual Server Export', () => {


### PR DESCRIPTION
## Summary

The MCP settings export endpoint (`GET /api/mcp-settings/export`, handled by `getMcpSettingsJson` in `src/controllers/configController.ts`) is mounted under `authenticatedRouter`, so any authenticated user — including a low-privileged account self-registered via `POST /auth/register` — can call it. The full-settings response includes secrets that should never be returned to non-admins:

- `users[].password` — bcrypt hashes (offline crackable)
- `oauthClients[].clientSecret`
- `oauthTokens[].accessToken` / `refreshToken`
- `bearerKeys[].token` — full API access tokens

There is no admin gate and no field redaction. `createSafeJSON` only handles circular references; the redacting log replacer is only used by `safeStringify`, not by this response path. This is a missing-authorization issue (CWE-862) combined with sensitive data exposure (CWE-200).

**Severity:** High — enables straightforward privilege escalation from any low-privileged account to admin (via stolen bearer token, or by cracking the admin bcrypt hash offline).

**Data flow (pre-fix):**
1. Attacker registers via the open `/auth/register` endpoint → receives JWT.
2. Attacker calls `GET /api/mcp-settings/export` with the JWT.
3. `authenticatedRouter` lets the request through (no admin check).
4. `getMcpSettingsJson` aggregates DAO results and returns them as JSON, unredacted.
5. Attacker now holds admin password hashes + valid bearer tokens.

## Fix

`src/controllers/configController.ts`:

1. Add a `requireAdmin(req, res)` helper that returns `403 { success: false, message: 'Admin privileges required' }` when `req.user.isAdmin` is not true. Called at the top of `getMcpSettingsJson`.
2. Add an `omitSensitiveFields` helper and apply it to the response so that, even for admins, the export omits:
   - `password` from each user
   - `clientSecret` from each oauth client
   - `accessToken` and `refreshToken` from each oauth token
   - `token` from each bearer key

The admin gate is the primary control; the redaction is defense-in-depth so an admin's exported config file (which is often shared or committed) doesn't carry live credentials.

## Tests

Added two cases in `tests/controllers/configController.test.ts`:

- **Non-admin is rejected:** request with `user.isAdmin = false` → expects `status(403)` and the standard error body, and asserts that none of the sensitive DAOs (`UserDao`, `OAuthClientDao`, `OAuthTokenDao`, `BearerKeyDao`) are queried.
- **Admin response is redacted:** mocks each DAO with a record that contains a sensitive field, then asserts the JSON response contains the records with the sensitive fields stripped.

Existing individual-server-export tests in the same file continue to pass (the default `mockRequest.user` is now an admin, matching the previous implicit behaviour).

## Adversarial review

Before submitting, we tried to disprove this. The endpoint is behind `authenticatedRouter`, so initially it looks like "you already need an account" — but `/auth/register` is open by default, so an external attacker can self-provision the precondition. We also checked whether `createSafeJSON` performs any redaction (it doesn't — only `safeStringify` uses the redacting replacer), and whether some upstream middleware enforces `isAdmin` for `/api/mcp-settings/*` (it doesn't; only a subset of admin-only routes have explicit checks). The vulnerability gives the attacker materially more access than they started with (admin password hash + live bearer tokens), so it isn't subsumed by the precondition.

Note: a parallel endpoint `GET /api/settings` (`serverController.getAllSettings`) appears to leak similar data and likely deserves the same treatment, but it's a separate surface and out of scope for this PR.

cc @lewiswigmore
