### PR TITLE
fix: load server config from DB after OAuth token exchange

### DIFF
--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -22,6 +22,7 @@ import {
   createTransportFromConfig,
 } from '../services/mcpService.js';
 import { getNameSeparator, loadSettings } from '../config/index.js';
+import { loadServerConfig } from '../services/oauthSettingsStore.js';
 import type { ServerInfo } from '../types/index.js';
 
 /**
@@ -253,10 +254,13 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
           serverName: serverInfo.name,
         });
 
-        // Refresh server configuration from disk to ensure we pick up newly saved tokens
+        // Refresh server configuration from DB (or file) to pick up newly saved tokens.
+        // DB-mode servers are not present in the JSON file, so loadSettings() returns undefined
+        // for them — causing the new OAuth provider to see no tokens and loop indefinitely.
+        const dbConfig = await loadServerConfig(serverInfo.name);
         const settings = loadSettings();
         const storedConfig = settings.mcpServers?.[serverInfo.name];
-        const effectiveConfig = storedConfig || serverInfo.config;
+        const effectiveConfig = dbConfig || storedConfig || serverInfo.config;
 
         if (!effectiveConfig) {
           throw new Error(

--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -21,7 +21,7 @@ import {
   getServerByOAuthState,
   createTransportFromConfig,
 } from '../services/mcpService.js';
-import { getNameSeparator, loadSettings } from '../config/index.js';
+import { getNameSeparator, replaceEnvVars } from '../config/index.js';
 import { loadServerConfig } from '../services/oauthSettingsStore.js';
 import type { ServerInfo } from '../types/index.js';
 
@@ -254,13 +254,14 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
           serverName: serverInfo.name,
         });
 
-        // Refresh server configuration from DB (or file) to pick up newly saved tokens.
-        // DB-mode servers are not present in the JSON file, so loadSettings() returns undefined
-        // for them — causing the new OAuth provider to see no tokens and loop indefinitely.
-        const dbConfig = await loadServerConfig(serverInfo.name);
-        const settings = loadSettings();
-        const storedConfig = settings.mcpServers?.[serverInfo.name];
-        const effectiveConfig = dbConfig || storedConfig || serverInfo.config;
+        // Refresh server configuration from storage (DB or file) to pick up newly saved tokens.
+        // loadServerConfig is DAO-backed and handles both DB and file modes, so a redundant
+        // loadSettings() call is not needed. Apply replaceEnvVars so fields like url/command
+        // have environment variable references expanded, consistent with initial server setup.
+        const freshConfig = await loadServerConfig(serverInfo.name);
+        const effectiveConfig = freshConfig
+          ? (replaceEnvVars(freshConfig as any) as typeof freshConfig)
+          : serverInfo.config;
 
         if (!effectiveConfig) {
           throw new Error(


### PR DESCRIPTION
## Problem

In DB mode (`DB_URL` set), OAuth callback for upstream servers (e.g. Cloudflare MCP) enters an infinite loop after a successful token exchange.

## Root Cause

After `finishAuth()` saves tokens to the database, the controller reloads server config using `loadSettings()` which reads from the **JSON file**:

```ts
const settings = loadSettings();
const storedConfig = settings.mcpServers?.[serverInfo.name]; // undefined for DB-only servers
const effectiveConfig = storedConfig || serverInfo.config;   // falls back to stale config (no tokens)
```

For servers configured only in the database (not in `global.json`), `storedConfig` is `undefined`. The stale `serverInfo.config` has no `accessToken`, so the new `MCPHubOAuthProvider` returns `undefined` from `tokens()`, the upstream server returns 401, tokens are cleared, and a new OAuth flow starts — infinite loop.

## Fix

Use `loadServerConfig()` (DAO-backed, reads from DB) to reload config after token exchange. Falls back to file config and `serverInfo.config` for backward compatibility with file mode.

```ts
const dbConfig = await loadServerConfig(serverInfo.name);
const settings = loadSettings();
const storedConfig = settings.mcpServers?.[serverInfo.name];
const effectiveConfig = dbConfig || storedConfig || serverInfo.config;
```

`loadServerConfig` already exists in `oauthSettingsStore.ts` and uses `serverDao.findById()` — returns fresh config including the newly saved tokens.

## Test

1. Run MCPHub with `DB_URL` pointing to PostgreSQL
2. Add an OAuth-protected MCP server (e.g. Cloudflare MCP) via the UI
3. Trigger OAuth flow → complete authorization in browser
4. **Before fix**: infinite loop — `Cleared OAuth tokens` immediately after `Saved OAuth tokens`
5. **After fix**: server connects successfully after callback

Closes #786