### PR TITLE
fix(embeddings): exclude tool description from toolset hash to prevent unnecessary regeneration

### DIFF
--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -968,10 +968,14 @@ const stableHashSerialize = (value: unknown): string => {
 };
 
 const buildToolSetHash = (tools: Tool[]): string => {
+  // Exclude description from the hash — some MCP servers (e.g. Wiz, Cortex) inject
+  // dynamic content into descriptions (permission checks, scope warnings) that changes
+  // on every connection, causing cache misses and unnecessary embedding regeneration.
+  // The tool's identity and schema (name + inputSchema) are stable structural properties
+  // and sufficient to detect real tool-set changes.
   const normalized = tools
     .map((tool) => ({
       name: tool.name || '',
-      description: tool.description || '',
       inputSchema: tool.inputSchema || null,
     }))
     .sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Problem

Some MCP servers (Wiz, Cortex, Context7, and others) inject **dynamic content** into tool descriptions at connection time — permission-check warnings, missing-scope notices, session-specific metadata. For example, Wiz MCP appends to descriptions:

> "Do not use this tool. The current user does not have the required scopes. [...read:system_health_issues...]"

This text changes depending on the user's current auth token and granted scopes.

Since `buildToolSetHash` includes `description`, the hash changes on every restart even when no tool has actually been added, removed, or structurally modified. This defeats the skip-check optimization added in #732 and causes **full embedding regeneration on every server restart** — burning OpenAI API credits and slowing startup.

## Fix

Exclude `description` from the toolset hash. Use only `name` and `inputSchema`, which are stable structural properties that genuinely indicate a tool-set change.

Tool descriptions are **still embedded** (the `searchableText` passed to the embedding API is unchanged). Only the cache-key computation is tightened.

## Before / After

**Before:** hash changes every restart for servers with dynamic descriptions → always regenerates  
**After:** hash stable across restarts as long as tool names and schemas don't change → skips regeneration correctly

## Testing

Verified against a Wiz MCP instance where tool descriptions contain dynamic scope-check annotations. After this fix, `[Embedding] Skipping — tool set already up-to-date` is logged on subsequent restarts instead of triggering a full regeneration.