### PR TITLE
fix: allow scoped bearer auth on smart routes

### DIFF
--- a/src/services/sseService.test.ts
+++ b/src/services/sseService.test.ts
@@ -352,6 +352,52 @@ describe('sseService', () => {
       expect(res.status).not.toHaveBeenCalledWith(401);
       expect(SSEServerTransport).toHaveBeenCalled();
     });
+
+    it('should allow group-scoped bearer keys on smart routing group paths (issue #784)', async () => {
+      setMockSystemConfig({
+        routing: {
+          enableGlobalRoute: true,
+          enableGroupNameRoute: true,
+          enableBearerAuth: true,
+          bearerAuthKey: 'group-token',
+          skipAuth: false,
+        },
+      });
+
+      (getBearerKeyDao as jest.MockedFunction<any>).mockReturnValueOnce({
+        findEnabled: jest.fn().mockResolvedValue([
+          {
+            id: 'smart-group-key-id',
+            name: 'smart-group-key',
+            token: 'group-token',
+            enabled: true,
+            accessType: 'groups',
+            allowedGroups: ['my-group'],
+            allowedServers: [],
+          },
+        ]),
+      });
+
+      (getGroupDao as jest.MockedFunction<any>).mockReturnValueOnce({
+        findByName: jest.fn().mockImplementation((name: string) =>
+          name === 'my-group'
+            ? Promise.resolve({ id: 'my-group-id', name: 'my-group', servers: [] })
+            : Promise.resolve(null),
+        ),
+        findById: jest.fn().mockResolvedValue(null),
+      });
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer group-token' },
+        params: { group: '$smart/my-group' },
+      });
+      const res = createMockResponse();
+
+      await handleSseConnection(req, res);
+
+      expect(res.status).not.toHaveBeenCalledWith(401);
+      expect(SSEServerTransport).toHaveBeenCalled();
+    });
   });
 
   describe('getGroup', () => {

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -59,8 +59,25 @@ const isValidUUID = (str: string): boolean => {
   return uuidRegex.test(str);
 };
 
+const normalizeBearerScopeParam = (groupParam?: string): string | undefined => {
+  if (!groupParam) {
+    return undefined;
+  }
+
+  if (groupParam.startsWith('$smart/')) {
+    const targetGroup = groupParam.substring(7).trim();
+    return targetGroup || undefined;
+  }
+
+  if (groupParam === '$smart') {
+    return undefined;
+  }
+
+  return groupParam;
+};
+
 const isBearerKeyAllowedForRequest = async (req: Request, key: BearerKey): Promise<boolean> => {
-  const paramValue = (req.params as any)?.group as string | undefined;
+  const paramValue = normalizeBearerScopeParam((req.params as any)?.group as string | undefined);
 
   // accessType 'all' allows all requests
   if (key.accessType === 'all') {


### PR DESCRIPTION
## Summary
- normalize `$smart/<group>` route params during bearer-key scope checks so group-scoped keys can access smart-routing group endpoints
- add a regression test covering issue #784 in `src/services/sseService.test.ts`
- restore local build/test reliability for optional `@huggingface/tokenizers` usage by adding a lightweight type shim and virtual Jest mocks

## Root cause
Bearer-key authorization matched `req.params.group` directly. For smart-routing URLs like `/mcp/$smart/public`, auth saw `"$smart/public"` instead of the actual group name `"public"`, so group-scoped keys were rejected with 401 before smart-routing parsing ran.

## Fix
- normalize only inside bearer scope matching:
  - `$smart/<group>` -> `<group>`
  - bare `$smart` stays unscoped/global
- keep the original route value everywhere else so downstream smart-routing behavior is unchanged

## Validation
- `pnpm lint`
- `pnpm backend:build`
- `pnpm test -- src/services/sseService.test.ts --runInBand`
- `pnpm test:ci`
- `pnpm build`
- `node scripts/verify-dist.js`
- manual smoke check:
  - `GET /health` -> healthy
  - `GET /` -> HTTP 200

Fixes #784