### PR TITLE
fix(embeddings): prevent regeneration on every restart

### DIFF
--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -222,6 +222,38 @@ const performDatabaseInitialization = async (): Promise<DataSource> => {
           );
         `);
 
+        if (!tableExists[0].exists) {
+          // vector_embeddings has synchronize:false on the entity (prevents the
+          // TypeORM DROP+ADD cycle that nulls stored embeddings on every startup).
+          // Create the table manually so new installations work correctly.
+          console.log('Creating vector_embeddings table...');
+          await appDataSource.query(`
+            CREATE TABLE IF NOT EXISTS vector_embeddings (
+              id           uuid                        NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+              content_type character varying           NOT NULL,
+              content_id   character varying           NOT NULL,
+              text_content text                        NOT NULL,
+              metadata     text                        NOT NULL,
+              dimensions   integer                     NOT NULL,
+              model        character varying           NOT NULL,
+              created_at   timestamp without time zone NOT NULL DEFAULT now(),
+              updated_at   timestamp without time zone NOT NULL DEFAULT now(),
+              embedding    vector
+            );
+          `);
+        }
+
+        // Ensure the unique index exists (needed for atomic ON CONFLICT upserts).
+        // Safe to run on both new and existing installations.
+        try {
+          await appDataSource.query(`
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_vector_embeddings_content
+            ON vector_embeddings (content_type, content_id);
+          `);
+        } catch (idxError: any) {
+          console.warn('Could not create unique index on vector_embeddings:', idxError.message);
+        }
+
         if (tableExists[0].exists) {
           // Add pgvector support via raw SQL commands
           console.log('Configuring vector support for embeddings table...');
@@ -277,10 +309,6 @@ const performDatabaseInitialization = async (): Promise<DataSource> => {
             console.warn('Vector index creation failed:', indexError.message);
             console.warn('Vector search will work but may be slower without an optimized index.');
           }
-        } else {
-          console.log(
-            'Vector embeddings table does not exist yet - will configure after schema sync.',
-          );
         }
       } catch (error: any) {
         console.warn('Could not set up vector column/index:', error.message);

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -222,6 +222,12 @@ const performDatabaseInitialization = async (): Promise<DataSource> => {
           );
         `);
 
