### PR TITLE
fix(mcpService): skip reconnect for disabled servers

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1387,6 +1387,12 @@ export const reconnectServer = async (serverName: string): Promise<void> => {
     throw new Error(`Server not found: ${serverName}`);
   }
 
+  const serverConfig = await getServerDao().findById(serverName);
+  if (serverConfig?.enabled === false) {
+    console.log(`Skipping reconnect for disabled server: ${serverName}`);
+    return;
+  }
+
   // Close existing connection if any
   if (serverInfo.client) {
     try {


### PR DESCRIPTION
## Summary

- `reconnectServer()` was ignoring `enabled: false` and attempting full reconnection when called directly (e.g. UI reconnect button on a disabled server)
- Fix reads authoritative `enabled` state from DB config before proceeding
- Reads from DB (not stale in-memory `serverInfo`) so enabling a server in UI then reconnecting still works correctly

Fixes #798

## Root Cause

```typescript
// Before: no enabled check — disabled servers would reconnect
export const reconnectServer = async (serverName: string): Promise<void> => {
  const serverInfo = getServerByName(serverName);
  if (!serverInfo) throw new Error(`Server not found: ${serverName}`);
  // proceeds to reconnect regardless of enabled state
```

## Fix

```typescript
const serverConfig = await getServerDao().findById(serverName);
if (serverConfig?.enabled === false) {
  console.log(`Skipping reconnect for disabled server: ${serverName}`);
  return;
}
```

## Test plan

- [x] Disabled server: trigger reconnect via UI → no connection attempt, no error logs
- [x] Enabled server: trigger reconnect via UI → connects normally
- [x] Toggle server from disabled → enabled → reconnect → connects successfully