### PR TITLE
fix(auth): reject scoped bearer keys on dashboard API (CWE-863)

### DIFF
--- a/src/middlewares/auth.test.ts
+++ b/src/middlewares/auth.test.ts
@@ -103,6 +103,70 @@ describe('auth middleware', () => {
     expect(response.body).toEqual({ success: true });
   });
 
+  it('does not accept group-scoped bearer key auth for dashboard API routes', async () => {
+    findEnabledMock.mockResolvedValue([
+      {
+        id: 'key-2',
+        name: 'group-scoped',
+        token: 'group-key',
+        enabled: true,
+        accessType: 'groups',
+        allowedGroups: ['engineering'],
+      },
+    ]);
+
+    const app = createApp();
+    const response = await request(app)
+      .get('/api/protected')
+      .set('Authorization', 'Bearer group-key');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ success: false, message: 'No token, authorization denied' });
+  });
+
+  it('does not accept server-scoped bearer key auth for dashboard API routes', async () => {
+    findEnabledMock.mockResolvedValue([
+      {
+        id: 'key-3',
+        name: 'server-scoped',
+        token: 'server-key',
+        enabled: true,
+        accessType: 'servers',
+        allowedServers: ['filesystem'],
+      },
+    ]);
+
+    const app = createApp();
+    const response = await request(app)
+      .get('/api/protected')
+      .set('Authorization', 'Bearer server-key');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ success: false, message: 'No token, authorization denied' });
+  });
+
+  it('does not accept custom-scoped bearer key auth for dashboard API routes', async () => {
+    findEnabledMock.mockResolvedValue([
+      {
+        id: 'key-4',
+        name: 'custom-scoped',
+        token: 'custom-key',
+        enabled: true,
+        accessType: 'custom',
+        allowedGroups: ['engineering'],
+        allowedServers: ['filesystem'],
+      },
+    ]);
+
+    const app = createApp();
+    const response = await request(app)
+      .get('/api/protected')
+      .set('Authorization', 'Bearer custom-key');
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ success: false, message: 'No token, authorization denied' });
+  });
+
   it('bypasses dashboard API authentication when skipAuth is true', async () => {
     currentSystemConfig.routing.skipAuth = true;
 

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -50,6 +50,16 @@ const validateBearerAuth = async (req: Request, systemConfig?: SystemConfig | nu
     return false;
   }
 
+  // Dashboard/API bearer authentication grants access to non-MCP management routes.
+  // Scoped keys are enforced on MCP routes in sseService.ts and must not bypass
+  // dashboard API authorization.
+  if (matchingKey.accessType !== 'all') {
+    console.warn(
+      `Bearer auth denied for dashboard API: key id=${matchingKey.id}, name=${matchingKey.name} has restricted accessType=${matchingKey.accessType}`,
+    );
+    return false;
+  }
+
   console.log(
     `Bearer auth succeeded with key id=${matchingKey.id}, name=${matchingKey.name}, accessType=${matchingKey.accessType}`,
   );


### PR DESCRIPTION
## Summary

Bearer keys with restricted scope (`accessType` of `groups`, `servers`, or `custom`) are currently accepted as valid authentication for the dashboard/management API. This allows the holder of a scoped key to call dashboard endpoints that go beyond the scope the issuing admin intended.

- **CWE-863**: Incorrect Authorization
- **Affected file/function**: `src/middlewares/auth.ts` — `validateBearerAuth`
- **Severity**: High (privilege/scope escalation by an authenticated key holder)

## Vulnerability details

In `validateBearerAuth`, once a request's bearer token matches any enabled `BearerKey`, the function returns `true` regardless of the key's `accessType`:

```ts
const matchingKey = enabledKeys.find((key) => safeCompare(key.token, token));
if (!matchingKey) return false;
// ...returns true here, even if accessType is 'groups' / 'servers' / 'custom'
```

The dashboard auth middleware then short-circuits with `next()` without populating `req.user`. Two consequences:

1. Endpoints that read the caller via `UserContextService` see no current user. In several places the code paths treat an absent user as effectively unrestricted (e.g. `!currentUser || currentUser.isAdmin`), so a scoped key holder gains broader visibility/management than the key was meant to allow.
2. Endpoints with no admin gate (e.g. `getAllServers`, `getAllSettings`, `getGroup`, activity endpoints) become reachable by any holder of *any* enabled bearer key — even one that the admin scoped to a single group or server.

Endpoints protected by `requireAdmin` (bearer-key CRUD, user CRUD) still 403 because `req.user.isAdmin` is unset, but a wide surface of dashboard management routes is exposed.

MCP routes themselves (`/sse`, `/mcp`) continue to enforce scope via `sseService.ts`, so this fix is specifically about the dashboard/management API path.

## Fix

`src/middlewares/auth.ts` — after a token matches, if `matchingKey.accessType !== 'all'`, reject the request from the dashboard auth path:

```ts
if (matchingKey.accessType !== 'all') {
  console.warn(
    `Bearer auth denied for dashboard API: key id=${matchingKey.id}, name=${matchingKey.name} has restricted accessType=${matchingKey.accessType}`,
  );
  return false;
}
```

Rationale: the dashboard API is a single, undifferentiated authorization surface — there is no per-route mapping back to a key's allowed groups/servers. The only `accessType` that semantically corresponds to "may use the dashboard API" is `all`. Scoped keys are still fully usable on MCP routes where their scope is meaningful and enforced.

## Tests

Added four cases in `src/middlewares/auth.test.ts`:

- `accessType: 'groups'` key → dashboard API request rejected with 401
- `accessType: 'servers'` key → 401
- `accessType: 'custom'` key → 401
- (existing) `accessType: 'all'` key → still succeeds

All four pass locally. No other tests were modified.

## Security analysis

- **Preconditions to exploit**: attacker must hold a valid, enabled bearer key with a non-`all` `accessType`, plus network access to the dashboard API. These keys are intentionally issued by admins to delegate limited access — the realistic threat is the legitimate holder of a scoped key escalating beyond their intended scope.
- **What the fix prevents**: any holder of a non-`all` key from authenticating against `/api/*` dashboard routes. Their key remains valid for MCP routes where `sseService.ts` enforces the scope.
- **What it does not change**: `accessType: 'all'` keys keep their existing behavior; MCP-route auth is untouched; admin-only endpoints behind `requireAdmin` remain admin-only.

## Adversarial review

Before submitting, we tried to disprove this. We checked whether `requireAdmin` or the `UserContextService`-based filters would already prevent meaningful access for a scoped key holder — they don't. `requireAdmin` blocks the truly admin-only mutations, but a substantial set of dashboard read/management endpoints either have no admin gate or treat an absent `currentUser` as unrestricted, so a holder of a key scoped to one group can still enumerate and act outside that scope. We also confirmed MCP-route scope enforcement in `sseService.ts` is independent of this middleware path, so restricting dashboard access here does not regress MCP behavior.

cc @lewiswigmore