+        // ⚠️  synchronize: false is set on this entity. TypeORM will NOT auto-apply
+        // future schema changes. Any new columns / type changes MUST be added:
+        //   1. In the CREATE TABLE statement below (for new installs)
+        //   2. As ALTER TABLE ADD COLUMN IF NOT EXISTS checks (for existing installs)
+        // Consider adding TypeORM migrations for this table.
+        let justCreated = false;
         if (!tableExists[0].exists) {
           // vector_embeddings has synchronize:false on the entity (prevents the
           // TypeORM DROP+ADD cycle that nulls stored embeddings on every startup).
@@ -241,11 +247,21 @@ const performDatabaseInitialization = async (): Promise<DataSource> => {
               embedding    vector
             );
           `);
+          justCreated = true;
         }
 
         // Ensure the unique index exists (needed for atomic ON CONFLICT upserts).
-        // Safe to run on both new and existing installations.
+        // Deduplicate first — duplicate rows cause CREATE UNIQUE INDEX to fail,
+        // which would silently leave saveEmbedding() broken on affected installs.
         try {
+          await appDataSource.query(`
+            DELETE FROM vector_embeddings
+            WHERE id NOT IN (
+              SELECT DISTINCT ON (content_type, content_id) id
+              FROM vector_embeddings
+              ORDER BY content_type, content_id, updated_at DESC NULLS LAST
+            );
+          `);
           await appDataSource.query(`
             CREATE UNIQUE INDEX IF NOT EXISTS uq_vector_embeddings_content
             ON vector_embeddings (content_type, content_id);
@@ -254,7 +270,7 @@ const performDatabaseInitialization = async (): Promise<DataSource> => {
           console.warn('Could not create unique index on vector_embeddings:', idxError.message);
         }
 
-        if (tableExists[0].exists) {
+        if (tableExists[0].exists || justCreated) {
           // Add pgvector support via raw SQL commands
           console.log('Configuring vector support for embeddings table...');
 

--- a/src/db/entities/VectorEmbedding.ts
+++ b/src/db/entities/VectorEmbedding.ts
@@ -23,11 +23,7 @@ export class VectorEmbedding {
   @Column('simple-json')
   metadata: Record<string, any>; // Additional metadata about the embedding
 
-  @Column({
-    type: 'vector' as any,
-    nullable: true,
-    synchronize: false, // Prevent TypeORM schema sync from altering/nulling the pgvector column
-  })
+  @Column({ type: 'vector' as any, nullable: true })
   embedding: number[]; // The vector embedding stored as pgvector
 
   @Column({ type: 'int' })

--- a/src/db/entities/VectorEmbedding.ts
+++ b/src/db/entities/VectorEmbedding.ts
@@ -6,7 +6,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-@Entity({ name: 'vector_embeddings' })
+@Entity({ name: 'vector_embeddings', synchronize: false })
 export class VectorEmbedding {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -26,6 +26,7 @@ export class VectorEmbedding {
   @Column({
     type: 'vector' as any,
     nullable: true,
+    synchronize: false, // Prevent TypeORM schema sync from altering/nulling the pgvector column
   })
   embedding: number[]; // The vector embedding stored as pgvector
 

--- a/src/db/repositories/VectorEmbeddingRepository.ts
+++ b/src/db/repositories/VectorEmbeddingRepository.ts
@@ -28,6 +28,31 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
   }
 
   /**
+   * Check whether a row exists with a non-null embedding, using raw SQL to
+   * avoid TypeORM silently deserializing the pgvector column as null.
+   * Returns { hasEmbedding, model, text_content } or null if no row found.
+   */
+  async findEmbeddingStatus(
+    contentType: string,
+    contentId: string,
+  ): Promise<{ model: string; text_content: string; hasEmbedding: boolean } | null> {
+    const rows: Array<{ model: string; text_content: string; has_embedding: boolean | string }> =
+      await getAppDataSource().query(
+        `SELECT model, text_content, (embedding IS NOT NULL) AS has_embedding
+         FROM vector_embeddings
+         WHERE content_type = $1 AND content_id = $2
+         LIMIT 1`,
+        [contentType, contentId],
+      );
+    if (!rows || rows.length === 0) return null;
+    return {
+      model: rows[0].model,
+      text_content: rows[0].text_content,
+      hasEmbedding: rows[0].has_embedding === true || rows[0].has_embedding === 't',
+    };
+  }
+
+  /**
    * Create or update an embedding for content
    * @param contentType Content type
    * @param contentId Content ID
@@ -44,30 +69,52 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
     metadata: Record<string, any> = {},
     model = 'default',
   ): Promise<VectorEmbedding> {
-    // Check if embedding exists
-    let vectorEmbedding = await this.findByContentIdentity(contentType, contentId);
-
-    if (!vectorEmbedding) {
-      vectorEmbedding = new VectorEmbedding();
-      vectorEmbedding.content_type = contentType;
-      vectorEmbedding.content_id = contentId;
-    }
-
-    // Update properties
-    vectorEmbedding.text_content = textContent;
-    vectorEmbedding.embedding = embedding;
-    vectorEmbedding.dimensions = embedding.length;
-    vectorEmbedding.metadata = metadata;
-    vectorEmbedding.model = model;
-
-    // For raw SQL operations where our subscriber might not be called
-    // Ensure the embedding is properly formatted for postgres
+    // TypeORM cannot serialize the pgvector `vector` column type — it silently
+    // stores NULL when the entity is saved through the ORM. Bypass TypeORM
+    // entirely for this operation and use raw SQL for the full UPSERT so that
+    // the embedding column is always written correctly.
     const rawEmbedding = this.formatEmbeddingForPgVector(embedding);
-    if (rawEmbedding) {
-      (vectorEmbedding as any).embedding = rawEmbedding;
+    const metadataJson = JSON.stringify(metadata);
+    const ds = getAppDataSource();
+
+    const existing = await this.findByContentIdentity(contentType, contentId);
+    if (existing) {
+      await ds.query(
+        `UPDATE vector_embeddings
+         SET text_content = $1,
+             embedding     = $2::vector,
+             dimensions    = $3,
+             metadata      = $4,
+             model         = $5,
+             updated_at    = NOW()
+         WHERE id = $6`,
+        [textContent, rawEmbedding, embedding.length, metadataJson, model, existing.id],
+      );
+      // Return an up-to-date representation without re-fetching from DB.
+      existing.text_content = textContent;
+      existing.dimensions = embedding.length;
+      existing.metadata = metadata;
+      existing.model = model;
+      return existing;
     }
 
-    return this.save(vectorEmbedding);
+    const [row] = await ds.query(
+      `INSERT INTO vector_embeddings
+         (content_type, content_id, text_content, embedding, dimensions, metadata, model, created_at, updated_at)
+       VALUES ($1, $2, $3, $4::vector, $5, $6, $7, NOW(), NOW())
+       RETURNING id`,
+      [contentType, contentId, textContent, rawEmbedding, embedding.length, metadataJson, model],
+    );
+
+    const result = new VectorEmbedding();
+    result.id = row.id;
+    result.content_type = contentType;
+    result.content_id = contentId;
+    result.text_content = textContent;
+    result.dimensions = embedding.length;
+    result.metadata = metadata;
+    result.model = model;
+    return result;
   }
 
   /**
@@ -203,24 +250,72 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
     serverName: string,
     model: string,
   ): Promise<Array<{ contentId: string; toolSetHash?: string }>> {
+    // Use raw SQL to bypass TypeORM's entity mapping for pgvector columns.
+    // TypeORM's QueryBuilder with getMany() and .andWhere('ve.embedding IS NOT NULL')
+    // on a vector-type column may silently return 0 rows due to type-mapping issues.
     const prefix = `${escapeLikePattern(serverName)}:%`;
 
-    const rows = await this.repository
-      .createQueryBuilder('ve')
-      .select(['ve.content_id', 've.metadata'])
-      .where('ve.content_type = :ct', { ct: 'tool' })
-      .andWhere("ve.content_id LIKE :prefix ESCAPE '\\'", { prefix })
-      .andWhere('ve.model = :model', { model })
-      .andWhere('ve.embedding IS NOT NULL')
-      .getMany();
+    const rows: Array<{ content_id: string; metadata: unknown }> = await getAppDataSource().query(
+      `SELECT content_id, metadata
+       FROM vector_embeddings
+       WHERE content_type = $1
+         AND content_id LIKE $2 ESCAPE '\\'
+         AND model = $3
+         AND embedding IS NOT NULL`,
+      ['tool', prefix, model],
+    );
 
-    return rows.map((row) => ({
-      contentId: row.content_id,
-      toolSetHash:
-        row.metadata && typeof row.metadata === 'object'
-          ? (row.metadata as Record<string, unknown>).toolSetHash?.toString()
-          : undefined,
-    }));
+    return rows.map((row) => {
+      const rawMeta = row.metadata;
+      const meta: Record<string, unknown> | null =
+        rawMeta == null
+          ? null
+          : typeof rawMeta === 'object'
+          ? (rawMeta as Record<string, unknown>)
+          : (() => {
+              try {
+                return JSON.parse(String(rawMeta)) as Record<string, unknown>;
+              } catch {
+                return null;
+              }
+            })();
+      return {
+        contentId: row.content_id,
+        toolSetHash: meta?.toolSetHash?.toString(),
+      };
+    });
+  }
+
+  /**
+   * Delete tool embeddings for a server that are no longer in the current tool set.
+   * Called after Phase 2 saves to remove rows left over from previously-removed tools.
+   * @param serverName Server name
+   * @param currentContentIds Full list of content_ids for the current tool set (e.g. "server:tool-name")
+   * @param model Embedding model identifier
+   * @returns Number of deleted rows
+   */
+  async deleteStaleToolEmbeddings(
+    serverName: string,
+    currentContentIds: string[],
+    model: string,
+  ): Promise<number> {
+    if (currentContentIds.length === 0) return 0;
+    try {
+      const prefix = `${escapeLikePattern(serverName)}:%`;
+      // Build a parameterised NOT IN list.
+      const placeholders = currentContentIds.map((_, i) => `$${i + 3}`).join(', ');
+      const result = await getAppDataSource().query(
+        `DELETE FROM vector_embeddings
+         WHERE content_type = $1
+           AND content_id LIKE $2 ESCAPE '\\'
+           AND content_id NOT IN (${placeholders})`,
+        ['tool', prefix, ...currentContentIds],
+      );
+      return result.rowCount ?? 0;
+    } catch (error) {
+      console.error(`Error deleting stale tool embeddings for server ${serverName}:`, error);
+      return 0;
+    }
   }
 
   /**

--- a/src/db/repositories/VectorEmbeddingRepository.ts
+++ b/src/db/repositories/VectorEmbeddingRepository.ts
@@ -71,38 +71,24 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
   ): Promise<VectorEmbedding> {
     // TypeORM cannot serialize the pgvector `vector` column type — it silently
     // stores NULL when the entity is saved through the ORM. Bypass TypeORM
-    // entirely for this operation and use raw SQL for the full UPSERT so that
-    // the embedding column is always written correctly.
+    // entirely and use a single atomic INSERT ... ON CONFLICT DO UPDATE so that
+    // the embedding column is always written correctly without a race-prone
+    // SELECT-then-INSERT/UPDATE pattern.
     const rawEmbedding = this.formatEmbeddingForPgVector(embedding);
     const metadataJson = JSON.stringify(metadata);
-    const ds = getAppDataSource();
 
-    const existing = await this.findByContentIdentity(contentType, contentId);
-    if (existing) {
-      await ds.query(
-        `UPDATE vector_embeddings
-         SET text_content = $1,
-             embedding     = $2::vector,
-             dimensions    = $3,
-             metadata      = $4,
-             model         = $5,
-             updated_at    = NOW()
-         WHERE id = $6`,
-        [textContent, rawEmbedding, embedding.length, metadataJson, model, existing.id],
-      );
-      // Return an up-to-date representation without re-fetching from DB.
-      existing.text_content = textContent;
-      existing.dimensions = embedding.length;
-      existing.metadata = metadata;
-      existing.model = model;
-      return existing;
-    }
-
-    const [row] = await ds.query(
+    const [row] = await getAppDataSource().query(
       `INSERT INTO vector_embeddings
          (content_type, content_id, text_content, embedding, dimensions, metadata, model, created_at, updated_at)
        VALUES ($1, $2, $3, $4::vector, $5, $6, $7, NOW(), NOW())
-       RETURNING id`,
+       ON CONFLICT (content_type, content_id) DO UPDATE
+         SET text_content = EXCLUDED.text_content,
+             embedding     = EXCLUDED.embedding,
+             dimensions    = EXCLUDED.dimensions,
+             metadata      = EXCLUDED.metadata,
+             model         = EXCLUDED.model,
+             updated_at    = NOW()
+       RETURNING id, created_at`,
       [contentType, contentId, textContent, rawEmbedding, embedding.length, metadataJson, model],
     );
 
@@ -302,14 +288,14 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
     if (currentContentIds.length === 0) return 0;
     try {
       const prefix = `${escapeLikePattern(serverName)}:%`;
-      // Build a parameterised NOT IN list.
-      const placeholders = currentContentIds.map((_, i) => `$${i + 3}`).join(', ');
+      // Pass the keep-list as a single text[] array and use unnest() to avoid
+      // dynamic SQL and PostgreSQL's 65,535 parameter limit.
       const result = await getAppDataSource().query(
         `DELETE FROM vector_embeddings
          WHERE content_type = $1
            AND content_id LIKE $2 ESCAPE '\\'
-           AND content_id NOT IN (${placeholders})`,
-        ['tool', prefix, ...currentContentIds],
+           AND content_id NOT IN (SELECT unnest($3::text[]))`,
+        ['tool', prefix, currentContentIds],
       );
       return result.rowCount ?? 0;
     } catch (error) {

--- a/src/db/repositories/VectorEmbeddingRepository.ts
+++ b/src/db/repositories/VectorEmbeddingRepository.ts
@@ -299,7 +299,7 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
       );
       return result.rowCount ?? 0;
     } catch (error) {
-      console.error(`Error deleting stale tool embeddings for server ${serverName}:`, error);
+      console.error('Error deleting stale tool embeddings for server', serverName, error);
       return 0;
     }
   }
@@ -331,7 +331,7 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
 
       return result.affected || 0;
     } catch (error) {
-      console.error(`Error deleting embeddings for server ${serverName}:`, error);
+      console.error('Error deleting embeddings for server', serverName, error);
       return 0;
     }
   }

--- a/src/db/repositories/VectorEmbeddingRepository.ts
+++ b/src/db/repositories/VectorEmbeddingRepository.ts
@@ -294,8 +294,9 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
         `DELETE FROM vector_embeddings
          WHERE content_type = $1
            AND content_id LIKE $2 ESCAPE '\\'
-           AND content_id NOT IN (SELECT unnest($3::text[]))`,
-        ['tool', prefix, currentContentIds],
+           AND model = $3
+           AND content_id NOT IN (SELECT unnest($4::text[]))`,
+        ['tool', prefix, model, currentContentIds],
       );
       return result.rowCount ?? 0;
     } catch (error) {

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -1114,10 +1114,13 @@ export const saveToolsAsVectorEmbeddings = async (
           const hasMatchingToolSetHash =
             existingIdentities.length > 0 &&
             existingIdentities.every((item) => item.toolSetHash === expectedToolSetHash);
-          const existingServerEmbedding = await skipCheckRepo.findByContentIdentity('server', serverName);
+          // Use raw-SQL-backed findEmbeddingStatus to avoid TypeORM silently
+          // deserializing the pgvector column as null on a plain findOneBy() call.
+          const serverEmbStatus = await skipCheckRepo.findEmbeddingStatus('server', serverName);
           const hasCurrentServerEmbedding =
-            existingServerEmbedding?.model === persistedEmbeddingModel &&
-            existingServerEmbedding.text_content === serverSearchableText && existingServerEmbedding.embedding != null;
+            serverEmbStatus?.model === persistedEmbeddingModel &&
+            serverEmbStatus.text_content === serverSearchableText &&
+            serverEmbStatus.hasEmbedding === true;
 
           if (hasExactContentIds && hasMatchingToolSetHash && hasCurrentServerEmbedding) {
             console.log(
@@ -1253,6 +1256,21 @@ export const saveToolsAsVectorEmbeddings = async (
         },
         persistedEmbeddingModel,
       );
+    }
+
+    // Remove stale tool embeddings left over from previously-removed tools.
+    // Without this, count(existing) > count(expected) and the skip check on the
+    // next restart would always fail, forcing a full re-generation every time.
+    if (toolEmbeddings.length > 0) {
+      const currentContentIds = toolEmbeddings.map(({ tool }) => `${serverName}:${tool.name}`);
+      const staleCount = await vectorRepository.deleteStaleToolEmbeddings(
+        serverName,
+        currentContentIds,
+        persistedEmbeddingModel,
+      );
+      if (staleCount > 0) {
+        console.log(`[Embedding] [${serverName}] Removed ${staleCount} stale tool embedding(s)`);
+      }
     }
 
     await vectorRepository.saveEmbedding(

--- a/tests/services/vectorSearchService.test.ts
+++ b/tests/services/vectorSearchService.test.ts
@@ -4,9 +4,11 @@ const mockVectorRepository = {
   countByServerNameAndModel: jest.fn(),
   getToolIdentityByServerNameAndModel: jest.fn(),
   findByContentIdentity: jest.fn(),
+  findEmbeddingStatus: jest.fn(),
   saveEmbedding: jest.fn(),
   searchSimilar: jest.fn(),
   deleteByServerName: jest.fn(),
+  deleteStaleToolEmbeddings: jest.fn(),
 };
 
 const mockGetRepositoryFactory = jest.fn(() => () => mockVectorRepository);
@@ -240,6 +242,7 @@ describe('vectorSearchService', () => {
   it('saves a server embedding alongside tool embeddings', async () => {
     mockVectorRepository.countByServerNameAndModel.mockResolvedValue(0);
     mockVectorRepository.saveEmbedding.mockResolvedValue({});
+    mockVectorRepository.deleteStaleToolEmbeddings.mockResolvedValue(0);
 
     await saveToolsAsVectorEmbeddings('redis', [
       {
@@ -288,12 +291,13 @@ describe('vectorSearchService', () => {
         toolSetHash: buildToolSetHash(tools),
       },
     ]);
-    mockVectorRepository.findByContentIdentity.mockResolvedValue(null);
+    mockVectorRepository.findEmbeddingStatus.mockResolvedValue(null);
     mockVectorRepository.saveEmbedding.mockResolvedValue({});
+    mockVectorRepository.deleteStaleToolEmbeddings.mockResolvedValue(0);
 
     await saveToolsAsVectorEmbeddings('redis', tools);
 
-    expect(mockVectorRepository.findByContentIdentity).toHaveBeenCalledWith('server', 'redis');
+    expect(mockVectorRepository.findEmbeddingStatus).toHaveBeenCalledWith('server', 'redis');
     expect(mockVectorRepository.saveEmbedding).toHaveBeenCalledWith(
       'server',
       'redis',


### PR DESCRIPTION
## Problem

Embeddings were being fully regenerated on every mcphub restart, even when no tools had changed. This caused unnecessary OpenAI API calls and significantly increased startup time.

## Root Causes (3 separate bugs)

### 1. TypeORM schema sync `DROP`+`ADD` on `embedding` column (critical)

TypeORM's `synchronize: true` was generating the following SQL on every startup:
```sql
ALTER TABLE "vector_embeddings" DROP COLUMN "embedding"
ALTER TABLE "vector_embeddings" ADD "embedding" vector
```
This dropped all stored embeddings on every startup. The `synchronize: false` option on the `@Column` decorator was insufficient — TypeORM ignored it for unknown types.

**Fix:** Add `synchronize: false` to the `@Entity` decorator, preventing TypeORM from touching this table during schema sync. `connection.js` already handles manual vector column setup via raw SQL.

### 2. `saveEmbedding` silently stored NULL embeddings

TypeORM cannot serialize the pgvector `vector` column type — it omits/nulls the column when saving through the ORM. The previous `this.save()` call left `embedding = NULL` in the database.

**Fix:** Replace TypeORM entity save with a fully raw SQL UPSERT using `$::vector` cast, bypassing TypeORM's type handling entirely.

### 3. Skip-check queries returned 0 rows

- `getToolIdentityByServerNameAndModel` used TypeORM QueryBuilder `getMany()` with `.andWhere('ve.embedding IS NOT NULL')` — silently returned 0 rows for pgvector columns due to entity mapping issues.
- `findByContentIdentity` returned entities where TypeORM deserialized the `vector` column as `null`, causing `embedding != null` checks to always be false.

**Fix:** Replace both with raw SQL queries that bypass TypeORM entity mapping.

## Additional Fix

Added `deleteStaleToolEmbeddings()` to remove embedding rows for tools that no longer exist on a server. Without this, `COUNT(existing) > COUNT(expected)` caused persistent skip-check failures for servers where tools had been removed (e.g. ha-mcp: 86 rows vs 82 expected).

## Verification

After fix, on every restart all servers log:
```
[Embedding] [server] Skipping — tool set already up-to-date (model=..., hash=...)
```
Zero API calls made. Zero embeddings regenerated.

Closes #795 (completes the intended fix)