### PR TITLE
feat(cli): add official mcphub CLI for hub administration and tool calling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ For deeper architecture context, read [docs/development/architecture.mdx](docs/d
 | Add an MCP server     | Edit `mcp_settings.json`, restart backend, check connect log line     |
 | Add an HTTP API       | `src/routes/` → `src/controllers/` → types in `src/types/` → tests   |
 | Add a frontend page   | `frontend/src/pages/` (+ `frontend/src/components/`), wire in router |
+| Add a CLI subcommand  | `src/cli/commands/<name>.ts` + register in `src/cli/main.ts` dispatcher + `src/cli/help.ts` + tests in `tests/cli/commands/` |
 | Add a translation key | Add to all four `locales/*.json` files                                |
 | Update public docs    | `docs/` (Mintlify); reflect major changes in `README.md`              |
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The same `mcphub` binary doubles as a CLI for the running hub — no extra insta
 mcphub login --url http://localhost:3000 --username admin
 mcphub servers list
 mcphub servers add fetch --type stdio --command uvx --arg mcp-server-fetch
+mcphub tools list                              # discover what tools are available
+mcphub tools get fetch_url                     # see required params + sample command
 mcphub call fetch_url url=https://example.com --json
 mcphub keys create --name ci --access-type all
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ http://localhost:3000/mcp/$smart/{group}  # Smart routing within group
 
 📖 See [API Reference](https://docs.mcphub.app/api-reference) for detailed endpoint documentation.
 
+### Manage From the Terminal
+
+The same `mcphub` binary doubles as a CLI for the running hub — no extra install needed.
+
+```bash
+mcphub login --url http://localhost:3000 --username admin
+mcphub servers list
+mcphub servers add fetch --type stdio --command uvx --arg mcp-server-fetch
+mcphub call fetch_url url=https://example.com --json
+mcphub keys create --name ci --access-type all
+```
+
+It also speaks the public marketplace API (`mcphub discover`, `mcphub install ...`) so server lookup and one-command install work against any hub with discovery enabled.
+
+📖 See [CLI Guide](https://docs.mcphub.app/features/cli) for every subcommand, profiles, and CI usage.
+
 ## 📚 Documentation
 
 | Topic                                                                          | Description                       |
@@ -94,6 +110,7 @@ http://localhost:3000/mcp/$smart/{group}  # Smart routing within group
 | [Database Mode](https://docs.mcphub.app/configuration/database-configuration) | PostgreSQL setup for production   |
 | [OAuth](https://docs.mcphub.app/features/oauth)                               | OAuth 2.0 client and server setup |
 | [Smart Routing](https://docs.mcphub.app/features/smart-routing)               | AI-powered tool discovery         |
+| [CLI Guide](https://docs.mcphub.app/features/cli)                             | Manage and call the hub from a terminal |
 | [Docker Setup](https://docs.mcphub.app/configuration/docker-setup)            | Docker deployment guide           |
 
 ## 🧑‍💻 Local Development

--- a/README.zh.md
+++ b/README.zh.md
@@ -93,6 +93,8 @@ http://localhost:3000/mcp/$smart/{group}  # 智能路由（特定分组）
 mcphub login --url http://localhost:3000 --username admin
 mcphub servers list
 mcphub servers add fetch --type stdio --command uvx --arg mcp-server-fetch
+mcphub tools list                              # 看有哪些 tool 可调
+mcphub tools get fetch_url                     # 看必填参数和样例命令
 mcphub call fetch_url url=https://example.com --json
 mcphub keys create --name ci --access-type all
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -85,6 +85,22 @@ http://localhost:3000/mcp/$smart/{group}  # 智能路由（特定分组）
 
 📖 查看 [API 参考](https://docs.mcphub.app/zh/api-reference)了解详细的端点文档。
 
+### 终端管理
+
+`mcphub` 同一个二进制兼任 CLI，无需额外安装。
+
+```bash
+mcphub login --url http://localhost:3000 --username admin
+mcphub servers list
+mcphub servers add fetch --type stdio --command uvx --arg mcp-server-fetch
+mcphub call fetch_url url=https://example.com --json
+mcphub keys create --name ci --access-type all
+```
+
+CLI 同样对接公共市场接口（`mcphub discover`、`mcphub install ...`），可对任意开启了 discovery 的 hub 做检索与一键安装。
+
+📖 查看 [CLI 指南](https://docs.mcphub.app/zh/features/cli)了解全部子命令、profile 管理与 CI 用法。
+
 ## 📚 文档
 
 | 主题                                                                           | 描述                         |
@@ -94,6 +110,7 @@ http://localhost:3000/mcp/$smart/{group}  # 智能路由（特定分组）
 | [数据库模式](https://docs.mcphub.app/zh/configuration/database-configuration) | PostgreSQL 生产环境配置      |
 | [OAuth](https://docs.mcphub.app/zh/features/oauth)                            | OAuth 2.0 客户端和服务端配置 |
 | [智能路由](https://docs.mcphub.app/zh/features/smart-routing)                 | AI 驱动的工具发现            |
+| [CLI 指南](https://docs.mcphub.app/zh/features/cli)                           | 终端管理与工具调用           |
 | [Docker 部署](https://docs.mcphub.app/zh/configuration/docker-setup)          | Docker 部署指南              |
 
 ## 🧑‍💻 本地开发

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,6 +17,7 @@ const CLI_COMMANDS = new Set([
   'servers',
   'groups',
   'keys',
+  'tools',
   'call',
   'export',
   'discover',

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,44 +4,50 @@ import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import fs from 'fs';
 
-// Enable debug logging if needed
-// process.env.DEBUG = 'true';
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Start with more debug information
-console.log('📋 MCPHub CLI');
-console.log(`📁 CLI script location: ${__dirname}`);
+// Subcommands routed to the CLI dispatcher in dist/cli/main.js. Anything else
+// (including no args) falls through to the legacy server bootstrap so
+// `npx @samanhappy/mcphub` keeps working exactly as before.
+const CLI_COMMANDS = new Set([
+  'login',
+  'logout',
+  'config',
+  'servers',
+  'groups',
+  'keys',
+  'call',
+  'export',
+  'discover',
+  'install',
+  'help',
+  '--help',
+  '-h',
+  '--version',
+  '-v',
+]);
 
-// The npm package directory structure when installed is:
-// node_modules/@samanhappy/mcphub/
-//   - dist/
-//   - bin/
-//   - frontend/dist/
+const argv = process.argv.slice(2);
+const isCliCommand = argv.length > 0 && CLI_COMMANDS.has(argv[0]);
 
-// Get the package root - this is where package.json is located
 function findPackageRoot() {
   const isDebug = process.env.DEBUG === 'true';
-  
-  // Possible locations for package.json
+
   const possibleRoots = [
-    // Standard npm package location
     path.resolve(__dirname, '..'),
-    // When installed via npx
-    path.resolve(__dirname, '..', '..', '..')
+    path.resolve(__dirname, '..', '..', '..'),
   ];
-  
-  // Special handling for npx
+
   if (process.argv[1] && process.argv[1].includes('_npx')) {
     const npxDir = path.dirname(process.argv[1]);
     possibleRoots.unshift(path.resolve(npxDir, '..'));
   }
-  
+
   if (isDebug) {
     console.log('DEBUG: Checking for package.json in:', possibleRoots);
   }
-  
+
   for (const root of possibleRoots) {
     const packageJsonPath = path.join(root, 'package.json');
     if (fs.existsSync(packageJsonPath)) {
@@ -58,41 +64,48 @@ function findPackageRoot() {
       }
     }
   }
-  
-  console.log('⚠️ Could not find package.json, using default path');
+
+  if (!isCliCommand) {
+    console.log('⚠️ Could not find package.json, using default path');
+  }
   return path.resolve(__dirname, '..');
 }
 
-// Locate and check the frontend distribution
-function checkFrontend(packageRoot) {
-  const isDebug = process.env.DEBUG === 'true';
-  const frontendDistPath = path.join(packageRoot, 'frontend', 'dist');
-  
-  if (isDebug) {
-    console.log(`DEBUG: Checking frontend at: ${frontendDistPath}`);
+const projectRoot = findPackageRoot();
+
+if (isCliCommand) {
+  // CLI subcommand path — keep stdout clean for --json / pipes.
+  const cliEntryPath = path.join(projectRoot, 'dist', 'cli', 'main.js');
+  if (!fs.existsSync(cliEntryPath)) {
+    console.error('❌ CLI build missing: ' + cliEntryPath);
+    console.error('Run "pnpm backend:build" (or "pnpm build") and retry.');
+    process.exit(1);
   }
-  
-  if (fs.existsSync(frontendDistPath) && fs.existsSync(path.join(frontendDistPath, 'index.html'))) {
+  const cliEntryUrl = pathToFileURL(cliEntryPath).href;
+  const mod = await import(cliEntryUrl);
+  await mod.runCli(argv);
+} else {
+  // Legacy: server bootstrap. Existing console.log banner preserved here so it
+  // never leaks into CLI subcommand output.
+  console.log('📋 MCPHub CLI');
+  console.log(`📁 CLI script location: ${__dirname}`);
+  console.log(`📦 Using package root: ${projectRoot}`);
+
+  const frontendDistPath = path.join(projectRoot, 'frontend', 'dist');
+  if (
+    fs.existsSync(frontendDistPath) &&
+    fs.existsSync(path.join(frontendDistPath, 'index.html'))
+  ) {
     console.log('✅ Frontend distribution found');
-    return true;
   } else {
     console.log('⚠️ Frontend distribution not found at', frontendDistPath);
-    return false;
   }
+
+  console.log('🚀 Starting MCPHub server...');
+  const entryPath = path.join(projectRoot, 'dist', 'index.js');
+  const entryUrl = pathToFileURL(entryPath).href;
+  import(entryUrl).catch((err) => {
+    console.error('Failed to start MCPHub:', err);
+    process.exit(1);
+  });
 }
-
-const projectRoot = findPackageRoot();
-console.log(`📦 Using package root: ${projectRoot}`);
-
-// Check if frontend exists
-checkFrontend(projectRoot);
-
-// Start the server
-console.log('🚀 Starting MCPHub server...');
-const entryPath = path.join(projectRoot, 'dist', 'index.js');
-// Convert to file:// URL for cross-platform ESM compatibility (required on Windows)
-const entryUrl = pathToFileURL(entryPath).href;
-import(entryUrl).catch(err => {
-  console.error('Failed to start MCPHub:', err);
-  process.exit(1);
-});

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,7 +30,8 @@
               "features/smart-routing",
               "features/oauth",
               "features/authentication",
-              "features/monitoring"
+              "features/monitoring",
+              "features/cli"
             ]
           },
           {
@@ -72,7 +73,8 @@
               "zh/features/server-management",
               "zh/features/group-management",
               "zh/features/smart-routing",
-              "zh/features/oauth"
+              "zh/features/oauth",
+              "zh/features/cli"
             ]
           },
           {

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -102,15 +102,45 @@ mcphub keys delete <id>
 
 The hub-generated token is printed once on `create` — copy it before navigating away.
 
-### `call`
+### `tools` — discover what to call
 
-Call an MCP tool against the active profile's hub. By default `/mcp/$smart` is used so smart routing picks the right tool.
+`tools` is the agent-friendly index for `call`: it answers **what tools exist, what params each one takes, which server hosts it** without having to hand-parse `servers list` JSON.
 
 ```bash
-mcphub call fetch_url url=https://example.com timeout=30 verbose=true
+# Flat list of every tool across every connected server.
+mcphub tools list
+mcphub tools list --json                       # machine-readable, no schemas
+mcphub tools list --schema --json              # include each tool's inputSchema
+mcphub tools list --server fetch               # scope to one server
+mcphub tools list --enabled-only
+
+# Inspect one tool: description, parameter table, full input schema, sample command.
+mcphub tools get fetch_url
+mcphub tools get fetch_url --server fetch      # disambiguate when two servers expose the same name
+mcphub tools schema fetch_url                  # alias for `get`
+```
+
+The `tools get` text view prints a parameter table marking which keys are `required`, followed by the full JSON schema and a ready-to-paste `mcphub call ...` example with the required params filled in.
+
+### `call`
+
+Call an MCP tool against the active profile's hub. By default `/mcp/$smart` is used so smart routing picks the right tool. The recommended agent workflow is **`tools list` → `tools get` → `call`**.
+
+```bash
+# 1. Find a tool
+mcphub tools list --json | jq '.[] | select(.name | contains("fetch"))'
+
+# 2. Check its schema
+mcphub tools get fetch_url --json | jq '.inputSchema'
+
+# 3. Call it
+mcphub call fetch_url url=https://example.com timeout=30
+mcphub call fetch_url url=https://example.com --server fetch        # pin to a specific server
 mcphub call my_tool --group dev nested='{"a":1}'
 mcphub call my_tool --params-json '{"deep":{"v":1}}'
 ```
+
+Routing precedence inside `call`: `--smart` > `--server <name>` > `--group <name>` > default (`$smart`). All three resolve to the same `/mcp/<slug>` endpoint; `--server` is the natural pair for `tools list`/`tools get` output.
 
 `key=value` argument coercion:
 
@@ -172,6 +202,26 @@ Notes:
 | `0` | Success |
 | `1` | Usage error (bad flag, missing argument, unauthorized state) |
 | `2` | API error (non-2xx response from the hub) |
+
+## Autonomous-agent recipe
+
+Every command supports `--json` and reads `MCPHUB_URL` / `MCPHUB_TOKEN`, so an agent can drive the entire discover → call loop from JSON:
+
+```bash
+export MCPHUB_URL=http://localhost:3000
+export MCPHUB_TOKEN=$JWT
+
+# 1. enumerate tools
+mcphub tools list --json > tools.json
+
+# 2. pick one and read its schema
+mcphub tools get fetch_url --json > schema.json
+
+# 3. build a payload from the schema and invoke
+mcphub call fetch_url --params-json "$(jq -n '{url:"https://example.com"}')" --json
+```
+
+The `tools list --json` response is intentionally flat (`{server, serverStatus, name, description, enabled}`) so an agent can filter in one pass without traversing nested `servers[*].tools[*]`.
 
 ## Scripting and CI
 

--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -1,0 +1,187 @@
+---
+title: 'CLI'
+description: 'Manage a running mcphub instance and call MCP tools from the terminal'
+---
+
+## Overview
+
+The `mcphub` binary doubles as a CLI for the running hub. Invoke `mcphub` with no arguments to start the server (the original behavior); pass a subcommand to drive a remote (or local) hub over its HTTP API.
+
+```bash
+mcphub --help                    # list every subcommand
+mcphub <command> [options]       # run a CLI command
+mcphub                            # legacy: start the server (unchanged)
+```
+
+The CLI ships with the same npm package as the server — there's nothing extra to install.
+
+## Logging in
+
+```bash
+mcphub login --url http://localhost:3000 --username admin --password ********
+```
+
+A JWT is cached in an XDG-compliant credentials file with `0600` permissions:
+
+- macOS/Linux: `$XDG_DATA_HOME/mcphub/credentials.json` (default `~/.local/share/mcphub/credentials.json`)
+- Legacy: `~/.mcphub/credentials.json` is still honored when it already exists
+
+Multiple **profiles** are supported, so a single shell can target `staging`, `prod`, etc. side-by-side:
+
+```bash
+mcphub login --profile staging --url https://staging.hub.example
+mcphub config use prod
+mcphub config list
+```
+
+You can also bypass the credentials file entirely:
+
+| Override | Where it comes from |
+| -------- | ------------------- |
+| `--url`, `--token`, `--bearer` flags | per-command |
+| `MCPHUB_URL`, `MCPHUB_TOKEN`, `MCPHUB_TOKEN_KIND` env | shell session / CI |
+| Active profile in `credentials.json` | default |
+
+Resolution order: flag → environment variable → active profile.
+
+## Global options
+
+| Option | Purpose |
+| ------ | ------- |
+| `--url <url>` | Override the active profile's base URL |
+| `--token <token>` | Override the active profile's token |
+| `--bearer` | Treat `--token` as a bearer key (default is JWT via `x-auth-token`) |
+| `--profile <name>` | Pick a saved profile other than `current` |
+| `--json` | Print JSON instead of human-friendly tables |
+| `--debug` | Print stack traces on error |
+
+## Commands
+
+### `servers`
+
+```bash
+mcphub servers list
+mcphub servers get <name>
+
+# Add from a JSON file:
+mcphub servers add fetch --from-file ./fetch.json
+
+# Or inline (--arg / --env can repeat):
+mcphub servers add fetch \
+  --type stdio --command uvx \
+  --arg mcp-server-fetch \
+  --env USER_AGENT=mcphub
+
+mcphub servers remove fetch
+mcphub servers toggle fetch --on
+mcphub servers reload fetch
+```
+
+### `groups`
+
+```bash
+mcphub groups list
+mcphub groups add dev --description "developer tools"
+mcphub groups add-server dev fetch
+mcphub groups remove-server dev fetch
+mcphub groups remove dev
+```
+
+`<group>` accepts either the UUID or the human-readable name; the CLI resolves the name to an id by listing groups first.
+
+### `keys`
+
+Manage bearer keys (admin only on the hub side).
+
+```bash
+mcphub keys list
+mcphub keys create --name ci --access-type all
+mcphub keys create --name dev-only --access-type groups --groups dev,staging
+mcphub keys delete <id>
+```
+
+The hub-generated token is printed once on `create` — copy it before navigating away.
+
+### `call`
+
+Call an MCP tool against the active profile's hub. By default `/mcp/$smart` is used so smart routing picks the right tool.
+
+```bash
+mcphub call fetch_url url=https://example.com timeout=30 verbose=true
+mcphub call my_tool --group dev nested='{"a":1}'
+mcphub call my_tool --params-json '{"deep":{"v":1}}'
+```
+
+`key=value` argument coercion:
+
+| Form | Result |
+| ---- | ------ |
+| `n=42`, `f=1.5` | number |
+| `b=true`, `b=false` | boolean |
+| `x=null` | `null` |
+| `obj={"a":1}`, `arr=[1,2]` | parsed JSON |
+| `payload=@./body.json` | JSON loaded from file |
+| `phone=0123` | preserved as the string `"0123"` (leading-zero protection) |
+| anything else | string |
+
+Pass `--no-coerce` to treat every value as a string.
+
+### `export`
+
+Download `mcp_settings.json` from the running hub.
+
+```bash
+mcphub export --out backup.json
+mcphub export > backup.json
+```
+
+### `discover` / `install` (marketplace)
+
+When the hub has `systemConfig.discovery.enabled = true`, the CLI can browse the public marketplace and install servers into your own hub or directly into a client-side config file.
+
+```bash
+# Browse the active profile's hub
+mcphub discover --search github --limit 10
+mcphub discover info amap-maps
+mcphub discover categories
+mcphub discover tags
+
+# Install into the active hub (POST /api/servers)
+mcphub install amap-maps --env AMAP_MAPS_API_KEY=...
+
+# Install from a different hub into the active one
+mcphub install some-server --remote https://hub.example.com --yes
+
+# Dry-run: just print the mcpServers snippet
+mcphub install amap-maps --dry-run
+
+# Install into a Claude Desktop / OpenClaw-style config file
+mcphub install amap-maps --to file --out ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+Notes:
+
+- `--type` picks the installation method (`npm`, `docker`, `uvx`, `pip`, `binary`). If omitted, the hub picks the first available; if the requested type doesn't exist, the CLI lists the alternatives.
+- `--env KEY=VAL` (repeatable) injects environment values — both predeclared and additional keys are merged into the resulting `env` block.
+- `--to file` writes atomically (temp file + rename), so a crashed write can't corrupt your client config.
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Success |
+| `1` | Usage error (bad flag, missing argument, unauthorized state) |
+| `2` | API error (non-2xx response from the hub) |
+
+## Scripting and CI
+
+The CLI is JSON-friendly: `--json` is honored by every command, and `MCPHUB_URL` / `MCPHUB_TOKEN` make it easy to skip the credentials file in CI.
+
+```bash
+export MCPHUB_URL=https://hub.example.com
+export MCPHUB_TOKEN=$CI_HUB_TOKEN
+
+mcphub servers list --json | jq '.[] | select(.status != "connected") | .name'
+```
+
+For bearer-key auth in CI, add `MCPHUB_TOKEN_KIND=bearer` (or `--bearer`). Note that bearer keys only authorize the `/api/*` admin surface when their `accessType` is `all` — scoped keys can call `/mcp/<group>` but not management routes.

--- a/docs/zh/features/cli.mdx
+++ b/docs/zh/features/cli.mdx
@@ -1,0 +1,187 @@
+---
+title: '命令行 CLI'
+description: '在终端中管理运行中的 mcphub 实例，并调用 MCP 工具'
+---
+
+## 概述
+
+`mcphub` 二进制同时是 CLI 入口。**不带参数**调用 `mcphub` 启动服务器（保持原有行为）；**带子命令**则通过 HTTP API 操作本地或远端 hub。
+
+```bash
+mcphub --help                    # 列出所有子命令
+mcphub <command> [options]       # 执行子命令
+mcphub                            # 旧行为：启动服务器（不变）
+```
+
+CLI 与服务器共用同一个 npm 包，无需额外安装。
+
+## 登录
+
+```bash
+mcphub login --url http://localhost:3000 --username admin --password ********
+```
+
+JWT 会缓存到符合 XDG 规范的凭据文件中，权限 `0600`：
+
+- macOS/Linux: `$XDG_DATA_HOME/mcphub/credentials.json`（默认 `~/.local/share/mcphub/credentials.json`）
+- 兼容旧路径：若 `~/.mcphub/credentials.json` 已存在则继续使用
+
+支持**多 profile**，可以在同一终端中并行操作 `staging`、`prod` 等：
+
+```bash
+mcphub login --profile staging --url https://staging.hub.example
+mcphub config use prod
+mcphub config list
+```
+
+也可以完全绕过凭据文件：
+
+| 覆盖方式 | 来源 |
+| -------- | ---- |
+| `--url`、`--token`、`--bearer` 参数 | 单条命令 |
+| `MCPHUB_URL`、`MCPHUB_TOKEN`、`MCPHUB_TOKEN_KIND` 环境变量 | shell / CI |
+| `credentials.json` 中的 active profile | 默认 |
+
+解析顺序：命令行参数 → 环境变量 → active profile。
+
+## 全局参数
+
+| 参数 | 用途 |
+| ---- | ---- |
+| `--url <url>` | 覆盖 active profile 的 URL |
+| `--token <token>` | 覆盖 active profile 的 token |
+| `--bearer` | 将 `--token` 当作 bearer key 使用（默认是 JWT，走 `x-auth-token`） |
+| `--profile <name>` | 选择非 current 的 profile |
+| `--json` | 输出 JSON 而非人类可读表格 |
+| `--debug` | 出错时打印堆栈 |
+
+## 子命令
+
+### `servers`
+
+```bash
+mcphub servers list
+mcphub servers get <name>
+
+# 从 JSON 文件添加：
+mcphub servers add fetch --from-file ./fetch.json
+
+# 或者内联（--arg / --env 可重复）：
+mcphub servers add fetch \
+  --type stdio --command uvx \
+  --arg mcp-server-fetch \
+  --env USER_AGENT=mcphub
+
+mcphub servers remove fetch
+mcphub servers toggle fetch --on
+mcphub servers reload fetch
+```
+
+### `groups`
+
+```bash
+mcphub groups list
+mcphub groups add dev --description "开发工具组"
+mcphub groups add-server dev fetch
+mcphub groups remove-server dev fetch
+mcphub groups remove dev
+```
+
+`<group>` 可填 UUID 或人类可读名称，CLI 会先列表再解析成 id。
+
+### `keys`
+
+管理 bearer 密钥（hub 端要求管理员权限）。
+
+```bash
+mcphub keys list
+mcphub keys create --name ci --access-type all
+mcphub keys create --name dev-only --access-type groups --groups dev,staging
+mcphub keys delete <id>
+```
+
+`create` 创建后服务端生成的 token 只会显示一次——记得当场复制。
+
+### `call`
+
+调用 active profile 对应 hub 上的 MCP 工具。默认走 `/mcp/$smart`，由智能路由挑选工具。
+
+```bash
+mcphub call fetch_url url=https://example.com timeout=30 verbose=true
+mcphub call my_tool --group dev nested='{"a":1}'
+mcphub call my_tool --params-json '{"deep":{"v":1}}'
+```
+
+`key=value` 强转规则：
+
+| 形式 | 结果 |
+| ---- | ---- |
+| `n=42`、`f=1.5` | 数字 |
+| `b=true`、`b=false` | 布尔 |
+| `x=null` | `null` |
+| `obj={"a":1}`、`arr=[1,2]` | JSON 解析 |
+| `payload=@./body.json` | 从文件加载 JSON |
+| `phone=0123` | 保留为字符串 `"0123"`（保护前导零） |
+| 其他 | 字符串 |
+
+`--no-coerce` 强制所有值按字符串处理。
+
+### `export`
+
+下载 hub 当前的 `mcp_settings.json`。
+
+```bash
+mcphub export --out backup.json
+mcphub export > backup.json
+```
+
+### `discover` / `install`（市场）
+
+当 hub 开启了 `systemConfig.discovery.enabled = true`，CLI 即可浏览公共市场并把 server 装到自己的 hub 或客户端配置文件里。
+
+```bash
+# 浏览 active profile 对应的 hub
+mcphub discover --search github --limit 10
+mcphub discover info amap-maps
+mcphub discover categories
+mcphub discover tags
+
+# 装到 active hub（POST /api/servers）
+mcphub install amap-maps --env AMAP_MAPS_API_KEY=...
+
+# 从另一个 hub 装到 active hub
+mcphub install some-server --remote https://hub.example.com --yes
+
+# 仅打印片段（dry-run）
+mcphub install amap-maps --dry-run
+
+# 装到 Claude Desktop / OpenClaw 风格的客户端配置文件
+mcphub install amap-maps --to file --out ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+要点：
+
+- `--type` 选择安装方式（`npm`、`docker`、`uvx`、`pip`、`binary`）。不指定则由 hub 选第一个可用；指定但不存在时 CLI 会列出可用类型。
+- `--env KEY=VAL`（可重复）注入环境变量——预声明的键和新增的键都会合并进最终 `env`。
+- `--to file` 采用原子写（临时文件 + rename），中断不会破坏客户端配置。
+
+## 退出码
+
+| 退出码 | 含义 |
+| ------ | ---- |
+| `0` | 成功 |
+| `1` | 用法错误（参数缺失、未登录等） |
+| `2` | API 错误（hub 返回非 2xx） |
+
+## 脚本与 CI
+
+CLI 对 JSON 友好：所有命令都支持 `--json`；`MCPHUB_URL` / `MCPHUB_TOKEN` 在 CI 中可跳过凭据文件。
+
+```bash
+export MCPHUB_URL=https://hub.example.com
+export MCPHUB_TOKEN=$CI_HUB_TOKEN
+
+mcphub servers list --json | jq '.[] | select(.status != "connected") | .name'
+```
+
+如果在 CI 中使用 bearer key，再追加 `MCPHUB_TOKEN_KIND=bearer`（或加 `--bearer`）。注意：bearer key 只有在 `accessType=all` 时才能调用 `/api/*` 管理接口；受限 scope 的 key 只能访问 `/mcp/<group>`。

--- a/docs/zh/features/cli.mdx
+++ b/docs/zh/features/cli.mdx
@@ -102,15 +102,45 @@ mcphub keys delete <id>
 
 `create` 创建后服务端生成的 token 只会显示一次——记得当场复制。
 
-### `call`
+### `tools` —— 发现可调用的工具
 
-调用 active profile 对应 hub 上的 MCP 工具。默认走 `/mcp/$smart`，由智能路由挑选工具。
+`tools` 是 `call` 的发现索引：回答**有哪些 tool、每个 tool 接受什么参数、归属哪个 server**——不用手工解析 `servers list` 的嵌套 JSON。
 
 ```bash
-mcphub call fetch_url url=https://example.com timeout=30 verbose=true
+# 列出所有连接中 server 的全部 tool
+mcphub tools list
+mcphub tools list --json                       # 机器可读，默认不带 schema
+mcphub tools list --schema --json              # 带上每个 tool 的 inputSchema
+mcphub tools list --server fetch               # 限定到一个 server
+mcphub tools list --enabled-only
+
+# 查看单个 tool 的描述、参数表、完整 schema 与样例命令
+mcphub tools get fetch_url
+mcphub tools get fetch_url --server fetch      # 同名 tool 在多个 server 上时用 --server 消歧
+mcphub tools schema fetch_url                  # `get` 的别名
+```
+
+`tools get` 的文本视图会先列参数表（带 `required` 标识），再打印完整 JSON schema，最后给一条可直接复制的 `mcphub call ...` 样例（必填参数已占位）。
+
+### `call`
+
+调用 active profile 对应 hub 上的 MCP 工具。默认走 `/mcp/$smart`，由智能路由挑选工具。**推荐的 agent 工作流：`tools list` → `tools get` → `call`**。
+
+```bash
+# 1. 找到一个 tool
+mcphub tools list --json | jq '.[] | select(.name | contains("fetch"))'
+
+# 2. 查 schema
+mcphub tools get fetch_url --json | jq '.inputSchema'
+
+# 3. 调用
+mcphub call fetch_url url=https://example.com timeout=30
+mcphub call fetch_url url=https://example.com --server fetch        # 指定到具体 server
 mcphub call my_tool --group dev nested='{"a":1}'
 mcphub call my_tool --params-json '{"deep":{"v":1}}'
 ```
+
+`call` 的路由优先级：`--smart` > `--server <name>` > `--group <name>` > 默认（`$smart`）。三种最终都走 `/mcp/<slug>` 同一个端点；`--server` 是和 `tools list`/`tools get` 输出天然对齐的写法。
 
 `key=value` 强转规则：
 
@@ -172,6 +202,26 @@ mcphub install amap-maps --to file --out ~/Library/Application\ Support/Claude/c
 | `0` | 成功 |
 | `1` | 用法错误（参数缺失、未登录等） |
 | `2` | API 错误（hub 返回非 2xx） |
+
+## Agent 自动化范式
+
+所有命令都支持 `--json`，并读取 `MCPHUB_URL` / `MCPHUB_TOKEN`，因此 agent 可以纯 JSON 驱动整个"发现 → 调用"流程：
+
+```bash
+export MCPHUB_URL=http://localhost:3000
+export MCPHUB_TOKEN=$JWT
+
+# 1. 枚举所有 tool
+mcphub tools list --json > tools.json
+
+# 2. 选定一个并读 schema
+mcphub tools get fetch_url --json > schema.json
+
+# 3. 根据 schema 构造参数并调用
+mcphub call fetch_url --params-json "$(jq -n '{url:"https://example.com"}')" --json
+```
+
+`tools list --json` 的响应是**扁平的**（`{server, serverStatus, name, description, enabled}`），agent 一次过滤就能定位目标，不必再下钻 `servers[*].tools[*]`。
 
 ## 脚本与 CI
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "pnpm backend:build && pnpm frontend:build",
     "backend:build": "tsc",
     "start": "node dist/index.js",
+    "cli": "tsx src/cli/main.ts",
     "backend:dev": "tsx watch src/index.ts",
     "backend:debug": "tsx watch src/index.ts --inspect",
     "lint": "eslint .",

--- a/scripts/verify-dist.js
+++ b/scripts/verify-dist.js
@@ -39,6 +39,13 @@ if (!fs.existsSync(serverJsPath)) {
   process.exit(1);
 }
 
+const cliMainPath = path.join(backendDistPath, 'cli', 'main.js');
+if (!fs.existsSync(cliMainPath)) {
+  console.error('❌ Error: dist/cli/main.js does not exist!');
+  console.error('CLI subcommand dispatch will fail. Run "npm run backend:build" again.');
+  process.exit(1);
+}
+
 // All checks passed
 console.log('✅ Verification passed! Frontend and backend dist files are present.');
 console.log('📦 Package is ready for publishing.');

--- a/src/cli/call-arguments.ts
+++ b/src/cli/call-arguments.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import { CliUsageError } from './errors.js';
+
+// Parse `key=value` pairs into a plain object. Type coercion:
+//   42, 1.5            → number
+//   true, false        → boolean
+//   null               → null
+//   @path              → JSON loaded from a file
+//   {...} or [...]     → parsed as JSON literal
+//   anything else      → string
+//
+// Quoted strings keep their text verbatim: key="42" stays as "42". The shell
+// strips outer quotes before they reach argv, so we look for an explicit
+// JSON-string form key=\"42\" (i.e. argv contains `key="42"`).
+
+export interface ParsedCallArgs {
+  args: Record<string, unknown>;
+  extra: string[]; // positional args left over (none in normal use)
+}
+
+export interface CoerceOptions {
+  fs?: Pick<typeof fs, 'readFileSync'>;
+  noCoerce?: boolean;
+}
+
+export function parseCallArguments(argv: string[], options: CoerceOptions = {}): ParsedCallArgs {
+  const args: Record<string, unknown> = {};
+  const extra: string[] = [];
+  const reader = options.fs ?? fs;
+
+  for (const token of argv) {
+    const eq = token.indexOf('=');
+    if (eq <= 0) {
+      extra.push(token);
+      continue;
+    }
+    const key = token.slice(0, eq);
+    const raw = token.slice(eq + 1);
+
+    if (options.noCoerce) {
+      args[key] = raw;
+      continue;
+    }
+
+    args[key] = coerce(raw, reader);
+  }
+
+  return { args, extra };
+}
+
+function coerce(raw: string, reader: Pick<typeof fs, 'readFileSync'>): unknown {
+  if (raw === 'null') return null;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+
+  if (raw.startsWith('@')) {
+    const path = raw.slice(1);
+    if (!path) throw new CliUsageError('@ prefix requires a file path');
+    const content = reader.readFileSync(path, 'utf8');
+    try {
+      return JSON.parse(content);
+    } catch (e) {
+      throw new CliUsageError(`Failed to parse JSON from ${path}: ${(e as Error).message}`);
+    }
+  }
+
+  if (
+    raw.length > 1 &&
+    ((raw.startsWith('{') && raw.endsWith('}')) || (raw.startsWith('[') && raw.endsWith(']')))
+  ) {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // fall through and keep as string — a value that happens to start with
+      // a brace but isn't valid JSON is more likely meant literally.
+    }
+  }
+
+  if (raw.startsWith('"') && raw.endsWith('"') && raw.length >= 2) {
+    // Explicit JSON string form — preserve the inner text without coercion.
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw.slice(1, -1);
+    }
+  }
+
+  if (isNumeric(raw)) {
+    return Number(raw);
+  }
+
+  return raw;
+}
+
+function isNumeric(s: string): boolean {
+  if (s === '' || s === '-' || s === '.') return false;
+  // Preserve identifier-like strings such as zip codes and phone numbers:
+  // a leading zero on a multi-digit integer keeps the value as a string.
+  if (/^-?0\d/.test(s)) return false;
+  return /^-?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(s);
+}

--- a/src/cli/call-arguments.ts
+++ b/src/cli/call-arguments.ts
@@ -56,7 +56,12 @@ function coerce(raw: string, reader: Pick<typeof fs, 'readFileSync'>): unknown {
   if (raw.startsWith('@')) {
     const path = raw.slice(1);
     if (!path) throw new CliUsageError('@ prefix requires a file path');
-    const content = reader.readFileSync(path, 'utf8');
+    let content: string;
+    try {
+      content = reader.readFileSync(path, 'utf8');
+    } catch (e) {
+      throw new CliUsageError(`Failed to read file ${path}: ${(e as Error).message}`);
+    }
     try {
       return JSON.parse(content);
     } catch (e) {

--- a/src/cli/commands/call.ts
+++ b/src/cli/commands/call.ts
@@ -1,0 +1,94 @@
+import { ApiClient } from '../http.js';
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags, buildClient, resolveTarget } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { parseCallArguments } from '../call-arguments.js';
+import { printJson, printLine } from '../output.js';
+
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc?: string;
+  id?: string | number;
+  result?: T;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface ToolCallResult {
+  content?: Array<{ type: string; text?: string; data?: unknown }>;
+  isError?: boolean;
+}
+
+export interface CallDeps {
+  client?: ApiClient;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: CallDeps = {}): Promise<void> {
+  const { positional, flags } = extractFlags(args, {
+    valued: ['--group', '--params-json'],
+    boolean: ['--smart', '--no-coerce'],
+  });
+
+  const tool = positional.shift();
+  if (!tool) {
+    throw new CliUsageError(
+      'Usage: mcphub call <tool> [key=value ...] [--group <g>|--smart] [--params-json <json>]',
+    );
+  }
+
+  let params: unknown;
+  if (flags['--params-json']) {
+    try {
+      params = JSON.parse(flags['--params-json'] as string);
+    } catch (e) {
+      throw new CliUsageError(`--params-json is not valid JSON: ${(e as Error).message}`);
+    }
+  } else {
+    const parsed = parseCallArguments(positional, { noCoerce: flags['--no-coerce'] === true });
+    params = parsed.args;
+  }
+
+  // --smart wins over --group; default also resolves to $smart so smart routing
+  // is the documented default behavior.
+  const group: string | '$smart' | null =
+    flags['--smart'] === true
+      ? '$smart'
+      : (flags['--group'] as string | undefined) ?? '$smart';
+
+  const client = deps.client ?? buildClient(resolveTarget(globals));
+  const body = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'tools/call',
+    params: { name: tool, arguments: params },
+  };
+
+  const response = await client.mcpCall<JsonRpcResponse<ToolCallResult>>(group, body);
+  if (globals.json) {
+    printJson(response);
+    return;
+  }
+  if (response.error) {
+    throw new CliUsageError(`MCP error ${response.error.code}: ${response.error.message}`);
+  }
+  printToolResult(response.result);
+}
+
+function printToolResult(result: ToolCallResult | undefined): void {
+  if (!result) {
+    printLine('(no result)');
+    return;
+  }
+  if (result.isError) {
+    printLine('(tool reported an error)');
+  }
+  if (!Array.isArray(result.content)) {
+    printLine(JSON.stringify(result, null, 2));
+    return;
+  }
+  for (const piece of result.content) {
+    if (piece.type === 'text' && typeof piece.text === 'string') {
+      printLine(piece.text);
+    } else {
+      printLine(JSON.stringify(piece, null, 2));
+    }
+  }
+}

--- a/src/cli/commands/call.ts
+++ b/src/cli/commands/call.ts
@@ -23,14 +23,14 @@ export interface CallDeps {
 
 export async function run(args: string[], globals: GlobalFlags, deps: CallDeps = {}): Promise<void> {
   const { positional, flags } = extractFlags(args, {
-    valued: ['--group', '--params-json'],
+    valued: ['--group', '--server', '--params-json'],
     boolean: ['--smart', '--no-coerce'],
   });
 
   const tool = positional.shift();
   if (!tool) {
     throw new CliUsageError(
-      'Usage: mcphub call <tool> [key=value ...] [--group <g>|--smart] [--params-json <json>]',
+      'Usage: mcphub call <tool> [key=value ...] [--group <g>|--server <s>|--smart] [--params-json <json>]',
     );
   }
 
@@ -46,12 +46,16 @@ export async function run(args: string[], globals: GlobalFlags, deps: CallDeps =
     params = parsed.args;
   }
 
-  // --smart wins over --group; default also resolves to $smart so smart routing
-  // is the documented default behavior.
+  // Routing precedence: --smart > --server > --group > default ($smart).
+  // /mcp/:slug? accepts a group name, a server name, or $smart, so --server
+  // and --group are different names for the same wire surface. --server is
+  // the natural pair for `mcphub tools list`/`tools get` output.
   const group: string | '$smart' | null =
     flags['--smart'] === true
       ? '$smart'
-      : (flags['--group'] as string | undefined) ?? '$smart';
+      : (flags['--server'] as string | undefined) ??
+        (flags['--group'] as string | undefined) ??
+        '$smart';
 
   const client = deps.client ?? buildClient(resolveTarget(globals));
   const body = {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,145 @@
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import {
+  Credentials,
+  deleteProfile,
+  loadCredentials,
+  saveCredentials,
+  setCurrentProfile,
+  setProfile,
+} from '../profile.js';
+import { bold, dim, green, maskToken, printJson, printLine, printTable } from '../output.js';
+
+export interface ConfigDeps {
+  loadCreds?: () => Credentials;
+  saveCreds?: (creds: Credentials) => void;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: ConfigDeps = {}): Promise<void> {
+  const sub = args.shift();
+  switch (sub) {
+    case undefined:
+    case 'show':
+      return showActive(globals, deps);
+    case 'list':
+      return list(globals, deps);
+    case 'use':
+      return use(args, deps);
+    case 'set-url':
+      return setUrl(args, globals, deps);
+    case 'set-token':
+      return setToken(args, globals, deps);
+    case 'remove':
+      return remove(args, deps);
+    default:
+      throw new CliUsageError(`Unknown config subcommand: ${sub}`);
+  }
+}
+
+function showActive(globals: GlobalFlags, deps: ConfigDeps): void {
+  const creds = (deps.loadCreds ?? loadCredentials)();
+  const name = globals.profile || creds.current;
+  if (!name || !creds.profiles[name]) {
+    printLine(dim('No active profile. Run `mcphub login` to create one.'));
+    return;
+  }
+  const profile = creds.profiles[name];
+  if (globals.json) {
+    printJson({
+      name,
+      url: profile.url,
+      tokenKind: profile.tokenKind ?? 'jwt',
+      tokenMasked: maskToken(profile.token),
+      username: profile.username ?? null,
+      savedAt: profile.savedAt ?? null,
+    });
+    return;
+  }
+  printLine(`${bold('profile')}    ${name}`);
+  printLine(`${bold('url')}        ${profile.url}`);
+  printLine(`${bold('tokenKind')}  ${profile.tokenKind ?? 'jwt'}`);
+  printLine(`${bold('token')}      ${maskToken(profile.token)}`);
+  if (profile.username) printLine(`${bold('username')}   ${profile.username}`);
+  if (profile.savedAt) printLine(`${bold('savedAt')}    ${profile.savedAt}`);
+}
+
+function list(globals: GlobalFlags, deps: ConfigDeps): void {
+  const creds = (deps.loadCreds ?? loadCredentials)();
+  const rows = Object.entries(creds.profiles).map(([name, p]) => ({
+    name,
+    current: name === creds.current ? '*' : '',
+    url: p.url,
+    tokenKind: p.tokenKind ?? 'jwt',
+    token: maskToken(p.token),
+    username: p.username ?? '',
+  }));
+  if (globals.json) {
+    printJson({ current: creds.current, profiles: rows });
+    return;
+  }
+  printTable(rows, ['name', 'current', 'url', 'tokenKind', 'token', 'username']);
+}
+
+function use(args: string[], deps: ConfigDeps): void {
+  const name = args[0];
+  if (!name) throw new CliUsageError('Usage: mcphub config use <name>');
+  const load = deps.loadCreds ?? loadCredentials;
+  const save = deps.saveCreds ?? saveCredentials;
+  const next = setCurrentProfile(load(), name);
+  save(next);
+  printLine(green(`Active profile set to "${name}".`));
+}
+
+function setUrl(args: string[], globals: GlobalFlags, deps: ConfigDeps): void {
+  const url = args[0];
+  if (!url) throw new CliUsageError('Usage: mcphub config set-url <url>');
+  const load = deps.loadCreds ?? loadCredentials;
+  const save = deps.saveCreds ?? saveCredentials;
+  const creds = load();
+  const target = globals.profile || creds.current || 'default';
+  const existing = creds.profiles[target];
+  const next = setProfile(creds, target, {
+    url,
+    tokenKind: existing?.tokenKind,
+    token: existing?.token,
+    username: existing?.username,
+  });
+  save(next);
+  printLine(green(`Set url for profile "${target}" to ${url}.`));
+}
+
+function setToken(args: string[], globals: GlobalFlags, deps: ConfigDeps): void {
+  const { positional, flags } = extractFlags(args, { boolean: ['--bearer'] });
+  const token = positional[0];
+  if (!token) throw new CliUsageError('Usage: mcphub config set-token <token> [--bearer]');
+  const load = deps.loadCreds ?? loadCredentials;
+  const save = deps.saveCreds ?? saveCredentials;
+  const creds = load();
+  const target = globals.profile || creds.current;
+  if (!target || !creds.profiles[target]) {
+    throw new CliUsageError('No profile to update. Run `mcphub login` first or pass --profile.');
+  }
+  const existing = creds.profiles[target];
+  const next = setProfile(creds, target, {
+    url: existing.url,
+    tokenKind: flags['--bearer'] ? 'bearer' : 'jwt',
+    token,
+    username: existing.username,
+  });
+  save(next);
+  printLine(green(`Set token for profile "${target}" (${flags['--bearer'] ? 'bearer' : 'jwt'}).`));
+}
+
+function remove(args: string[], deps: ConfigDeps): void {
+  const name = args[0];
+  if (!name) throw new CliUsageError('Usage: mcphub config remove <name>');
+  const load = deps.loadCreds ?? loadCredentials;
+  const save = deps.saveCreds ?? saveCredentials;
+  const creds = load();
+  if (!creds.profiles[name]) {
+    throw new CliUsageError(`Profile not found: ${name}`);
+  }
+  save(deleteProfile(creds, name));
+  printLine(green(`Removed profile "${name}".`));
+}

--- a/src/cli/commands/discover.ts
+++ b/src/cli/commands/discover.ts
@@ -1,0 +1,153 @@
+import { ApiClient } from '../http.js';
+import { CliApiError, CliUsageError } from '../errors.js';
+import { GlobalFlags, resolveTargetForPublic } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { dim, printJson, printLine, printTable } from '../output.js';
+
+// Minimal local types for the discovery responses. These mirror the shapes
+// added by the #809 branch's discoveryController. Defined locally so the CLI
+// doesn't depend on the MarketServer type being shipped to main.
+
+interface DiscoveryServer {
+  name: string;
+  display_name?: string;
+  description?: string;
+  categories?: string[];
+  tags?: string[];
+  installations?: Record<string, unknown>;
+}
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+export interface DiscoverDeps {
+  client?: ApiClient;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: DiscoverDeps = {}): Promise<void> {
+  const sub = args[0];
+  // Reserved subcommands consume the head; everything else flows through to
+  // the default "list" behavior.
+  if (sub === 'info') {
+    return info(args.slice(1), globals, deps);
+  }
+  if (sub === 'categories') {
+    return categories(args.slice(1), globals, deps);
+  }
+  if (sub === 'tags') {
+    return tags(args.slice(1), globals, deps);
+  }
+  return list(args, globals, deps);
+}
+
+function client(globals: GlobalFlags, remote: string | undefined, deps: DiscoverDeps): ApiClient {
+  if (deps.client) return deps.client;
+  const { baseUrl } = resolveTargetForPublic(globals, remote);
+  // Public endpoints — no token attached.
+  return new ApiClient({ baseUrl });
+}
+
+function notEnabledHint(): string {
+  return (
+    'Discovery is not enabled on the target hub.\n' +
+    'Ask an admin to set `systemConfig.discovery.enabled = true` in mcp_settings.json.'
+  );
+}
+
+async function list(args: string[], globals: GlobalFlags, deps: DiscoverDeps): Promise<void> {
+  const { flags } = extractFlags(args, {
+    valued: ['--remote', '--search', '--category', '--tag', '--limit'],
+  });
+  const c = client(globals, flags['--remote'] as string | undefined, deps);
+  const qs = new URLSearchParams();
+  if (flags['--search']) qs.set('search', String(flags['--search']));
+  if (flags['--category']) qs.set('category', String(flags['--category']));
+  if (flags['--tag']) qs.set('tag', String(flags['--tag']));
+  if (flags['--limit']) qs.set('limit', String(flags['--limit']));
+  const path = `/discovery/servers${qs.toString() ? `?${qs}` : ''}`;
+  let res: ApiResponse<{ total: number; servers: DiscoveryServer[] }>;
+  try {
+    res = await c.get(path);
+  } catch (e) {
+    if (e instanceof CliApiError && e.status === 404) {
+      throw new CliUsageError(notEnabledHint());
+    }
+    throw e;
+  }
+  const data = res.data ?? { total: 0, servers: [] };
+  if (globals.json) {
+    printJson(data);
+    return;
+  }
+  if (data.servers.length === 0) {
+    printLine(dim('(no servers)'));
+    return;
+  }
+  printTable(
+    data.servers.map((s) => ({
+      name: s.name,
+      categories: (s.categories ?? []).join(','),
+      description: trim(s.description ?? '', 60),
+    })),
+    ['name', 'categories', 'description'],
+  );
+  printLine(dim(`Total: ${data.total}`));
+}
+
+async function info(args: string[], globals: GlobalFlags, deps: DiscoverDeps): Promise<void> {
+  const { positional, flags } = extractFlags(args, { valued: ['--remote'] });
+  const name = positional[0];
+  if (!name) throw new CliUsageError('Usage: mcphub discover info <name>');
+  const c = client(globals, flags['--remote'] as string | undefined, deps);
+  try {
+    const res = await c.get<ApiResponse<DiscoveryServer>>(
+      `/discovery/servers/${encodeURIComponent(name)}`,
+    );
+    if (globals.json) {
+      printJson(res.data);
+      return;
+    }
+    printLine(JSON.stringify(res.data, null, 2));
+  } catch (e) {
+    if (e instanceof CliApiError && e.status === 404) {
+      // The same 404 covers "discovery disabled" and "server not found" —
+      // discoveryController returns "Not found" for both. Use the response
+      // message to disambiguate when possible.
+      if (typeof e.message === 'string' && /not.*found/i.test(e.message)) {
+        throw new CliUsageError(`Server not found in marketplace: ${name}`);
+      }
+      throw new CliUsageError(notEnabledHint());
+    }
+    throw e;
+  }
+}
+
+async function categories(args: string[], globals: GlobalFlags, deps: DiscoverDeps): Promise<void> {
+  const { flags } = extractFlags(args, { valued: ['--remote'] });
+  const c = client(globals, flags['--remote'] as string | undefined, deps);
+  const res = await c.get<ApiResponse<string[]>>('/discovery/categories');
+  if (globals.json) {
+    printJson(res.data);
+    return;
+  }
+  for (const cat of res.data ?? []) printLine(cat);
+}
+
+async function tags(args: string[], globals: GlobalFlags, deps: DiscoverDeps): Promise<void> {
+  const { flags } = extractFlags(args, { valued: ['--remote'] });
+  const c = client(globals, flags['--remote'] as string | undefined, deps);
+  const res = await c.get<ApiResponse<string[]>>('/discovery/tags');
+  if (globals.json) {
+    printJson(res.data);
+    return;
+  }
+  for (const t of res.data ?? []) printLine(t);
+}
+
+function trim(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + '…';
+}

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import { ApiClient } from '../http.js';
+import { GlobalFlags, buildClient, resolveTarget } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { green, printLine } from '../output.js';
+
+export interface ExportDeps {
+  client?: ApiClient;
+  fs?: Pick<typeof fs, 'writeFileSync'>;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: ExportDeps = {}): Promise<void> {
+  const { flags } = extractFlags(args, { valued: ['--out'] });
+  const client = deps.client ?? buildClient(resolveTarget(globals));
+  const settings = await client.get<unknown>('/api/mcp-settings/export');
+  const json = JSON.stringify(settings, null, 2);
+  const outPath = flags['--out'] as string | undefined;
+  if (outPath) {
+    (deps.fs ?? fs).writeFileSync(outPath, json);
+    printLine(green(`Wrote ${outPath}`));
+    return;
+  }
+  // Use printLine so the trailing newline is consistent with the rest of CLI
+  // output (and so --json behavior is predictable when piped).
+  printLine(json);
+}

--- a/src/cli/commands/groups.ts
+++ b/src/cli/commands/groups.ts
@@ -1,0 +1,128 @@
+import { ApiClient } from '../http.js';
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags, buildClient, resolveTarget } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { green, printJson, printLine, printTable } from '../output.js';
+import type { IGroup } from '../../types/index.js';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+export interface GroupsDeps {
+  client?: ApiClient;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: GroupsDeps = {}): Promise<void> {
+  const sub = args.shift();
+  const client = deps.client ?? buildClient(resolveTarget(globals));
+  switch (sub) {
+    case undefined:
+    case 'list':
+      return list(client, globals);
+    case 'get':
+      return get(client, args, globals);
+    case 'add':
+      return add(client, args, globals);
+    case 'remove':
+      return remove(client, args);
+    case 'add-server':
+      return addServer(client, args);
+    case 'remove-server':
+      return removeServer(client, args);
+    default:
+      throw new CliUsageError(`Unknown groups subcommand: ${sub}`);
+  }
+}
+
+async function fetchAll(client: ApiClient): Promise<IGroup[]> {
+  const res = await client.get<ApiResponse<IGroup[]>>('/api/groups');
+  return res.data ?? [];
+}
+
+// /api/groups/:id resolves by UUID. The CLI accepts a name too — we look it up
+// client-side and substitute the UUID before calling.
+async function resolveGroupId(client: ApiClient, ref: string): Promise<string> {
+  const groups = await fetchAll(client);
+  const match = groups.find((g) => g.id === ref || g.name === ref);
+  if (!match) throw new CliUsageError(`Group not found: ${ref}`);
+  return match.id;
+}
+
+async function list(client: ApiClient, globals: GlobalFlags): Promise<void> {
+  const groups = await fetchAll(client);
+  if (globals.json) {
+    printJson(groups);
+    return;
+  }
+  printTable(
+    groups.map((g) => ({
+      name: g.name,
+      id: g.id,
+      servers: Array.isArray(g.servers) ? g.servers.length : 0,
+      description: g.description ?? '',
+    })),
+    ['name', 'id', 'servers', 'description'],
+  );
+}
+
+async function get(client: ApiClient, args: string[], globals: GlobalFlags): Promise<void> {
+  const ref = args[0];
+  if (!ref) throw new CliUsageError('Usage: mcphub groups get <id|name>');
+  const id = await resolveGroupId(client, ref);
+  const res = await client.get<ApiResponse<IGroup>>(`/api/groups/${encodeURIComponent(id)}`);
+  if (globals.json) {
+    printJson(res.data);
+    return;
+  }
+  printLine(JSON.stringify(res.data, null, 2));
+}
+
+async function add(client: ApiClient, args: string[], globals: GlobalFlags): Promise<void> {
+  const { positional, flags } = extractFlags(args, {
+    valued: ['--description'],
+  });
+  const name = positional[0];
+  if (!name) throw new CliUsageError('Usage: mcphub groups add <name> [--description <d>]');
+  const res = await client.post<ApiResponse<IGroup>>('/api/groups', {
+    name,
+    description: flags['--description'] ?? '',
+  });
+  if (globals.json) {
+    printJson(res.data);
+    return;
+  }
+  printLine(green(`Created group "${name}" (id: ${res.data?.id ?? 'unknown'}).`));
+}
+
+async function remove(client: ApiClient, args: string[]): Promise<void> {
+  const ref = args[0];
+  if (!ref) throw new CliUsageError('Usage: mcphub groups remove <id|name>');
+  const id = await resolveGroupId(client, ref);
+  await client.delete(`/api/groups/${encodeURIComponent(id)}`);
+  printLine(green(`Removed group "${ref}".`));
+}
+
+async function addServer(client: ApiClient, args: string[]): Promise<void> {
+  const [groupRef, serverName] = args;
+  if (!groupRef || !serverName) {
+    throw new CliUsageError('Usage: mcphub groups add-server <group> <server>');
+  }
+  const id = await resolveGroupId(client, groupRef);
+  await client.post(`/api/groups/${encodeURIComponent(id)}/servers`, { serverName });
+  printLine(green(`Added "${serverName}" to group "${groupRef}".`));
+}
+
+async function removeServer(client: ApiClient, args: string[]): Promise<void> {
+  const [groupRef, serverName] = args;
+  if (!groupRef || !serverName) {
+    throw new CliUsageError('Usage: mcphub groups remove-server <group> <server>');
+  }
+  const id = await resolveGroupId(client, groupRef);
+  await client.delete(
+    `/api/groups/${encodeURIComponent(id)}/servers/${encodeURIComponent(serverName)}`,
+  );
+  printLine(green(`Removed "${serverName}" from group "${groupRef}".`));
+}

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -39,7 +39,7 @@ type Destination = 'hub' | 'file' | 'stdout';
 export interface InstallDeps {
   sourceClient?: ApiClient; // marketplace source (no auth needed)
   destClient?: ApiClient; // active profile hub (auth needed for /api/servers)
-  fs?: Pick<typeof fs, 'readFileSync' | 'writeFileSync' | 'existsSync'>;
+  fs?: Pick<typeof fs, 'readFileSync' | 'writeFileSync' | 'existsSync' | 'renameSync'>;
   prompts?: { line: (q: string) => Promise<string> };
 }
 
@@ -93,15 +93,13 @@ export async function run(args: string[], globals: GlobalFlags, deps: InstallDep
     throw new CliUsageError('Marketplace response did not include an install snippet.');
   }
 
-  // Fold env overrides into the resolved snippet. We only touch keys that the
-  // snippet already declares so we don't accidentally inject unrelated env
-  // vars into the spawned server.
+  // Merge --env overrides into the resolved snippet. The user explicitly
+  // passed these so we add new keys too (e.g. DEBUG=1, optional provider keys)
+  // rather than restricting overrides to whatever the marketplace declared.
   const snippetKey = Object.keys(install.mcpServers)[0];
   const snippet = install.mcpServers[snippetKey];
-  if (snippet.env) {
-    for (const [k, v] of Object.entries(envOverrides)) {
-      if (k in snippet.env) snippet.env[k] = v;
-    }
+  if (Object.keys(envOverrides).length > 0) {
+    snippet.env = { ...(snippet.env ?? {}), ...envOverrides };
   }
 
   // Prompt for required-but-unset env vars when we have a TTY and --yes isn't set.
@@ -208,7 +206,11 @@ function writeToFile(
     }
     merged.mcpServers[k] = v;
   }
-  reader.writeFileSync(outPath, JSON.stringify(merged, null, 2));
+  // Atomic write: a crashed write must not leave a half-written config (the
+  // target may be the user's primary Claude Desktop / OpenClaw config).
+  const tmp = `${outPath}.tmp.${process.pid}`;
+  reader.writeFileSync(tmp, JSON.stringify(merged, null, 2));
+  reader.renameSync(tmp, outPath);
   printLine(green(`Wrote ${Object.keys(install.mcpServers).length} server(s) to ${outPath}.`));
 }
 

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,0 +1,244 @@
+import fs from 'node:fs';
+import { ApiClient } from '../http.js';
+import { CliApiError, CliUsageError } from '../errors.js';
+import {
+  GlobalFlags,
+  buildClient,
+  resolveTarget,
+  resolveTargetForPublic,
+} from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { green, printJson, printLine, printWarn } from '../output.js';
+import { promptLine } from '../prompts.js';
+
+// Local mirrors of the #809 controller's response shape. See
+// `src/controllers/discoveryController.ts` on the implement-issue-809 branch.
+
+interface InstallSnippet {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+interface InstallResponse {
+  name: string;
+  installationType: string;
+  availableTypes: string[];
+  mcpServers: Record<string, InstallSnippet>;
+  arguments?: Record<string, { description?: string; required?: boolean; example?: string }>;
+}
+
+interface ApiEnvelope<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+type Destination = 'hub' | 'file' | 'stdout';
+
+export interface InstallDeps {
+  sourceClient?: ApiClient; // marketplace source (no auth needed)
+  destClient?: ApiClient; // active profile hub (auth needed for /api/servers)
+  fs?: Pick<typeof fs, 'readFileSync' | 'writeFileSync' | 'existsSync'>;
+  prompts?: { line: (q: string) => Promise<string> };
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: InstallDeps = {}): Promise<void> {
+  const { positional, flags } = extractFlags(args, {
+    valued: ['--remote', '--type', '--to', '--out'],
+    boolean: ['--yes', '--force', '--dry-run'],
+  });
+
+  const name = positional[0];
+  if (!name) {
+    throw new CliUsageError(
+      'Usage: mcphub install <name> [--remote <url>] [--type <type>]\n' +
+        '                 [--to hub|file|stdout] [--out <path>] [--env K=V ...]\n' +
+        '                 [--dry-run] [--yes] [--force]',
+    );
+  }
+
+  const dest: Destination = flags['--dry-run']
+    ? 'stdout'
+    : ((flags['--to'] as Destination | undefined) ?? 'hub');
+  if (!['hub', 'file', 'stdout'].includes(dest)) {
+    throw new CliUsageError(`--to must be one of: hub, file, stdout (got "${dest}")`);
+  }
+
+  const envOverrides = collectEnvOverrides(args);
+
+  const sourceClient =
+    deps.sourceClient ??
+    new ApiClient({
+      baseUrl: resolveTargetForPublic(globals, flags['--remote'] as string | undefined).baseUrl,
+    });
+
+  const typeQuery = flags['--type'] ? `?type=${encodeURIComponent(String(flags['--type']))}` : '';
+  let envelope: ApiEnvelope<InstallResponse>;
+  try {
+    envelope = await sourceClient.get<ApiEnvelope<InstallResponse>>(
+      `/discovery/servers/${encodeURIComponent(name)}/install${typeQuery}`,
+    );
+  } catch (e) {
+    if (e instanceof CliApiError && e.status === 404) {
+      // Surface the server's message verbatim so the "no 'docker' installation
+      // method" hint reaches the user. discoveryController returns it in body.message.
+      throw new CliUsageError(e.message);
+    }
+    throw e;
+  }
+
+  const install = envelope.data;
+  if (!install || !install.mcpServers) {
+    throw new CliUsageError('Marketplace response did not include an install snippet.');
+  }
+
+  // Fold env overrides into the resolved snippet. We only touch keys that the
+  // snippet already declares so we don't accidentally inject unrelated env
+  // vars into the spawned server.
+  const snippetKey = Object.keys(install.mcpServers)[0];
+  const snippet = install.mcpServers[snippetKey];
+  if (snippet.env) {
+    for (const [k, v] of Object.entries(envOverrides)) {
+      if (k in snippet.env) snippet.env[k] = v;
+    }
+  }
+
+  // Prompt for required-but-unset env vars when we have a TTY and --yes isn't set.
+  await fillRequiredEnv(install, snippet, {
+    yes: flags['--yes'] === true,
+    prompts: deps.prompts,
+  });
+
+  if (dest === 'stdout') {
+    printJson({ mcpServers: install.mcpServers });
+    return;
+  }
+
+  if (dest === 'file') {
+    return writeToFile(install, flags['--out'] as string | undefined, !!flags['--force'], deps);
+  }
+
+  // dest === 'hub'
+  return writeToHub(install, snippetKey, globals, deps);
+}
+
+function collectEnvOverrides(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === '--env') {
+      const v = argv[++i];
+      if (v === undefined) throw new CliUsageError('--env expects KEY=VALUE');
+      const eq = v.indexOf('=');
+      if (eq < 0) throw new CliUsageError(`--env expects KEY=VALUE, got: ${v}`);
+      out[v.slice(0, eq)] = v.slice(eq + 1);
+    } else if (token.startsWith('--env=')) {
+      const v = token.slice('--env='.length);
+      const eq = v.indexOf('=');
+      if (eq < 0) throw new CliUsageError(`--env expects KEY=VALUE, got: ${v}`);
+      out[v.slice(0, eq)] = v.slice(eq + 1);
+    }
+  }
+  return out;
+}
+
+async function fillRequiredEnv(
+  install: InstallResponse,
+  snippet: InstallSnippet,
+  opts: { yes: boolean; prompts?: InstallDeps['prompts'] },
+): Promise<void> {
+  if (!install.arguments || !snippet.env) return;
+  const missing: string[] = [];
+  for (const [argName, def] of Object.entries(install.arguments)) {
+    if (!def.required) continue;
+    const current = snippet.env[argName];
+    const placeholder =
+      current === undefined ||
+      current === '' ||
+      current === def.example ||
+      (typeof current === 'string' && /<.*>/.test(current));
+    if (!placeholder) continue;
+    if (opts.yes) {
+      missing.push(argName);
+      continue;
+    }
+    const prompt = opts.prompts?.line ?? promptLine;
+    const value = await prompt(`${argName}${def.description ? ` (${def.description})` : ''}: `);
+    if (!value) {
+      missing.push(argName);
+      continue;
+    }
+    snippet.env[argName] = value;
+  }
+  if (missing.length > 0) {
+    throw new CliUsageError(
+      `Missing required env values: ${missing.join(', ')}. Pass them via --env KEY=VALUE.`,
+    );
+  }
+}
+
+function writeToFile(
+  install: InstallResponse,
+  outPath: string | undefined,
+  force: boolean,
+  deps: InstallDeps,
+): void {
+  if (!outPath) {
+    throw new CliUsageError('--to file requires --out <path>');
+  }
+  const reader = deps.fs ?? fs;
+  let existing: { mcpServers?: Record<string, unknown> } = {};
+  if (reader.existsSync(outPath)) {
+    try {
+      existing = JSON.parse(reader.readFileSync(outPath, 'utf8'));
+    } catch (e) {
+      throw new CliUsageError(`Failed to parse existing ${outPath}: ${(e as Error).message}`);
+    }
+  }
+  const merged: { mcpServers: Record<string, unknown> } = {
+    ...existing,
+    mcpServers: { ...(existing.mcpServers ?? {}) },
+  };
+  for (const [k, v] of Object.entries(install.mcpServers)) {
+    if (merged.mcpServers[k] && !force) {
+      throw new CliUsageError(
+        `"${k}" already present in ${outPath}. Pass --force to overwrite.`,
+      );
+    }
+    merged.mcpServers[k] = v;
+  }
+  reader.writeFileSync(outPath, JSON.stringify(merged, null, 2));
+  printLine(green(`Wrote ${Object.keys(install.mcpServers).length} server(s) to ${outPath}.`));
+}
+
+async function writeToHub(
+  install: InstallResponse,
+  snippetKey: string,
+  globals: GlobalFlags,
+  deps: InstallDeps,
+): Promise<void> {
+  const dest = deps.destClient ?? buildClient(resolveTarget(globals));
+  const snippet = install.mcpServers[snippetKey];
+  const config = {
+    type: 'stdio' as const,
+    command: snippet.command,
+    args: snippet.args,
+    env: snippet.env,
+    enabled: true,
+  };
+  await dest.post('/api/servers', { name: snippetKey, config });
+  printLine(
+    green(
+      `Installed "${snippetKey}" (${install.installationType}) into the active hub. ` +
+        `Run \`mcphub servers reload ${snippetKey}\` if it doesn't connect automatically.`,
+    ),
+  );
+  if (install.availableTypes && install.availableTypes.length > 1) {
+    printWarn(
+      `Other installation types available: ${install.availableTypes
+        .filter((t) => t !== install.installationType)
+        .join(', ')}`,
+    );
+  }
+}

--- a/src/cli/commands/keys.ts
+++ b/src/cli/commands/keys.ts
@@ -1,0 +1,112 @@
+import { ApiClient } from '../http.js';
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags, buildClient, resolveTarget } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { green, maskToken, printJson, printLine, printTable } from '../output.js';
+import type { BearerKey, BearerKeyAccessType } from '../../types/index.js';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+const VALID_ACCESS_TYPES: BearerKeyAccessType[] = ['all', 'groups', 'servers', 'custom'];
+
+export interface KeysDeps {
+  client?: ApiClient;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: KeysDeps = {}): Promise<void> {
+  const sub = args.shift();
+  const client = deps.client ?? buildClient(resolveTarget(globals));
+  switch (sub) {
+    case undefined:
+    case 'list':
+      return list(client, globals);
+    case 'create':
+      return create(client, args, globals);
+    case 'delete':
+      return remove(client, args);
+    default:
+      throw new CliUsageError(`Unknown keys subcommand: ${sub}`);
+  }
+}
+
+async function list(client: ApiClient, globals: GlobalFlags): Promise<void> {
+  const res = await client.get<ApiResponse<BearerKey[]>>('/api/auth/keys');
+  const keys = res.data ?? [];
+  if (globals.json) {
+    // Show the raw token in --json so scripts can capture it. Plaintext only
+    // returns to the user who has admin access to the hub anyway.
+    printJson(keys);
+    return;
+  }
+  printTable(
+    keys.map((k) => ({
+      id: k.id,
+      name: k.name,
+      enabled: k.enabled ? 'yes' : 'no',
+      accessType: k.accessType,
+      token: maskToken(k.token),
+    })),
+    ['id', 'name', 'enabled', 'accessType', 'token'],
+  );
+}
+
+async function create(client: ApiClient, args: string[], globals: GlobalFlags): Promise<void> {
+  const { flags } = extractFlags(args, {
+    valued: ['--name', '--access-type', '--groups', '--servers', '--token'],
+    boolean: ['--disabled'],
+  });
+  const name = flags['--name'] as string | undefined;
+  if (!name) {
+    throw new CliUsageError(
+      'Usage: mcphub keys create --name <n> [--access-type all|groups|servers|custom] [--groups a,b] [--servers x,y]',
+    );
+  }
+  const accessType = (flags['--access-type'] as BearerKeyAccessType | undefined) ?? 'all';
+  if (!VALID_ACCESS_TYPES.includes(accessType)) {
+    throw new CliUsageError(
+      `Invalid --access-type: ${accessType}. Expected one of ${VALID_ACCESS_TYPES.join(', ')}`,
+    );
+  }
+  const body: Partial<BearerKey> = {
+    name,
+    enabled: !flags['--disabled'],
+    accessType,
+  };
+  if (flags['--token']) body.token = flags['--token'] as string;
+  if (accessType === 'groups' || accessType === 'custom') {
+    if (flags['--groups']) body.allowedGroups = splitCsv(flags['--groups'] as string);
+  }
+  if (accessType === 'servers' || accessType === 'custom') {
+    if (flags['--servers']) body.allowedServers = splitCsv(flags['--servers'] as string);
+  }
+
+  const res = await client.post<ApiResponse<BearerKey>>('/api/auth/keys', body);
+  if (globals.json) {
+    printJson(res.data);
+    return;
+  }
+  printLine(green(`Created key "${name}" (id: ${res.data?.id ?? 'unknown'}).`));
+  if (res.data?.token) {
+    // The server generates the token if not supplied. Print it once — admins
+    // need to copy it before navigating away.
+    printLine(`Token: ${res.data.token}`);
+  }
+}
+
+async function remove(client: ApiClient, args: string[]): Promise<void> {
+  const id = args[0];
+  if (!id) throw new CliUsageError('Usage: mcphub keys delete <id>');
+  await client.delete(`/api/auth/keys/${encodeURIComponent(id)}`);
+  printLine(green(`Deleted key ${id}.`));
+}
+
+function splitCsv(s: string): string[] {
+  return s
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+}

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,0 +1,111 @@
+import { ApiClient } from '../http.js';
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import {
+  Credentials,
+  loadCredentials,
+  saveCredentials,
+  setProfile,
+  getProfile,
+} from '../profile.js';
+import { green, yellow, printLine, printWarn } from '../output.js';
+import { promptLine, promptPassword } from '../prompts.js';
+
+interface LoginResponse {
+  success: boolean;
+  token: string;
+  user: { username: string; isAdmin: boolean };
+  isUsingDefaultPassword?: boolean;
+  message?: string;
+}
+
+export interface LoginDeps {
+  loadCreds?: () => Credentials;
+  saveCreds?: (creds: Credentials) => void;
+  createClient?: (baseUrl: string) => ApiClient;
+  prompts?: {
+    line: (q: string) => Promise<string>;
+    password: (q: string) => Promise<string>;
+  };
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: LoginDeps = {}): Promise<void> {
+  const { flags } = extractFlags(args, {
+    valued: ['--url', '--username', '--password', '--profile-name'],
+  });
+
+  const loadCreds = deps.loadCreds ?? loadCredentials;
+  const saveCreds = deps.saveCreds ?? saveCredentials;
+  const prompts = deps.prompts ?? { line: promptLine, password: promptPassword };
+
+  const credentials = loadCreds();
+  const targetProfileName =
+    (flags['--profile-name'] as string | undefined) ||
+    globals.profile ||
+    credentials.current ||
+    'default';
+  const existing = getProfile(credentials, targetProfileName);
+
+  const url =
+    (flags['--url'] as string | undefined) ||
+    globals.url ||
+    existing?.url ||
+    (await prompts.line('mcphub URL [http://localhost:3000]: ')) ||
+    'http://localhost:3000';
+
+  const username =
+    (flags['--username'] as string | undefined) ||
+    existing?.username ||
+    (await prompts.line('Username [admin]: ')) ||
+    'admin';
+
+  const password =
+    (flags['--password'] as string | undefined) || (await prompts.password('Password: '));
+
+  if (!password) {
+    throw new CliUsageError('Password is required.');
+  }
+
+  const client = deps.createClient ? deps.createClient(url) : new ApiClient({ baseUrl: url });
+  const response = await client.post<LoginResponse>('/api/auth/login', { username, password });
+
+  if (!response || !response.token) {
+    throw new CliUsageError('Login response did not include a token.');
+  }
+
+  const next = setProfile(credentials, targetProfileName, {
+    url,
+    tokenKind: 'jwt',
+    token: response.token,
+    username: response.user?.username || username,
+  });
+  saveCreds(next);
+
+  printLine(green(`Logged in as ${response.user?.username || username} at ${url}`));
+  printLine(`Saved as profile "${targetProfileName}".`);
+
+  if (response.isUsingDefaultPassword) {
+    printWarn('Warning: this account is still using the default password. Change it soon.');
+  }
+}
+
+export async function logout(args: string[], globals: GlobalFlags, deps: LoginDeps = {}): Promise<void> {
+  const loadCreds = deps.loadCreds ?? loadCredentials;
+  const saveCreds = deps.saveCreds ?? saveCredentials;
+  const credentials = loadCreds();
+  const targetName = globals.profile || credentials.current;
+  if (!targetName || !credentials.profiles[targetName]) {
+    throw new CliUsageError('No active profile to log out from.');
+  }
+  const existing = credentials.profiles[targetName];
+  const next = setProfile(credentials, targetName, {
+    url: existing.url,
+    username: existing.username,
+    // token + tokenKind dropped intentionally
+  });
+  saveCreds(next);
+  printLine(yellow(`Cleared token for profile "${targetName}".`));
+  // Silence unused-arg warning while keeping the signature consistent.
+  void args;
+}

--- a/src/cli/commands/servers.ts
+++ b/src/cli/commands/servers.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import { ApiClient } from '../http.js';
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags, buildClient, resolveTarget } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { green, printJson, printLine, printTable } from '../output.js';
+import type { ServerConfig, ServerInfo } from '../../types/index.js';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+export interface ServersDeps {
+  client?: ApiClient;
+  fs?: Pick<typeof fs, 'readFileSync'>;
+}
+
+export async function run(args: string[], globals: GlobalFlags, deps: ServersDeps = {}): Promise<void> {
+  const sub = args.shift();
+  const client = deps.client ?? buildClient(resolveTarget(globals));
+  switch (sub) {
+    case undefined:
+    case 'list':
+      return list(client, globals);
+    case 'get':
+      return get(client, args, globals);
+    case 'add':
+      return add(client, args, globals, deps);
+    case 'remove':
+      return remove(client, args);
+    case 'toggle':
+      return toggle(client, args);
+    case 'reload':
+      return reload(client, args);
+    default:
+      throw new CliUsageError(`Unknown servers subcommand: ${sub}`);
+  }
+}
+
+async function list(client: ApiClient, globals: GlobalFlags): Promise<void> {
+  const res = await client.get<ApiResponse<ServerInfo[]>>('/api/servers');
+  const servers = res.data ?? [];
+  if (globals.json) {
+    printJson(servers);
+    return;
+  }
+  printTable(
+    servers.map((s) => ({
+      name: s.name,
+      status: s.status,
+      tools: s.tools?.length ?? 0,
+      owner: s.owner ?? '',
+      error: s.error ?? '',
+    })),
+    ['name', 'status', 'tools', 'owner', 'error'],
+  );
+}
+
+async function get(client: ApiClient, args: string[], globals: GlobalFlags): Promise<void> {
+  const name = args[0];
+  if (!name) throw new CliUsageError('Usage: mcphub servers get <name>');
+  const res = await client.get<ApiResponse<ServerConfig | ServerInfo>>(
+    `/api/servers/${encodeURIComponent(name)}`,
+  );
+  if (globals.json) {
+    printJson(res.data);
+    return;
+  }
+  printLine(JSON.stringify(res.data, null, 2));
+}
+
+async function add(
+  client: ApiClient,
+  args: string[],
+  globals: GlobalFlags,
+  deps: ServersDeps,
+): Promise<void> {
+  const { positional, flags } = extractFlags(args, {
+    valued: ['--from-file', '--type', '--command', '--url', '--description'],
+    boolean: ['--enabled', '--disabled'],
+  });
+  const name = positional[0];
+  if (!name) {
+    throw new CliUsageError(
+      'Usage: mcphub servers add <name> --from-file <path>\n' +
+        '   or  mcphub servers add <name> --type <stdio|sse|streamable-http|openapi> [--command ...] [--arg ...] [--env K=V ...]',
+    );
+  }
+
+  let config: ServerConfig;
+  if (flags['--from-file']) {
+    const path = flags['--from-file'] as string;
+    const raw = (deps.fs ?? fs).readFileSync(path, 'utf8');
+    config = JSON.parse(raw) as ServerConfig;
+  } else {
+    const argArgs = collectRepeated(args, '--arg');
+    const envEntries = collectRepeated(args, '--env').map((kv) => {
+      const idx = kv.indexOf('=');
+      if (idx < 0) throw new CliUsageError(`--env expects KEY=VALUE, got: ${kv}`);
+      return [kv.slice(0, idx), kv.slice(idx + 1)] as const;
+    });
+    config = {
+      type: (flags['--type'] as ServerConfig['type']) || 'stdio',
+      description: flags['--description'] as string | undefined,
+      command: flags['--command'] as string | undefined,
+      args: argArgs.length > 0 ? argArgs : undefined,
+      env: envEntries.length > 0 ? Object.fromEntries(envEntries) : undefined,
+      url: flags['--url'] as string | undefined,
+      enabled: flags['--disabled'] ? false : true,
+    };
+  }
+
+  const res = await client.post<ApiResponse<unknown>>('/api/servers', { name, config });
+  if (globals.json) {
+    printJson(res);
+    return;
+  }
+  printLine(green(`Added server "${name}".`));
+}
+
+async function remove(client: ApiClient, args: string[]): Promise<void> {
+  const name = args[0];
+  if (!name) throw new CliUsageError('Usage: mcphub servers remove <name>');
+  await client.delete(`/api/servers/${encodeURIComponent(name)}`);
+  printLine(green(`Removed server "${name}".`));
+}
+
+async function toggle(client: ApiClient, args: string[]): Promise<void> {
+  const { positional, flags } = extractFlags(args, { boolean: ['--on', '--off'] });
+  const name = positional[0];
+  if (!name) throw new CliUsageError('Usage: mcphub servers toggle <name> [--on|--off]');
+  const body: Record<string, unknown> = {};
+  if (flags['--on']) body.enabled = true;
+  if (flags['--off']) body.enabled = false;
+  await client.post(`/api/servers/${encodeURIComponent(name)}/toggle`, body);
+  printLine(green(`Toggled server "${name}".`));
+}
+
+async function reload(client: ApiClient, args: string[]): Promise<void> {
+  const name = args[0];
+  if (!name) throw new CliUsageError('Usage: mcphub servers reload <name>');
+  await client.post(`/api/servers/${encodeURIComponent(name)}/reload`, {});
+  printLine(green(`Reloaded server "${name}".`));
+}
+
+// Helper: pull every occurrence of `--flag <value>` out of argv. extractFlags
+// only captures the last occurrence, so repeated flags need this scan.
+function collectRepeated(argv: string[], flag: string): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === flag) {
+      const v = argv[i + 1];
+      if (v !== undefined && !v.startsWith('--')) out.push(v);
+    } else if (argv[i].startsWith(`${flag}=`)) {
+      out.push(argv[i].slice(flag.length + 1));
+    }
+  }
+  return out;
+}

--- a/src/cli/commands/servers.ts
+++ b/src/cli/commands/servers.ts
@@ -146,13 +146,19 @@ async function reload(client: ApiClient, args: string[]): Promise<void> {
 }
 
 // Helper: pull every occurrence of `--flag <value>` out of argv. extractFlags
-// only captures the last occurrence, so repeated flags need this scan.
+// only captures the last occurrence, so repeated flags need this scan. Values
+// may legitimately start with `--` (e.g. `--arg --version` for a wrapped CLI);
+// we consume them unconditionally and skip the next index so we don't re-scan
+// the value as another flag boundary.
 function collectRepeated(argv: string[], flag: string): string[] {
   const out: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === flag) {
       const v = argv[i + 1];
-      if (v !== undefined && !v.startsWith('--')) out.push(v);
+      if (v !== undefined) {
+        out.push(v);
+        i++;
+      }
     } else if (argv[i].startsWith(`${flag}=`)) {
       out.push(argv[i].slice(flag.length + 1));
     }

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -1,0 +1,213 @@
+import { ApiClient } from '../http.js';
+import { CliUsageError } from '../errors.js';
+import { GlobalFlags, buildClient, resolveTarget } from '../context.js';
+import { extractFlags } from '../parse-args.js';
+import { bold, dim, printJson, printLine, printTable } from '../output.js';
+import type { ServerInfo, Tool } from '../../types/index.js';
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+interface FlatTool {
+  server: string;
+  serverStatus: ServerInfo['status'];
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  inputSchema?: Record<string, unknown>;
+}
+
+export interface ToolsDeps {
+  client?: ApiClient;
+}
+
+// `tools` is the agent-friendly index for `call`: it answers "what can I call,
+// what params does it take, where does it live" in one place, without making
+// callers post-process `servers list` responses.
+
+export async function run(args: string[], globals: GlobalFlags, deps: ToolsDeps = {}): Promise<void> {
+  const sub = args.shift();
+  const client = deps.client ?? buildClient(resolveTarget(globals));
+  switch (sub) {
+    case undefined:
+    case 'list':
+      return list(client, args, globals);
+    case 'get':
+    case 'schema':
+      return get(client, args, globals);
+    default:
+      throw new CliUsageError(`Unknown tools subcommand: ${sub}`);
+  }
+}
+
+async function fetchFlatTools(client: ApiClient): Promise<FlatTool[]> {
+  const res = await client.get<ApiResponse<ServerInfo[]>>('/api/servers');
+  const servers = res.data ?? [];
+  const out: FlatTool[] = [];
+  for (const s of servers) {
+    for (const t of (s.tools ?? []) as Tool[]) {
+      out.push({
+        server: s.name,
+        serverStatus: s.status,
+        name: t.name,
+        description: t.description,
+        enabled: t.enabled,
+        inputSchema: t.inputSchema as Record<string, unknown> | undefined,
+      });
+    }
+  }
+  return out;
+}
+
+async function list(client: ApiClient, args: string[], globals: GlobalFlags): Promise<void> {
+  const { flags } = extractFlags(args, {
+    valued: ['--server'],
+    boolean: ['--schema', '--enabled-only'],
+  });
+  let tools = await fetchFlatTools(client);
+  if (flags['--server']) {
+    const wanted = String(flags['--server']);
+    tools = tools.filter((t) => t.server === wanted);
+  }
+  if (flags['--enabled-only']) {
+    tools = tools.filter((t) => t.enabled !== false);
+  }
+
+  if (globals.json) {
+    if (!flags['--schema']) {
+      // Drop inputSchema by default to keep the JSON small; callers can opt in.
+      printJson(tools.map(({ inputSchema: _omit, ...rest }) => rest));
+    } else {
+      printJson(tools);
+    }
+    return;
+  }
+
+  if (tools.length === 0) {
+    printLine(dim('(no tools)'));
+    return;
+  }
+  printTable(
+    tools.map((t) => ({
+      server: t.server,
+      tool: t.name,
+      enabled: t.enabled === false ? 'no' : 'yes',
+      description: truncate(t.description ?? '', 60),
+    })),
+    ['server', 'tool', 'enabled', 'description'],
+  );
+  printLine(
+    dim(
+      `\nUse \`mcphub tools get <tool> [--server <name>]\` to see input schema and required params.`,
+    ),
+  );
+}
+
+async function get(client: ApiClient, args: string[], globals: GlobalFlags): Promise<void> {
+  const { positional, flags } = extractFlags(args, { valued: ['--server'] });
+  const name = positional[0];
+  if (!name) {
+    throw new CliUsageError('Usage: mcphub tools get <tool-name> [--server <server-name>]');
+  }
+  const wantedServer = flags['--server'] as string | undefined;
+  const matches = (await fetchFlatTools(client)).filter(
+    (t) => t.name === name && (!wantedServer || t.server === wantedServer),
+  );
+
+  if (matches.length === 0) {
+    throw new CliUsageError(
+      wantedServer
+        ? `Tool "${name}" not found on server "${wantedServer}". Run \`mcphub tools list\` to see what's available.`
+        : `Tool "${name}" not found. Run \`mcphub tools list\` to see what's available.`,
+    );
+  }
+  if (matches.length > 1 && !wantedServer) {
+    const hosts = matches.map((m) => m.server).join(', ');
+    throw new CliUsageError(
+      `Tool "${name}" exists on multiple servers (${hosts}). Pass --server <name> to pick one.`,
+    );
+  }
+
+  const tool = matches[0];
+  if (globals.json) {
+    printJson(tool);
+    return;
+  }
+
+  const schema = tool.inputSchema as
+    | { properties?: Record<string, { type?: string; description?: string }>; required?: string[] }
+    | undefined;
+  const required = new Set(schema?.required ?? []);
+  const props = schema?.properties ?? {};
+
+  printLine(`${bold('Server:')}      ${tool.server} (${tool.serverStatus})`);
+  printLine(`${bold('Tool:')}        ${tool.name}`);
+  if (tool.description) {
+    printLine(`${bold('Description:')} ${tool.description}`);
+  }
+  if (tool.enabled === false) {
+    printLine(dim('(disabled — calls will fail until re-enabled)'));
+  }
+  printLine('');
+  if (Object.keys(props).length === 0) {
+    printLine(dim('No documented parameters.'));
+  } else {
+    printLine(bold('Parameters:'));
+    const rows = Object.entries(props).map(([key, p]) => ({
+      param: key,
+      type: typeof p === 'object' && p ? p.type ?? '' : '',
+      required: required.has(key) ? 'yes' : 'no',
+      description: truncate(typeof p === 'object' && p ? p.description ?? '' : '', 60),
+    }));
+    printTable(rows, ['param', 'type', 'required', 'description']);
+  }
+
+  printLine('');
+  printLine(bold('Input schema (JSON):'));
+  printLine(JSON.stringify(tool.inputSchema ?? {}, null, 2));
+
+  printLine('');
+  printLine(bold('Example:'));
+  const example = buildExample(tool, required, props);
+  printLine(`  ${example}`);
+}
+
+function buildExample(
+  tool: FlatTool,
+  required: Set<string>,
+  props: Record<string, { type?: string; description?: string }>,
+): string {
+  const sample = (type: string | undefined) => {
+    switch (type) {
+      case 'number':
+      case 'integer':
+        return '0';
+      case 'boolean':
+        return 'true';
+      case 'array':
+        return '[]';
+      case 'object':
+        return '{}';
+      default:
+        return '<value>';
+    }
+  };
+  const parts = ['mcphub', 'call', tool.name];
+  // Show required params first, with a hint at the type. Optional params are
+  // intentionally omitted so the example is the minimum-viable call.
+  const reqKeys = Array.from(required);
+  for (const key of reqKeys) {
+    const p = props[key];
+    parts.push(`${key}=${sample(typeof p === 'object' && p ? p.type : undefined)}`);
+  }
+  parts.push(`--server`, tool.server);
+  return parts.join(' ');
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + '…';
+}

--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -1,0 +1,80 @@
+import { ApiClient, TokenKind } from './http.js';
+import { CliUsageError } from './errors.js';
+import {
+  Credentials,
+  getProfile,
+  loadCredentials,
+  Profile,
+} from './profile.js';
+
+export interface GlobalFlags {
+  url?: string;
+  token?: string;
+  bearer?: boolean;
+  profile?: string;
+  json?: boolean;
+  debug?: boolean;
+}
+
+export interface ResolvedTarget {
+  baseUrl: string;
+  token?: string;
+  tokenKind: TokenKind;
+  profileName?: string;
+}
+
+// Resolve where requests should go and what token to use, in this order:
+// 1. CLI flags (--url / --token / --bearer)
+// 2. Environment variables (MCPHUB_URL / MCPHUB_TOKEN / MCPHUB_TOKEN_KIND)
+// 3. Active profile in credentials.json (--profile <name> or current)
+// Commands that only need a URL (e.g. discover) call resolveTargetForPublic()
+// instead, which doesn't require a token.
+
+export function resolveTarget(globals: GlobalFlags, creds?: Credentials): ResolvedTarget {
+  const credentials = creds ?? loadCredentials();
+  const profile: Profile | undefined = getProfile(credentials, globals.profile);
+
+  const baseUrl = globals.url ?? process.env.MCPHUB_URL ?? profile?.url;
+  if (!baseUrl) {
+    throw new CliUsageError(
+      'No mcphub URL configured. Use --url <url>, MCPHUB_URL env, or run `mcphub login`.',
+    );
+  }
+  const tokenKind: TokenKind =
+    (globals.bearer ? 'bearer' : undefined) ??
+    (process.env.MCPHUB_TOKEN_KIND as TokenKind | undefined) ??
+    profile?.tokenKind ??
+    'jwt';
+  const token = globals.token ?? process.env.MCPHUB_TOKEN ?? profile?.token;
+  if (!token) {
+    throw new CliUsageError(
+      'Not logged in. Use --token <token>, MCPHUB_TOKEN env, or run `mcphub login`.',
+    );
+  }
+  return { baseUrl, token, tokenKind, profileName: globals.profile ?? credentials.current };
+}
+
+export function resolveTargetForPublic(
+  globals: GlobalFlags,
+  remote?: string,
+  creds?: Credentials,
+): { baseUrl: string } {
+  const credentials = creds ?? loadCredentials();
+  const profile = getProfile(credentials, globals.profile);
+  const baseUrl = remote ?? globals.url ?? process.env.MCPHUB_URL ?? profile?.url;
+  if (!baseUrl) {
+    throw new CliUsageError(
+      'No mcphub URL configured. Use --remote <url>, --url <url>, MCPHUB_URL env, or run `mcphub login`.',
+    );
+  }
+  return { baseUrl };
+}
+
+export function buildClient(target: ResolvedTarget, fetchImpl?: typeof fetch): ApiClient {
+  return new ApiClient({
+    baseUrl: target.baseUrl,
+    token: target.token,
+    tokenKind: target.tokenKind,
+    fetchImpl,
+  });
+}

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,0 +1,31 @@
+// Errors thrown by the CLI layer. Top-level handler in main.ts inspects the
+// constructor (or `requiresLogin` flag) to choose an exit code and decide
+// whether to print remediation hints.
+
+export class CliUsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CliUsageError';
+  }
+}
+
+export interface CliApiErrorInit {
+  status: number;
+  message: string;
+  body?: unknown;
+  requiresLogin?: boolean;
+}
+
+export class CliApiError extends Error {
+  readonly status: number;
+  readonly body: unknown;
+  readonly requiresLogin: boolean;
+
+  constructor(init: CliApiErrorInit) {
+    super(init.message);
+    this.name = 'CliApiError';
+    this.status = init.status;
+    this.body = init.body;
+    this.requiresLogin = init.requiresLogin ?? init.status === 401;
+  }
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -15,7 +15,7 @@ Commands:
   keys                             manage bearer keys
   call                             call an MCP tool via /mcp/$smart or /mcp/<group>
   export                           export the running hub's mcp_settings.json
-  discover                         browse a remote hub's public marketplace (#809)
+  discover                         browse a remote hub's public marketplace
   install                          install a server from a remote marketplace
   help [command]                   show help for a command
 

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,148 @@
+import { printLine } from './output.js';
+
+const TOP_LEVEL_HELP = `mcphub — official CLI for the mcphub server
+
+Usage:
+  mcphub                           start the mcphub server (legacy, no-arg form)
+  mcphub <command> [options]       run a CLI command
+
+Commands:
+  login                            interactively log in to a mcphub instance
+  logout                           clear the cached token for the active profile
+  config                           manage local profiles and credentials
+  servers                          list/get/add/remove/toggle/reload MCP servers
+  groups                           manage server groups
+  keys                             manage bearer keys
+  call                             call an MCP tool via /mcp/$smart or /mcp/<group>
+  export                           export the running hub's mcp_settings.json
+  discover                         browse a remote hub's public marketplace (#809)
+  install                          install a server from a remote marketplace
+  help [command]                   show help for a command
+
+Global options:
+  --url <url>                      override the active profile's base URL
+  --token <token>                  override the active profile's token
+  --bearer                         treat --token as a bearer key (default: JWT)
+  --profile <name>                 use a specific saved profile
+  --json                           print JSON output instead of human-friendly
+  --debug                          print stack traces on error
+
+Environment:
+  MCPHUB_URL, MCPHUB_TOKEN, MCPHUB_TOKEN_KIND
+  XDG_CONFIG_HOME, XDG_DATA_HOME, NO_COLOR
+`;
+
+const COMMAND_HELP: Record<string, string> = {
+  login: `mcphub login [--url <url>] [--username <name>] [--password <pwd>]
+
+Log in to a mcphub instance and cache a JWT in the active profile.
+Prompts for missing values. The token is written to credentials.json
+with 0600 permissions.`,
+
+  logout: `mcphub logout
+
+Clear the token from the active profile (URL and username are preserved).`,
+
+  config: `mcphub config <subcommand>
+
+Subcommands:
+  show                             print the active profile (token masked)
+  list                             list all saved profiles
+  use <name>                       switch the active profile
+  set-url <url>                    set the URL of a profile (--profile to target)
+  set-token <token> [--bearer]     set the token of a profile manually
+  remove <name>                    delete a saved profile`,
+
+  servers: `mcphub servers <subcommand>
+
+Subcommands:
+  list                             list all servers
+  get <name>                       show one server's config
+  add <name> --from-file <path>    add a server from a JSON file
+  add <name> --type stdio --command <cmd> [--arg <a> ...] [--env K=V ...]
+  remove <name>                    delete a server
+  toggle <name> [--on|--off]       enable/disable a server
+  reload <name>                    reconnect a server`,
+
+  groups: `mcphub groups <subcommand>
+
+Subcommands:
+  list                             list groups
+  get <id|name>                    show one group
+  add <name> [--description <d>]   create a group
+  remove <id|name>                 delete a group
+  add-server <group> <server>      add a server to a group
+  remove-server <group> <server>   remove a server from a group`,
+
+  keys: `mcphub keys <subcommand>
+
+Subcommands:
+  list                             list bearer keys
+  create --name <n> [--access-type all|groups|servers|custom]
+         [--groups a,b] [--servers x,y]
+  delete <id>                      delete a key`,
+
+  call: `mcphub call <tool> [k=v ...] [--group <g>|--smart] [--params-json <json>]
+
+Call an MCP tool. Argument parsing:
+  key=value                        string by default
+  key=42 / key=true / key=null     auto-coerced to number/boolean/null
+  key=@path                        load JSON from file
+  --params-json '{"a":1}'          override the entire params object`,
+
+  export: `mcphub export [--out <path>]
+
+Download the running hub's mcp_settings.json. Default: stdout (pretty JSON).`,
+
+  discover: `mcphub discover [subcommand] [--remote <url>] [--search <q>]
+                          [--category <c>] [--tag <t>] [--limit <n>]
+
+Browse the public marketplace API (requires the hub to have
+systemConfig.discovery.enabled=true).
+
+Subcommands:
+  (default)                        list market servers
+  info <name>                      show a single server
+  categories                       list categories
+  tags                             list tags`,
+
+  install: `mcphub install <name> [--remote <url>] [--type npm|docker|uvx|pip|binary]
+                          [--to hub|file|stdout] [--out <path>]
+                          [--env K=V ...] [--dry-run] [--yes] [--force]
+
+Install a server from a remote hub's marketplace.
+
+--to hub      POST /api/servers on the active profile's hub (default)
+--to file     merge mcpServers into a Claude Desktop / OpenClaw-style JSON
+--to stdout   print the mcpServers snippet (same as --dry-run)
+`,
+};
+
+export function printHelp(command?: string): void {
+  if (!command) {
+    printLine(TOP_LEVEL_HELP);
+    return;
+  }
+  const help = COMMAND_HELP[command];
+  if (!help) {
+    printLine(`No help available for "${command}".`);
+    printLine('');
+    printLine(TOP_LEVEL_HELP);
+    return;
+  }
+  printLine(help);
+}
+
+export function printVersion(): void {
+  // The version is read lazily so tests don't have to mock the package.json
+  // path. We import via createRequire to keep this ESM-safe.
+  import('node:module').then(({ createRequire }) => {
+    try {
+      const require = createRequire(import.meta.url);
+      const pkg = require('../../package.json');
+      printLine(pkg.version ?? 'unknown');
+    } catch {
+      printLine('unknown');
+    }
+  });
+}

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -13,7 +13,8 @@ Commands:
   servers                          list/get/add/remove/toggle/reload MCP servers
   groups                           manage server groups
   keys                             manage bearer keys
-  call                             call an MCP tool via /mcp/$smart or /mcp/<group>
+  tools                            list MCP tools and inspect their input schema
+  call                             call an MCP tool via /mcp/$smart or /mcp/<server|group>
   export                           export the running hub's mcp_settings.json
   discover                         browse a remote hub's public marketplace
   install                          install a server from a remote marketplace
@@ -82,13 +83,33 @@ Subcommands:
          [--groups a,b] [--servers x,y]
   delete <id>                      delete a key`,
 
-  call: `mcphub call <tool> [k=v ...] [--group <g>|--smart] [--params-json <json>]
+  tools: `mcphub tools <subcommand>
 
-Call an MCP tool. Argument parsing:
+The agent-friendly index for \`call\`. Use it to discover what's available
+and what params each tool wants without hand-parsing \`servers list\` JSON.
+
+Subcommands:
+  list [--server <name>] [--enabled-only] [--schema]
+                                   list tools across all (or one) servers
+  get <tool> [--server <name>]     show one tool's description, parameters,
+                                   input schema, and a sample \`call\` command
+  schema <tool> [--server <name>]  alias for \`get\``,
+
+  call: `mcphub call <tool> [k=v ...] [--server <s>|--group <g>|--smart] [--params-json <json>]
+
+Discover what to pass via:
+  mcphub tools list                   # all tools
+  mcphub tools get <tool>             # required params + sample command
+
+Argument parsing:
   key=value                        string by default
   key=42 / key=true / key=null     auto-coerced to number/boolean/null
   key=@path                        load JSON from file
-  --params-json '{"a":1}'          override the entire params object`,
+  --params-json '{"a":1}'          override the entire params object
+
+Routing precedence: --smart > --server > --group > default ($smart). All
+three resolve to /mcp/<slug>; --server is the natural pair for
+\`tools list\` output.`,
 
   export: `mcphub export [--out <path>]
 

--- a/src/cli/http.ts
+++ b/src/cli/http.ts
@@ -1,0 +1,115 @@
+import { CliApiError } from './errors.js';
+
+export type TokenKind = 'jwt' | 'bearer';
+
+export interface ApiClientOptions {
+  baseUrl: string;
+  token?: string;
+  tokenKind?: TokenKind;
+  fetchImpl?: typeof fetch;
+}
+
+// Thin fetch wrapper. Auth injection is determined by tokenKind so a single
+// client can target dashboard API (JWT via x-auth-token) or scoped bearer key
+// (Authorization: Bearer ...) routes. Non-2xx → CliApiError with parsed body.
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly token?: string;
+  private readonly tokenKind: TokenKind;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: ApiClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
+    this.token = opts.token;
+    this.tokenKind = opts.tokenKind ?? 'jwt';
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  }
+
+  private buildHeaders(extra?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...(extra ?? {}),
+    };
+    if (this.token) {
+      if (this.tokenKind === 'bearer') {
+        headers.Authorization = `Bearer ${this.token}`;
+      } else {
+        headers['x-auth-token'] = this.token;
+      }
+    }
+    return headers;
+  }
+
+  async request<T = unknown>(
+    method: string,
+    path: string,
+    body?: unknown,
+    init?: RequestInit,
+  ): Promise<T> {
+    const url = path.startsWith('http') ? path : `${this.baseUrl}${path.startsWith('/') ? '' : '/'}${path}`;
+    const headers = this.buildHeaders(init?.headers as Record<string, string> | undefined);
+    let payload: BodyInit | undefined;
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      payload = JSON.stringify(body);
+    }
+    const res = await this.fetchImpl(url, {
+      ...init,
+      method,
+      headers,
+      body: payload,
+    });
+    const text = await res.text();
+    let parsed: unknown = undefined;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+
+    if (!res.ok) {
+      const message = extractMessage(parsed) ?? `${method} ${path} failed with ${res.status}`;
+      throw new CliApiError({
+        status: res.status,
+        message,
+        body: parsed,
+        requiresLogin: res.status === 401,
+      });
+    }
+
+    return parsed as T;
+  }
+
+  get<T = unknown>(path: string, init?: RequestInit) {
+    return this.request<T>('GET', path, undefined, init);
+  }
+  post<T = unknown>(path: string, body?: unknown, init?: RequestInit) {
+    return this.request<T>('POST', path, body, init);
+  }
+  put<T = unknown>(path: string, body?: unknown, init?: RequestInit) {
+    return this.request<T>('PUT', path, body, init);
+  }
+  delete<T = unknown>(path: string, init?: RequestInit) {
+    return this.request<T>('DELETE', path, undefined, init);
+  }
+
+  // POST to /mcp/:group? with a JSON-RPC body. `group` may be a literal group
+  // name, '$smart' for smart routing, or null for the global endpoint.
+  async mcpCall<T = unknown>(group: string | '$smart' | null, payload: unknown): Promise<T> {
+    const suffix = group ? `/${encodeURIComponent(group)}` : '';
+    return this.request<T>('POST', `/mcp${suffix}`, payload);
+  }
+}
+
+function extractMessage(body: unknown): string | undefined {
+  if (body && typeof body === 'object') {
+    const obj = body as { message?: unknown; error?: unknown };
+    if (typeof obj.message === 'string') return obj.message;
+    if (typeof obj.error === 'string') return obj.error;
+  }
+  if (typeof body === 'string' && body.trim()) return body;
+  return undefined;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,96 @@
+import { CliApiError, CliUsageError } from './errors.js';
+import { GlobalFlags } from './context.js';
+import { parseGlobalFlags } from './parse-args.js';
+import { printError, printLine, printWarn } from './output.js';
+import { printHelp, printVersion } from './help.js';
+
+export type CommandHandler = (args: string[], globals: GlobalFlags) => Promise<void>;
+
+interface CommandModule {
+  run?: CommandHandler;
+  logout?: CommandHandler;
+}
+
+const SUBCOMMAND_LOADERS: Record<string, () => Promise<CommandModule>> = {
+  login: () => import('./commands/login.js'),
+  logout: () => import('./commands/login.js'),
+  config: () => import('./commands/config.js'),
+  servers: () => import('./commands/servers.js'),
+  groups: () => import('./commands/groups.js'),
+  keys: () => import('./commands/keys.js'),
+  call: () => import('./commands/call.js'),
+  export: () => import('./commands/export.js'),
+  discover: () => import('./commands/discover.js'),
+  install: () => import('./commands/install.js'),
+};
+
+export async function runCli(argv: string[]): Promise<void> {
+  const { globalFlags, rest } = parseGlobalFlags(argv);
+  const command = rest.shift();
+
+  try {
+    if (!command || command === 'help' || command === '--help' || command === '-h') {
+      printHelp(rest[0]);
+      return;
+    }
+    if (command === '--version' || command === '-v') {
+      printVersion();
+      return;
+    }
+
+    const loader = SUBCOMMAND_LOADERS[command];
+    if (!loader) {
+      throw new CliUsageError(`Unknown command: ${command}. Run \`mcphub --help\` for a list.`);
+    }
+
+    const mod = await loader();
+    const handler = command === 'logout' ? mod.logout : mod.run;
+    if (!handler) {
+      throw new CliUsageError(`Command not implemented: ${command}`);
+    }
+    await handler(rest, globalFlags);
+  } catch (err) {
+    handleTopLevelError(err, globalFlags);
+  }
+}
+
+function handleTopLevelError(err: unknown, globals: GlobalFlags): void {
+  if (err instanceof CliUsageError) {
+    printError(err.message);
+    process.exitCode = 1;
+    return;
+  }
+  if (err instanceof CliApiError) {
+    printError(`API error (${err.status}): ${err.message}`);
+    if (err.requiresLogin) {
+      printWarn('Hint: run `mcphub login` to refresh your token.');
+    }
+    if (globals.debug && err.body !== undefined) {
+      printLine(typeof err.body === 'string' ? err.body : JSON.stringify(err.body, null, 2));
+    }
+    process.exitCode = 2;
+    return;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  printError(`Unexpected error: ${message}`);
+  if (globals.debug && err instanceof Error && err.stack) {
+    printLine(err.stack);
+  }
+  process.exitCode = 1;
+}
+
+// Self-run when invoked directly (`tsx src/cli/main.ts ...` or
+// `node dist/cli/main.js ...`). bin/cli.js also imports runCli explicitly, so
+// the dispatcher works in both modes.
+import { fileURLToPath as toPath } from 'node:url';
+import process from 'node:process';
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  (process.argv[1] === toPath(import.meta.url) ||
+    process.argv[1].endsWith('/cli/main.ts') ||
+    process.argv[1].endsWith('/cli/main.js'));
+
+if (invokedDirectly) {
+  void runCli(process.argv.slice(2));
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,6 +18,7 @@ const SUBCOMMAND_LOADERS: Record<string, () => Promise<CommandModule>> = {
   servers: () => import('./commands/servers.js'),
   groups: () => import('./commands/groups.js'),
   keys: () => import('./commands/keys.js'),
+  tools: () => import('./commands/tools.js'),
   call: () => import('./commands/call.js'),
   export: () => import('./commands/export.js'),
   discover: () => import('./commands/discover.js'),

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,0 +1,59 @@
+// stdout/stderr helpers. Honors NO_COLOR and non-TTY stdout. JSON output is
+// always emitted via printJson() so --json never mixes with ANSI escapes.
+
+const colorEnabled =
+  process.env.NO_COLOR === undefined &&
+  process.env.TERM !== 'dumb' &&
+  process.stdout.isTTY === true;
+
+const wrap = (code: number, text: string): string =>
+  colorEnabled ? `\x1b[${code}m${text}\x1b[0m` : text;
+
+export const red = (s: string): string => wrap(31, s);
+export const green = (s: string): string => wrap(32, s);
+export const yellow = (s: string): string => wrap(33, s);
+export const cyan = (s: string): string => wrap(36, s);
+export const dim = (s: string): string => wrap(2, s);
+export const bold = (s: string): string => wrap(1, s);
+
+export function printJson(value: unknown): void {
+  process.stdout.write(JSON.stringify(value, null, 2) + '\n');
+}
+
+export function printLine(text = ''): void {
+  process.stdout.write(text + '\n');
+}
+
+export function printError(text: string): void {
+  process.stderr.write(red(text) + '\n');
+}
+
+export function printWarn(text: string): void {
+  process.stderr.write(yellow(text) + '\n');
+}
+
+// Minimal column-aligned table printer. Renders to stdout. Columns are sized
+// by the widest cell in each column; values are coerced via String().
+export function printTable(rows: Array<Record<string, unknown>>, columns: string[]): void {
+  if (rows.length === 0) {
+    printLine(dim('(empty)'));
+    return;
+  }
+  const widths = columns.map((col) =>
+    Math.max(col.length, ...rows.map((r) => String(r[col] ?? '').length)),
+  );
+  const renderRow = (cells: string[]): string =>
+    cells.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+
+  printLine(bold(renderRow(columns)));
+  printLine(dim(renderRow(widths.map((w) => '-'.repeat(w)))));
+  for (const row of rows) {
+    printLine(renderRow(columns.map((col) => String(row[col] ?? ''))));
+  }
+}
+
+export function maskToken(token: string | undefined): string {
+  if (!token) return '(none)';
+  if (token.length <= 4) return '*'.repeat(token.length);
+  return '*'.repeat(Math.max(token.length - 4, 4)) + token.slice(-4);
+}

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,0 +1,125 @@
+import { CliUsageError } from './errors.js';
+import { GlobalFlags } from './context.js';
+
+// Boolean flags that don't take a value when present without "=".
+const BOOLEAN_GLOBALS = new Set(['--bearer', '--json', '--debug']);
+
+// Flags handled at the top level (consumed by main.ts before dispatching to
+// a subcommand handler). Anything else flows through to the subcommand's
+// argv unchanged so subcommand-specific flags can be parsed locally.
+
+const VALUED_GLOBALS = new Set(['--url', '--token', '--profile']);
+
+export interface ParsedGlobals {
+  globalFlags: GlobalFlags;
+  rest: string[];
+}
+
+export function parseGlobalFlags(argv: string[]): ParsedGlobals {
+  const globalFlags: GlobalFlags = {};
+  const rest: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (BOOLEAN_GLOBALS.has(arg)) {
+      assignFlag(globalFlags, arg, true);
+      continue;
+    }
+
+    if (VALUED_GLOBALS.has(arg)) {
+      const value = argv[++i];
+      if (value === undefined) {
+        throw new CliUsageError(`Missing value for ${arg}`);
+      }
+      assignFlag(globalFlags, arg, value);
+      continue;
+    }
+
+    // Support --flag=value form for valued flags
+    const eqIdx = arg.indexOf('=');
+    if (eqIdx > 0 && arg.startsWith('--')) {
+      const name = arg.slice(0, eqIdx);
+      const value = arg.slice(eqIdx + 1);
+      if (VALUED_GLOBALS.has(name)) {
+        assignFlag(globalFlags, name, value);
+        continue;
+      }
+      if (BOOLEAN_GLOBALS.has(name)) {
+        assignFlag(globalFlags, name, value !== 'false');
+        continue;
+      }
+    }
+
+    rest.push(arg);
+  }
+
+  return { globalFlags, rest };
+}
+
+function assignFlag(target: GlobalFlags, flag: string, value: string | boolean): void {
+  switch (flag) {
+    case '--url':
+      target.url = value as string;
+      break;
+    case '--token':
+      target.token = value as string;
+      break;
+    case '--bearer':
+      target.bearer = value as boolean;
+      break;
+    case '--profile':
+      target.profile = value as string;
+      break;
+    case '--json':
+      target.json = value as boolean;
+      break;
+    case '--debug':
+      target.debug = value as boolean;
+      break;
+  }
+}
+
+// Simple subcommand flag extractor. Pulls --name <value> and --bool occurrences
+// out of `argv` and returns positional arguments. Supports --name=value too.
+export function extractFlags(
+  argv: string[],
+  spec: { valued?: string[]; boolean?: string[] },
+): { positional: string[]; flags: Record<string, string | boolean> } {
+  const valued = new Set(spec.valued ?? []);
+  const bools = new Set(spec.boolean ?? []);
+  const positional: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (bools.has(arg)) {
+      flags[arg] = true;
+      continue;
+    }
+    if (valued.has(arg)) {
+      const value = argv[++i];
+      if (value === undefined) {
+        throw new CliUsageError(`Missing value for ${arg}`);
+      }
+      flags[arg] = value;
+      continue;
+    }
+    const eqIdx = arg.indexOf('=');
+    if (eqIdx > 0 && arg.startsWith('--')) {
+      const name = arg.slice(0, eqIdx);
+      const value = arg.slice(eqIdx + 1);
+      if (valued.has(name)) {
+        flags[name] = value;
+        continue;
+      }
+      if (bools.has(name)) {
+        flags[name] = value !== 'false';
+        continue;
+      }
+    }
+    positional.push(arg);
+  }
+
+  return { positional, flags };
+}

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -1,0 +1,138 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// XDG-aware credential and config storage. Credentials are written with 0600
+// (owner read/write only) and the parent directory with 0700; writes are atomic
+// (tmp + rename) so a crashed write can't leave a half-written file.
+
+export interface Profile {
+  url: string;
+  tokenKind?: 'jwt' | 'bearer';
+  token?: string;
+  username?: string;
+  savedAt?: string;
+}
+
+export interface Credentials {
+  current: string;
+  profiles: Record<string, Profile>;
+}
+
+export interface CliConfigFile {
+  defaultOutput?: 'text' | 'json';
+  defaultProfile?: string;
+}
+
+const APP_NAME = 'mcphub';
+
+function homeDir(): string {
+  // Prefer HOME / USERPROFILE so tests (and users) can override via env. On
+  // some macOS configurations os.homedir() ignores HOME and reads the real
+  // passwd entry, which would defeat both isolation and explicit overrides.
+  return process.env.HOME || process.env.USERPROFILE || os.homedir() || process.cwd();
+}
+
+function xdgConfigHome(): string {
+  return process.env.XDG_CONFIG_HOME || path.join(homeDir(), '.config');
+}
+
+function xdgDataHome(): string {
+  return process.env.XDG_DATA_HOME || path.join(homeDir(), '.local', 'share');
+}
+
+function legacyDir(): string {
+  return path.join(homeDir(), `.${APP_NAME}`);
+}
+
+export function credentialsPath(): string {
+  const legacy = path.join(legacyDir(), 'credentials.json');
+  if (fs.existsSync(legacy)) {
+    return legacy;
+  }
+  return path.join(xdgDataHome(), APP_NAME, 'credentials.json');
+}
+
+export function configPath(): string {
+  return path.join(xdgConfigHome(), APP_NAME, 'config.json');
+}
+
+const EMPTY_CREDENTIALS: Credentials = { current: '', profiles: {} };
+
+export function loadCredentials(): Credentials {
+  const p = credentialsPath();
+  if (!fs.existsSync(p)) {
+    return { ...EMPTY_CREDENTIALS };
+  }
+  try {
+    const raw = fs.readFileSync(p, 'utf8');
+    const parsed = JSON.parse(raw) as Credentials;
+    if (!parsed || typeof parsed !== 'object' || !parsed.profiles) {
+      return { ...EMPTY_CREDENTIALS };
+    }
+    return parsed;
+  } catch {
+    return { ...EMPTY_CREDENTIALS };
+  }
+}
+
+export function saveCredentials(creds: Credentials): void {
+  const p = credentialsPath();
+  const dir = path.dirname(p);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Best-effort tighten on existing dir (mkdirSync mode is honored only on
+  // creation; chmod on dir works on POSIX, no-op on Windows).
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    /* ignore */
+  }
+  const tmp = `${p}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, p);
+  try {
+    fs.chmodSync(p, 0o600);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function loadConfigFile(): CliConfigFile {
+  const p = configPath();
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+export function getProfile(creds: Credentials, name?: string): Profile | undefined {
+  const target = name || creds.current;
+  if (!target) return undefined;
+  return creds.profiles[target];
+}
+
+export function setProfile(creds: Credentials, name: string, profile: Profile): Credentials {
+  return {
+    current: creds.current || name,
+    profiles: { ...creds.profiles, [name]: { ...profile, savedAt: new Date().toISOString() } },
+  };
+}
+
+export function deleteProfile(creds: Credentials, name: string): Credentials {
+  if (!(name in creds.profiles)) return creds;
+  const next = { ...creds.profiles };
+  delete next[name];
+  return {
+    current: creds.current === name ? Object.keys(next)[0] || '' : creds.current,
+    profiles: next,
+  };
+}
+
+export function setCurrentProfile(creds: Credentials, name: string): Credentials {
+  if (!(name in creds.profiles)) {
+    throw new Error(`Profile not found: ${name}`);
+  }
+  return { ...creds, current: name };
+}

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -1,0 +1,57 @@
+import readline from 'node:readline';
+
+export async function promptLine(question: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await new Promise<string>((resolve) => rl.question(question, resolve));
+  } finally {
+    rl.close();
+  }
+}
+
+// Hidden-input prompt for passwords. Requires a TTY for raw mode; on a
+// non-interactive stdin (pipes, CI) we just echo the question and read a line
+// so the prompt is still usable in scripts.
+export async function promptPassword(question: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    return promptLine(question);
+  }
+  process.stdout.write(question);
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+
+  return new Promise<string>((resolve) => {
+    let buf = '';
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        const code = ch.charCodeAt(0);
+        if (ch === '\r' || ch === '\n') {
+          process.stdin.setRawMode(false);
+          process.stdin.pause();
+          process.stdin.off('data', onData);
+          process.stdout.write('\n');
+          resolve(buf);
+          return;
+        }
+        if (code === 3) {
+          // Ctrl-C
+          process.stdin.setRawMode(false);
+          process.stdout.write('\n');
+          process.exit(130);
+        }
+        if (code === 127 || code === 8) {
+          // Backspace / DEL
+          buf = buf.slice(0, -1);
+          continue;
+        }
+        if (code < 32) {
+          // Drop other control chars
+          continue;
+        }
+        buf += ch;
+      }
+    };
+    process.stdin.on('data', onData);
+  });
+}

--- a/tests/cli/call-arguments.test.ts
+++ b/tests/cli/call-arguments.test.ts
@@ -21,6 +21,18 @@ describe('parseCallArguments', () => {
     expect(args).toEqual({ raw: '{not-json}' });
   });
 
+  it('@<missing-file> raises a friendly CliUsageError', () => {
+    const fakeFs = {
+      readFileSync: () => {
+        const err = new Error('ENOENT: no such file or directory');
+        throw err;
+      },
+    } as any;
+    expect(() =>
+      parseCallArguments(['payload=@/no/such.json'], { fs: fakeFs }),
+    ).toThrow(/Failed to read file \/no\/such\.json/);
+  });
+
   it('@path loads JSON from a file', () => {
     const fakeFs = {
       readFileSync: (p: any) => {

--- a/tests/cli/call-arguments.test.ts
+++ b/tests/cli/call-arguments.test.ts
@@ -1,0 +1,55 @@
+import { parseCallArguments } from '../../src/cli/call-arguments.js';
+
+describe('parseCallArguments', () => {
+  it('coerces numbers, booleans, and null by default', () => {
+    const { args } = parseCallArguments(['n=42', 'f=3.14', 'b=true', 'no=false', 'z=null']);
+    expect(args).toEqual({ n: 42, f: 3.14, b: true, no: false, z: null });
+  });
+
+  it('keeps plain strings as strings', () => {
+    const { args } = parseCallArguments(['name=alice', 'city=New York']);
+    expect(args).toEqual({ name: 'alice', city: 'New York' });
+  });
+
+  it('parses JSON literals for objects and arrays', () => {
+    const { args } = parseCallArguments(['obj={"a":1}', 'arr=[1,2,3]']);
+    expect(args).toEqual({ obj: { a: 1 }, arr: [1, 2, 3] });
+  });
+
+  it('falls back to string when brace content is not valid JSON', () => {
+    const { args } = parseCallArguments(['raw={not-json}']);
+    expect(args).toEqual({ raw: '{not-json}' });
+  });
+
+  it('@path loads JSON from a file', () => {
+    const fakeFs = {
+      readFileSync: (p: any) => {
+        expect(String(p)).toBe('/tmp/p.json');
+        return JSON.stringify({ deep: { v: 1 } });
+      },
+    } as any;
+    const { args } = parseCallArguments(['payload=@/tmp/p.json'], { fs: fakeFs });
+    expect(args).toEqual({ payload: { deep: { v: 1 } } });
+  });
+
+  it('--no-coerce disables type coercion', () => {
+    const { args } = parseCallArguments(['n=42', 'b=true'], { noCoerce: true });
+    expect(args).toEqual({ n: '42', b: 'true' });
+  });
+
+  it('tokens without "=" are returned as extras', () => {
+    const { args, extra } = parseCallArguments(['k=v', 'leftover']);
+    expect(args).toEqual({ k: 'v' });
+    expect(extra).toEqual(['leftover']);
+  });
+
+  it('preserves leading-zero strings (phone numbers, zip codes)', () => {
+    const { args } = parseCallArguments(['phone=0123']);
+    expect(args).toEqual({ phone: '0123' });
+  });
+
+  it('preserves explicit JSON-string form key="42"', () => {
+    const { args } = parseCallArguments(['v="42"']);
+    expect(args).toEqual({ v: '42' });
+  });
+});

--- a/tests/cli/commands/call.test.ts
+++ b/tests/cli/commands/call.test.ts
@@ -41,6 +41,18 @@ describe('call command', () => {
     expect(calls[0].url).toBe('http://hub.test/mcp/dev');
   });
 
+  it('--server routes to /mcp/<server> (same wire surface as --group)', async () => {
+    const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
+    await call.run(['echo', '--server', 'fetch'], {}, { client });
+    expect(calls[0].url).toBe('http://hub.test/mcp/fetch');
+  });
+
+  it('--server wins over --group when both are present', async () => {
+    const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
+    await call.run(['echo', '--group', 'dev', '--server', 'fetch'], {}, { client });
+    expect(calls[0].url).toBe('http://hub.test/mcp/fetch');
+  });
+
   it('--smart wins over --group', async () => {
     const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
     await call.run(['echo', '--group', 'dev', '--smart'], {}, { client });

--- a/tests/cli/commands/call.test.ts
+++ b/tests/cli/commands/call.test.ts
@@ -1,0 +1,75 @@
+import * as call from '../../../src/cli/commands/call.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+function makeClient(response: unknown) {
+  const calls: Array<{ method: string; url: string; body: any }> = [];
+  const fetchImpl = (async (url: any, init: any) => {
+    calls.push({
+      method: init.method,
+      url: String(url),
+      body: init.body ? JSON.parse(init.body) : undefined,
+    });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(response),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { client: new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl }), calls };
+}
+
+describe('call command', () => {
+  it('defaults to /mcp/$smart and builds tools/call JSON-RPC body', async () => {
+    const { client, calls } = makeClient({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { content: [{ type: 'text', text: 'hi' }] },
+    });
+    await call.run(['echo', 'msg=hello', 'n=5'], {}, { client });
+    expect(calls[0].url).toBe('http://hub.test/mcp/%24smart');
+    expect(calls[0].body).toEqual({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { msg: 'hello', n: 5 } },
+    });
+  });
+
+  it('--group routes to /mcp/<group>', async () => {
+    const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
+    await call.run(['echo', '--group', 'dev'], {}, { client });
+    expect(calls[0].url).toBe('http://hub.test/mcp/dev');
+  });
+
+  it('--smart wins over --group', async () => {
+    const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
+    await call.run(['echo', '--group', 'dev', '--smart'], {}, { client });
+    expect(calls[0].url).toBe('http://hub.test/mcp/%24smart');
+  });
+
+  it('--params-json overrides positional args', async () => {
+    const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
+    await call.run(['echo', 'ignored=1', '--params-json', '{"deep":{"v":1}}'], {}, { client });
+    expect(calls[0].body.params.arguments).toEqual({ deep: { v: 1 } });
+  });
+
+  it('throws CliUsageError on MCP error response', async () => {
+    const { client } = makeClient({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32601, message: 'Method not found' },
+    });
+    await expect(call.run(['nosuch'], {}, { client })).rejects.toThrow(/MCP error -32601/);
+  });
+
+  it('missing tool name throws usage error', async () => {
+    const { client } = makeClient({});
+    await expect(call.run([], {}, { client })).rejects.toThrow(/Usage: mcphub call/);
+  });
+
+  it('--no-coerce keeps string values', async () => {
+    const { client, calls } = makeClient({ jsonrpc: '2.0', id: 1, result: {} });
+    await call.run(['echo', 'n=42', '--no-coerce'], {}, { client });
+    expect(calls[0].body.params.arguments).toEqual({ n: '42' });
+  });
+});

--- a/tests/cli/commands/config.test.ts
+++ b/tests/cli/commands/config.test.ts
@@ -1,0 +1,58 @@
+import * as config from '../../../src/cli/commands/config.js';
+import { Credentials } from '../../../src/cli/profile.js';
+
+function makeDeps(initial: Credentials) {
+  const state: { saved?: Credentials } = {};
+  return {
+    deps: {
+      loadCreds: () => initial,
+      saveCreds: (c: Credentials) => {
+        state.saved = c;
+      },
+    },
+    state,
+  };
+}
+
+const initial: Credentials = {
+  current: 'default',
+  profiles: {
+    default: { url: 'http://hub.test', tokenKind: 'jwt', token: 'tok-1234', username: 'admin' },
+    staging: { url: 'http://staging.hub', tokenKind: 'bearer', token: 'tok-5678' },
+  },
+};
+
+describe('config command', () => {
+  it('config use switches the current profile', async () => {
+    const { deps, state } = makeDeps(initial);
+    await config.run(['use', 'staging'], {}, deps);
+    expect(state.saved?.current).toBe('staging');
+  });
+
+  it('config set-url updates the targeted profile', async () => {
+    const { deps, state } = makeDeps(initial);
+    await config.run(['set-url', 'https://new.hub'], { profile: 'staging' }, deps);
+    expect(state.saved?.profiles.staging.url).toBe('https://new.hub');
+    // Token preserved
+    expect(state.saved?.profiles.staging.token).toBe('tok-5678');
+  });
+
+  it('config set-token with --bearer flips tokenKind', async () => {
+    const { deps, state } = makeDeps(initial);
+    await config.run(['set-token', 'new-bearer', '--bearer'], {}, deps);
+    expect(state.saved?.profiles.default.token).toBe('new-bearer');
+    expect(state.saved?.profiles.default.tokenKind).toBe('bearer');
+  });
+
+  it('config remove deletes the profile and fixes current pointer', async () => {
+    const { deps, state } = makeDeps(initial);
+    await config.run(['remove', 'default'], {}, deps);
+    expect(state.saved?.profiles.default).toBeUndefined();
+    expect(state.saved?.current).toBe('staging');
+  });
+
+  it('unknown subcommand throws CliUsageError', async () => {
+    const { deps } = makeDeps(initial);
+    await expect(config.run(['bogus'], {}, deps)).rejects.toThrow(/Unknown config subcommand/);
+  });
+});

--- a/tests/cli/commands/discover.test.ts
+++ b/tests/cli/commands/discover.test.ts
@@ -1,0 +1,53 @@
+import * as discover from '../../../src/cli/commands/discover.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+function makeClient(handler: (url: string) => { status?: number; body?: unknown }) {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: any) => {
+    const s = String(url);
+    calls.push(s);
+    const { status = 200, body } = handler(s);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (body !== undefined ? JSON.stringify(body) : ''),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { client: new ApiClient({ baseUrl: 'http://hub.test', fetchImpl }), calls };
+}
+
+describe('discover command', () => {
+  it('list passes through query params', async () => {
+    const { client, calls } = makeClient(() => ({
+      body: { success: true, data: { total: 0, servers: [] } },
+    }));
+    await discover.run(
+      ['--remote', 'http://hub.test', '--search', 'github', '--limit', '5'],
+      {},
+      { client },
+    );
+    expect(calls[0]).toBe('http://hub.test/discovery/servers?search=github&limit=5');
+  });
+
+  it('list returns a helpful message when discovery is disabled (404)', async () => {
+    const { client } = makeClient(() => ({
+      status: 404,
+      body: { success: false, message: 'Not found' },
+    }));
+    await expect(discover.run([], {}, { client })).rejects.toThrow(/Discovery is not enabled/);
+  });
+
+  it('info <name> calls /discovery/servers/:name', async () => {
+    const { client, calls } = makeClient(() => ({
+      body: { success: true, data: { name: 'amap-maps' } },
+    }));
+    await discover.run(['info', 'amap-maps'], {}, { client });
+    expect(calls[0]).toBe('http://hub.test/discovery/servers/amap-maps');
+  });
+
+  it('categories subcommand hits /discovery/categories', async () => {
+    const { client, calls } = makeClient(() => ({ body: { success: true, data: ['dev'] } }));
+    await discover.run(['categories'], {}, { client });
+    expect(calls[0]).toBe('http://hub.test/discovery/categories');
+  });
+});

--- a/tests/cli/commands/export.test.ts
+++ b/tests/cli/commands/export.test.ts
@@ -1,0 +1,46 @@
+import * as exportCmd from '../../../src/cli/commands/export.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+function fakeClient(body: unknown): ApiClient {
+  const fetchImpl = (async () =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response)) as unknown as typeof fetch;
+  return new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl });
+}
+
+describe('export command', () => {
+  it('--out writes JSON to the given path', async () => {
+    const writes: Array<{ path: string; data: string }> = [];
+    const client = fakeClient({ mcpServers: { a: { command: 'npx' } } });
+    await exportCmd.run(['--out', '/tmp/backup.json'], {}, {
+      client,
+      fs: {
+        writeFileSync: (p: any, d: any) => {
+          writes.push({ path: String(p), data: String(d) });
+        },
+      } as any,
+    });
+    expect(writes).toHaveLength(1);
+    expect(writes[0].path).toBe('/tmp/backup.json');
+    expect(JSON.parse(writes[0].data)).toEqual({ mcpServers: { a: { command: 'npx' } } });
+  });
+
+  it('without --out prints pretty JSON to stdout', async () => {
+    const client = fakeClient({ mcpServers: {} });
+    const writes: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (chunk: any) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await exportCmd.run([], {}, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    expect(writes.join('')).toMatch(/"mcpServers"/);
+  });
+});

--- a/tests/cli/commands/groups.test.ts
+++ b/tests/cli/commands/groups.test.ts
@@ -1,0 +1,92 @@
+import * as groups from '../../../src/cli/commands/groups.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+type Captured = { method: string; url: string; body?: any };
+
+function makeClient(
+  responder: (req: Captured) => any,
+): { client: ApiClient; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl = (async (url: any, init: any) => {
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    const captured: Captured = { method: init.method, url: String(url), body };
+    calls.push(captured);
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(responder(captured) ?? { success: true }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { client: new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl }), calls };
+}
+
+const sampleGroups = [
+  { id: 'uuid-1', name: 'dev', servers: ['a', 'b'], description: '' },
+  { id: 'uuid-2', name: 'prod', servers: [], description: 'prod servers' },
+];
+
+describe('groups command', () => {
+  it('list calls GET /api/groups', async () => {
+    const { client, calls } = makeClient(() => ({ success: true, data: sampleGroups }));
+    await groups.run(['list'], {}, { client });
+    expect(calls[0].url).toBe('http://hub.test/api/groups');
+  });
+
+  it('add posts name + description', async () => {
+    const { client, calls } = makeClient(() => ({
+      success: true,
+      data: { id: 'new-id', name: 'x', servers: [] },
+    }));
+    await groups.run(['add', 'x', '--description', 'a desc'], {}, { client });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].body).toEqual({ name: 'x', description: 'a desc' });
+  });
+
+  it('get by name resolves to UUID via list', async () => {
+    const { client, calls } = makeClient((req) => {
+      if (req.url.endsWith('/api/groups')) {
+        return { success: true, data: sampleGroups };
+      }
+      return { success: true, data: sampleGroups[0] };
+    });
+    await groups.run(['get', 'dev'], {}, { client });
+    expect(calls.map((c) => c.url)).toEqual([
+      'http://hub.test/api/groups',
+      'http://hub.test/api/groups/uuid-1',
+    ]);
+  });
+
+  it('add-server posts to /servers under resolved group', async () => {
+    const { client, calls } = makeClient((req) => {
+      if (req.url.endsWith('/api/groups')) {
+        return { success: true, data: sampleGroups };
+      }
+      return { success: true };
+    });
+    await groups.run(['add-server', 'prod', 'srv-1'], {}, { client });
+    expect(calls[1]).toMatchObject({
+      method: 'POST',
+      url: 'http://hub.test/api/groups/uuid-2/servers',
+      body: { serverName: 'srv-1' },
+    });
+  });
+
+  it('remove-server deletes by resolved id and server name', async () => {
+    const { client, calls } = makeClient((req) => {
+      if (req.url.endsWith('/api/groups')) {
+        return { success: true, data: sampleGroups };
+      }
+      return { success: true };
+    });
+    await groups.run(['remove-server', 'prod', 'srv-2'], {}, { client });
+    expect(calls[1]).toMatchObject({
+      method: 'DELETE',
+      url: 'http://hub.test/api/groups/uuid-2/servers/srv-2',
+    });
+  });
+
+  it('resolveGroupId throws for unknown group ref', async () => {
+    const { client } = makeClient(() => ({ success: true, data: [] }));
+    await expect(groups.run(['get', 'missing'], {}, { client })).rejects.toThrow(/Group not found/);
+  });
+});

--- a/tests/cli/commands/install.test.ts
+++ b/tests/cli/commands/install.test.ts
@@ -1,0 +1,141 @@
+import * as install from '../../../src/cli/commands/install.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+type Captured = { method: string; url: string; body?: any };
+
+function makeClient(
+  handler: (req: Captured) => { status?: number; body?: unknown },
+): { client: ApiClient; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl = (async (url: any, init: any) => {
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    const captured: Captured = { method: init.method, url: String(url), body };
+    calls.push(captured);
+    const { status = 200, body: respBody } = handler(captured);
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => (respBody !== undefined ? JSON.stringify(respBody) : ''),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { client: new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl }), calls };
+}
+
+const INSTALL_RESPONSE = {
+  success: true,
+  data: {
+    name: 'amap-maps',
+    installationType: 'npm',
+    availableTypes: ['npm', 'docker'],
+    mcpServers: {
+      'amap-maps': {
+        command: 'npx',
+        args: ['-y', '@amap/mcp-server-amap'],
+        env: { AMAP_MAPS_API_KEY: '<your-api-key>' },
+      },
+    },
+    arguments: {
+      AMAP_MAPS_API_KEY: { description: 'AMap API key', required: true, example: '<your-api-key>' },
+    },
+  },
+};
+
+describe('install command', () => {
+  it('--dry-run prints snippet to stdout without writing anywhere', async () => {
+    const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
+    const writes: string[] = [];
+    const origWrite = process.stdout.write;
+    (process.stdout as any).write = (chunk: any) => {
+      writes.push(String(chunk));
+      return true;
+    };
+    try {
+      await install.run(
+        ['amap-maps', '--dry-run', '--env', 'AMAP_MAPS_API_KEY=abc'],
+        {},
+        { sourceClient: source },
+      );
+    } finally {
+      (process.stdout as any).write = origWrite;
+    }
+    const json = JSON.parse(writes.join('').trim());
+    expect(json.mcpServers['amap-maps'].env.AMAP_MAPS_API_KEY).toBe('abc');
+  });
+
+  it('--to hub POSTs the resolved snippet to /api/servers', async () => {
+    const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
+    const { client: dest, calls: destCalls } = makeClient(() => ({
+      body: { success: true },
+    }));
+    await install.run(
+      ['amap-maps', '--to', 'hub', '--env', 'AMAP_MAPS_API_KEY=secret'],
+      {},
+      { sourceClient: source, destClient: dest },
+    );
+    expect(destCalls[0]).toMatchObject({
+      method: 'POST',
+      url: 'http://hub.test/api/servers',
+    });
+    expect(destCalls[0].body.name).toBe('amap-maps');
+    expect(destCalls[0].body.config.command).toBe('npx');
+    expect(destCalls[0].body.config.env.AMAP_MAPS_API_KEY).toBe('secret');
+  });
+
+  it('--to file merges into existing mcpServers JSON', async () => {
+    const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
+    let written: { path: string; data: string } | undefined;
+    const fakeFs = {
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify({ mcpServers: { other: { command: 'foo' } } }),
+      writeFileSync: (p: any, d: any) => {
+        written = { path: String(p), data: String(d) };
+      },
+    } as any;
+    await install.run(
+      ['amap-maps', '--to', 'file', '--out', '/tmp/claude.json', '--env', 'AMAP_MAPS_API_KEY=k'],
+      {},
+      { sourceClient: source, fs: fakeFs },
+    );
+    expect(written?.path).toBe('/tmp/claude.json');
+    const merged = JSON.parse(written!.data);
+    expect(merged.mcpServers.other).toEqual({ command: 'foo' });
+    expect(merged.mcpServers['amap-maps']).toBeDefined();
+  });
+
+  it('--to file refuses to overwrite without --force', async () => {
+    const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
+    const fakeFs = {
+      existsSync: () => true,
+      readFileSync: () => JSON.stringify({ mcpServers: { 'amap-maps': { command: 'old' } } }),
+      writeFileSync: () => {
+        throw new Error('should not be called');
+      },
+    } as any;
+    await expect(
+      install.run(
+        ['amap-maps', '--to', 'file', '--out', '/tmp/claude.json', '--env', 'AMAP_MAPS_API_KEY=k'],
+        {},
+        { sourceClient: source, fs: fakeFs },
+      ),
+    ).rejects.toThrow(/Pass --force/);
+  });
+
+  it('--yes with missing required env throws with actionable message', async () => {
+    const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
+    await expect(
+      install.run(['amap-maps', '--to', 'stdout', '--yes'], {}, { sourceClient: source }),
+    ).rejects.toThrow(/Missing required env values: AMAP_MAPS_API_KEY/);
+  });
+
+  it('surfaces "no <type> installation" 404 from the marketplace', async () => {
+    const { client: source } = makeClient(() => ({
+      status: 404,
+      body: { success: false, message: "Server has no 'docker' installation method" },
+    }));
+    await expect(
+      install.run(['amap-maps', '--type', 'docker', '--to', 'stdout', '--yes'], {}, {
+        sourceClient: source,
+      }),
+    ).rejects.toThrow(/no 'docker' installation method/);
+  });
+});

--- a/tests/cli/commands/install.test.ts
+++ b/tests/cli/commands/install.test.ts
@@ -81,14 +81,18 @@ describe('install command', () => {
     expect(destCalls[0].body.config.env.AMAP_MAPS_API_KEY).toBe('secret');
   });
 
-  it('--to file merges into existing mcpServers JSON', async () => {
+  it('--to file merges into existing mcpServers JSON and writes atomically', async () => {
     const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
-    let written: { path: string; data: string } | undefined;
+    let lastWrite: { path: string; data: string } | undefined;
+    let lastRename: { from: string; to: string } | undefined;
     const fakeFs = {
       existsSync: () => true,
       readFileSync: () => JSON.stringify({ mcpServers: { other: { command: 'foo' } } }),
       writeFileSync: (p: any, d: any) => {
-        written = { path: String(p), data: String(d) };
+        lastWrite = { path: String(p), data: String(d) };
+      },
+      renameSync: (from: any, to: any) => {
+        lastRename = { from: String(from), to: String(to) };
       },
     } as any;
     await install.run(
@@ -96,8 +100,10 @@ describe('install command', () => {
       {},
       { sourceClient: source, fs: fakeFs },
     );
-    expect(written?.path).toBe('/tmp/claude.json');
-    const merged = JSON.parse(written!.data);
+    // Write goes to a temp file, then rename to the final path.
+    expect(lastWrite?.path).toMatch(/^\/tmp\/claude\.json\.tmp\./);
+    expect(lastRename).toEqual({ from: lastWrite?.path, to: '/tmp/claude.json' });
+    const merged = JSON.parse(lastWrite!.data);
     expect(merged.mcpServers.other).toEqual({ command: 'foo' });
     expect(merged.mcpServers['amap-maps']).toBeDefined();
   });
@@ -110,6 +116,9 @@ describe('install command', () => {
       writeFileSync: () => {
         throw new Error('should not be called');
       },
+      renameSync: () => {
+        throw new Error('should not be called');
+      },
     } as any;
     await expect(
       install.run(
@@ -118,6 +127,30 @@ describe('install command', () => {
         { sourceClient: source, fs: fakeFs },
       ),
     ).rejects.toThrow(/Pass --force/);
+  });
+
+  it('--env merges additional keys not declared by the marketplace', async () => {
+    const { client: source } = makeClient(() => ({ body: INSTALL_RESPONSE }));
+    const { client: dest, calls: destCalls } = makeClient(() => ({
+      body: { success: true },
+    }));
+    await install.run(
+      [
+        'amap-maps',
+        '--to',
+        'hub',
+        '--env',
+        'AMAP_MAPS_API_KEY=secret',
+        '--env',
+        'DEBUG=1',
+      ],
+      {},
+      { sourceClient: source, destClient: dest },
+    );
+    expect(destCalls[0].body.config.env).toEqual({
+      AMAP_MAPS_API_KEY: 'secret',
+      DEBUG: '1',
+    });
   });
 
   it('--yes with missing required env throws with actionable message', async () => {

--- a/tests/cli/commands/keys.test.ts
+++ b/tests/cli/commands/keys.test.ts
@@ -1,0 +1,79 @@
+import * as keys from '../../../src/cli/commands/keys.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+type Captured = { method: string; url: string; body?: any };
+
+function makeClient(
+  responder: (req: Captured) => any,
+): { client: ApiClient; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl = (async (url: any, init: any) => {
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    const captured: Captured = { method: init.method, url: String(url), body };
+    calls.push(captured);
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(responder(captured) ?? { success: true }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { client: new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl }), calls };
+}
+
+describe('keys command', () => {
+  it('list calls GET /api/auth/keys', async () => {
+    const { client, calls } = makeClient(() => ({
+      success: true,
+      data: [{ id: '1', name: 'ci', enabled: true, accessType: 'all', token: 'abc12345' }],
+    }));
+    await keys.run(['list'], {}, { client });
+    expect(calls[0]).toMatchObject({ method: 'GET', url: 'http://hub.test/api/auth/keys' });
+  });
+
+  it('create posts name and default access-type all', async () => {
+    const { client, calls } = makeClient(() => ({
+      success: true,
+      data: { id: 'new-id', name: 'ci', token: 'fresh-token' },
+    }));
+    await keys.run(['create', '--name', 'ci'], {}, { client });
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: 'http://hub.test/api/auth/keys',
+      body: { name: 'ci', enabled: true, accessType: 'all' },
+    });
+  });
+
+  it('create with --access-type groups and --groups parses CSV', async () => {
+    const { client, calls } = makeClient(() => ({
+      success: true,
+      data: { id: 'x', name: 'g-only' },
+    }));
+    await keys.run(
+      ['create', '--name', 'g-only', '--access-type', 'groups', '--groups', 'dev, prod'],
+      {},
+      { client },
+    );
+    expect(calls[0].body).toEqual({
+      name: 'g-only',
+      enabled: true,
+      accessType: 'groups',
+      allowedGroups: ['dev', 'prod'],
+    });
+  });
+
+  it('create with invalid --access-type throws CliUsageError', async () => {
+    const { client } = makeClient(() => ({}));
+    await expect(
+      keys.run(['create', '--name', 'x', '--access-type', 'bogus'], {}, { client }),
+    ).rejects.toThrow(/Invalid --access-type/);
+  });
+
+  it('delete calls DELETE /api/auth/keys/:id', async () => {
+    const { client, calls } = makeClient(() => ({ success: true }));
+    await keys.run(['delete', 'abc'], {}, { client });
+    expect(calls[0]).toMatchObject({
+      method: 'DELETE',
+      url: 'http://hub.test/api/auth/keys/abc',
+    });
+  });
+});

--- a/tests/cli/commands/login.test.ts
+++ b/tests/cli/commands/login.test.ts
@@ -1,0 +1,93 @@
+import * as login from '../../../src/cli/commands/login.js';
+import { ApiClient } from '../../../src/cli/http.js';
+import { Credentials } from '../../../src/cli/profile.js';
+
+function fakeClient(response: unknown): ApiClient {
+  const fetchImpl = (async () =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(response),
+    } as unknown as Response)) as unknown as typeof fetch;
+  return new ApiClient({ baseUrl: 'http://hub.test', fetchImpl });
+}
+
+function fakeDeps(initial: Credentials, opts: { response?: unknown; prompts?: any } = {}) {
+  const state: { saved?: Credentials } = {};
+  const deps: login.LoginDeps = {
+    loadCreds: () => initial,
+    saveCreds: (c) => {
+      state.saved = c;
+    },
+    createClient: () => fakeClient(opts.response ?? {
+      success: true,
+      token: 'fresh-jwt',
+      user: { username: 'admin', isAdmin: true },
+    }),
+    prompts: opts.prompts ?? {
+      line: async () => '',
+      password: async () => 'unused',
+    },
+  };
+  return { deps, state };
+}
+
+describe('login command', () => {
+  it('logs in with --url --username --password, saves a JWT profile', async () => {
+    const { deps, state } = fakeDeps({ current: '', profiles: {} });
+    await login.run(
+      ['--url', 'http://hub.test', '--username', 'admin', '--password', 'admin123'],
+      {},
+      deps,
+    );
+    expect(state.saved?.profiles.default).toMatchObject({
+      url: 'http://hub.test',
+      tokenKind: 'jwt',
+      token: 'fresh-jwt',
+      username: 'admin',
+    });
+    expect(state.saved?.current).toBe('default');
+  });
+
+  it('saves under a named profile when --profile is provided via globals', async () => {
+    const { deps, state } = fakeDeps({ current: '', profiles: {} });
+    await login.run(
+      ['--url', 'http://hub.test', '--username', 'admin', '--password', 'admin123'],
+      { profile: 'staging' },
+      deps,
+    );
+    expect(state.saved?.profiles.staging).toBeDefined();
+    expect(state.saved?.current).toBe('staging');
+  });
+
+  it('throws when password is missing and prompt returns empty', async () => {
+    const { deps } = fakeDeps(
+      { current: '', profiles: {} },
+      {
+        prompts: { line: async () => '', password: async () => '' },
+      },
+    );
+    await expect(
+      login.run(['--url', 'http://hub.test', '--username', 'admin'], {}, deps),
+    ).rejects.toThrow(/Password is required/);
+  });
+
+  it('logout clears the token but keeps url and username', async () => {
+    const initial: Credentials = {
+      current: 'default',
+      profiles: {
+        default: {
+          url: 'http://hub.test',
+          tokenKind: 'jwt',
+          token: 'old',
+          username: 'admin',
+        },
+      },
+    };
+    const { deps, state } = fakeDeps(initial);
+    await login.logout([], {}, deps);
+    expect(state.saved?.profiles.default.token).toBeUndefined();
+    expect(state.saved?.profiles.default.url).toBe('http://hub.test');
+    expect(state.saved?.profiles.default.username).toBe('admin');
+  });
+});

--- a/tests/cli/commands/servers.test.ts
+++ b/tests/cli/commands/servers.test.ts
@@ -81,6 +81,32 @@ describe('servers command', () => {
     });
   });
 
+  it('add inline preserves --arg values that look like flags', async () => {
+    // Regression: collectRepeated used to skip values starting with "--", which
+    // broke wrapped CLIs (`python --arg --version`). Now we consume the value
+    // verbatim and advance past it.
+    const { client, calls } = makeClient(() => ({ success: true, data: {} }));
+    await servers.run(
+      [
+        'add',
+        'wrapped',
+        '--type',
+        'stdio',
+        '--command',
+        'python',
+        '--arg',
+        '--version',
+        '--arg',
+        '-m',
+        '--arg',
+        'pkg',
+      ],
+      {},
+      { client },
+    );
+    expect(calls[0].body.config.args).toEqual(['--version', '-m', 'pkg']);
+  });
+
   it('remove calls DELETE with URL-encoded name', async () => {
     const { client, calls } = makeClient(() => ({ success: true }));
     await servers.run(['remove', 'my server'], {}, { client });

--- a/tests/cli/commands/servers.test.ts
+++ b/tests/cli/commands/servers.test.ts
@@ -1,0 +1,116 @@
+import * as servers from '../../../src/cli/commands/servers.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+type Captured = { method: string; url: string; body?: any };
+
+function makeClient(handler: (req: Captured) => any): { client: ApiClient; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl = (async (url: any, init: any) => {
+    const body = init?.body ? JSON.parse(init.body) : undefined;
+    const captured: Captured = { method: init.method, url: String(url), body };
+    calls.push(captured);
+    const result = handler(captured);
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(result ?? { success: true }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { client: new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl }), calls };
+}
+
+describe('servers command', () => {
+  it('list calls GET /api/servers and prints table', async () => {
+    const { client, calls } = makeClient(() => ({
+      success: true,
+      data: [
+        { name: 'a', status: 'connected', tools: [{}, {}], owner: 'admin', error: null },
+        { name: 'b', status: 'disconnected', tools: [], owner: 'admin', error: 'oops' },
+      ],
+    }));
+    await servers.run(['list'], {}, { client });
+    expect(calls).toEqual([{ method: 'GET', url: 'http://hub.test/api/servers', body: undefined }]);
+  });
+
+  it('add --from-file POSTs the parsed JSON', async () => {
+    const { client, calls } = makeClient(() => ({ success: true, data: {} }));
+    const fakeFs = {
+      readFileSync: () =>
+        JSON.stringify({ type: 'stdio', command: 'npx', args: ['-y', 'foo'] }),
+    } as any;
+    await servers.run(['add', 'foo', '--from-file', '/tmp/foo.json'], {}, {
+      client,
+      fs: fakeFs,
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe('http://hub.test/api/servers');
+    expect(calls[0].body).toEqual({
+      name: 'foo',
+      config: { type: 'stdio', command: 'npx', args: ['-y', 'foo'] },
+    });
+  });
+
+  it('add inline collects repeated --arg and --env entries', async () => {
+    const { client, calls } = makeClient(() => ({ success: true, data: {} }));
+    await servers.run(
+      [
+        'add',
+        'foo',
+        '--type',
+        'stdio',
+        '--command',
+        'npx',
+        '--arg',
+        '-y',
+        '--arg',
+        'pkg',
+        '--env',
+        'KEY=A',
+        '--env',
+        'OTHER=B',
+      ],
+      {},
+      { client },
+    );
+    expect(calls[0].body.config).toMatchObject({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'pkg'],
+      env: { KEY: 'A', OTHER: 'B' },
+      enabled: true,
+    });
+  });
+
+  it('remove calls DELETE with URL-encoded name', async () => {
+    const { client, calls } = makeClient(() => ({ success: true }));
+    await servers.run(['remove', 'my server'], {}, { client });
+    expect(calls[0]).toMatchObject({
+      method: 'DELETE',
+      url: 'http://hub.test/api/servers/my%20server',
+    });
+  });
+
+  it('toggle --on includes enabled:true', async () => {
+    const { client, calls } = makeClient(() => ({ success: true }));
+    await servers.run(['toggle', 'foo', '--on'], {}, { client });
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: 'http://hub.test/api/servers/foo/toggle',
+      body: { enabled: true },
+    });
+  });
+
+  it('reload POSTs an empty body to /reload', async () => {
+    const { client, calls } = makeClient(() => ({ success: true }));
+    await servers.run(['reload', 'foo'], {}, { client });
+    expect(calls[0]).toMatchObject({
+      method: 'POST',
+      url: 'http://hub.test/api/servers/foo/reload',
+    });
+  });
+
+  it('unknown subcommand throws', async () => {
+    const { client } = makeClient(() => ({}));
+    await expect(servers.run(['bogus'], {}, { client })).rejects.toThrow(/Unknown servers/);
+  });
+});

--- a/tests/cli/commands/tools.test.ts
+++ b/tests/cli/commands/tools.test.ts
@@ -55,30 +55,7 @@ const SERVERS_RESPONSE = {
   ],
 };
 
-function captureStdout(fn: () => Promise<void>) {
-  const orig = process.stdout.write;
-  const captured: string[] = [];
-  (process.stdout as any).write = (chunk: any) => {
-    captured.push(String(chunk));
-    return true;
-  };
-  return fn().finally(() => {
-    (process.stdout as any).write = orig;
-  });
-}
-
 describe('tools command', () => {
-  it('list flattens tools across servers (table mode)', async () => {
-    const client = makeClient(SERVERS_RESPONSE);
-    let output = '';
-    await captureStdout(async () => {
-      await tools.run(['list'], {}, { client });
-    }).then(() => { /* no-op */ });
-    // captureStdout returns void; we need to grab via separate approach.
-    // Simpler: just rely on --json mode for assertion below.
-    void output;
-  });
-
   it('list --json returns the flattened tools without schemas by default', async () => {
     const client = makeClient(SERVERS_RESPONSE);
     const captured: string[] = [];

--- a/tests/cli/commands/tools.test.ts
+++ b/tests/cli/commands/tools.test.ts
@@ -1,0 +1,219 @@
+import * as tools from '../../../src/cli/commands/tools.js';
+import { ApiClient } from '../../../src/cli/http.js';
+
+function makeClient(body: unknown) {
+  const fetchImpl = (async () =>
+    ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(body),
+    } as unknown as Response)) as unknown as typeof fetch;
+  return new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl });
+}
+
+const SERVERS_RESPONSE = {
+  success: true,
+  data: [
+    {
+      name: 'fetch',
+      status: 'connected',
+      tools: [
+        {
+          name: 'fetch_url',
+          description: 'Fetch a URL',
+          enabled: true,
+          inputSchema: {
+            type: 'object',
+            properties: {
+              url: { type: 'string', description: 'Target URL' },
+              timeout: { type: 'number', description: 'Timeout in ms' },
+            },
+            required: ['url'],
+          },
+        },
+      ],
+    },
+    {
+      name: 'time',
+      status: 'connected',
+      tools: [
+        {
+          name: 'current_time',
+          description: 'Current time',
+          enabled: true,
+          inputSchema: { type: 'object', properties: {} },
+        },
+        {
+          // Same tool name as fetch.fetch_url — disambiguation case.
+          name: 'fetch_url',
+          description: 'Fetch a URL (time-version)',
+          enabled: false,
+          inputSchema: { type: 'object', properties: {} },
+        },
+      ],
+    },
+  ],
+};
+
+function captureStdout(fn: () => Promise<void>) {
+  const orig = process.stdout.write;
+  const captured: string[] = [];
+  (process.stdout as any).write = (chunk: any) => {
+    captured.push(String(chunk));
+    return true;
+  };
+  return fn().finally(() => {
+    (process.stdout as any).write = orig;
+  });
+}
+
+describe('tools command', () => {
+  it('list flattens tools across servers (table mode)', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    let output = '';
+    await captureStdout(async () => {
+      await tools.run(['list'], {}, { client });
+    }).then(() => { /* no-op */ });
+    // captureStdout returns void; we need to grab via separate approach.
+    // Simpler: just rely on --json mode for assertion below.
+    void output;
+  });
+
+  it('list --json returns the flattened tools without schemas by default', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['list'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed).toEqual([
+      { server: 'fetch', serverStatus: 'connected', name: 'fetch_url', description: 'Fetch a URL', enabled: true },
+      { server: 'time', serverStatus: 'connected', name: 'current_time', description: 'Current time', enabled: true },
+      { server: 'time', serverStatus: 'connected', name: 'fetch_url', description: 'Fetch a URL (time-version)', enabled: false },
+    ]);
+  });
+
+  it('list --schema includes the inputSchema field', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['list', '--schema'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed[0].inputSchema).toBeDefined();
+  });
+
+  it('list --server filters to one server', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['list', '--server', 'fetch'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed.every((t: any) => t.server === 'fetch')).toBe(true);
+  });
+
+  it('list --enabled-only drops disabled tools', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['list', '--enabled-only'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed.find((t: any) => t.name === 'fetch_url' && t.server === 'time')).toBeUndefined();
+  });
+
+  it('get <name> returns the tool with schema when a single match exists', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['get', 'current_time'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed.name).toBe('current_time');
+    expect(parsed.server).toBe('time');
+    expect(parsed.inputSchema).toBeDefined();
+  });
+
+  it('get errors helpfully when the tool name is ambiguous', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    await expect(tools.run(['get', 'fetch_url'], {}, { client })).rejects.toThrow(
+      /exists on multiple servers \(fetch, time\)/,
+    );
+  });
+
+  it('get --server disambiguates', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['get', 'fetch_url', '--server', 'fetch'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed.server).toBe('fetch');
+    expect(parsed.inputSchema.required).toEqual(['url']);
+  });
+
+  it('get on a missing tool suggests `tools list`', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    await expect(tools.run(['get', 'nosuch'], {}, { client })).rejects.toThrow(/mcphub tools list/);
+  });
+
+  it('schema is an alias for get', async () => {
+    const client = makeClient(SERVERS_RESPONSE);
+    const captured: string[] = [];
+    const orig = process.stdout.write;
+    (process.stdout as any).write = (c: any) => {
+      captured.push(String(c));
+      return true;
+    };
+    try {
+      await tools.run(['schema', 'current_time'], { json: true }, { client });
+    } finally {
+      (process.stdout as any).write = orig;
+    }
+    const parsed = JSON.parse(captured.join(''));
+    expect(parsed.name).toBe('current_time');
+  });
+});

--- a/tests/cli/http.test.ts
+++ b/tests/cli/http.test.ts
@@ -1,0 +1,129 @@
+import { ApiClient } from '../../src/cli/http.js';
+import { CliApiError } from '../../src/cli/errors.js';
+
+type FetchCall = {
+  url: string;
+  init: RequestInit;
+};
+
+function mockFetch(response: {
+  status?: number;
+  body?: unknown;
+  text?: string;
+}): { fn: typeof fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fn = (async (url: any, init: any) => {
+    calls.push({ url: String(url), init });
+    const status = response.status ?? 200;
+    const text =
+      response.text !== undefined
+        ? response.text
+        : response.body !== undefined
+        ? JSON.stringify(response.body)
+        : '';
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => text,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { fn, calls };
+}
+
+describe('ApiClient', () => {
+  it('injects x-auth-token for JWT tokens', async () => {
+    const { fn, calls } = mockFetch({ body: { ok: true } });
+    const client = new ApiClient({
+      baseUrl: 'http://hub.test',
+      token: 'jwt-abc',
+      tokenKind: 'jwt',
+      fetchImpl: fn,
+    });
+    await client.get('/api/servers');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://hub.test/api/servers');
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['x-auth-token']).toBe('jwt-abc');
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('injects Authorization: Bearer for bearer-kind tokens', async () => {
+    const { fn, calls } = mockFetch({ body: { ok: true } });
+    const client = new ApiClient({
+      baseUrl: 'http://hub.test/',
+      token: 'bearer-xyz',
+      tokenKind: 'bearer',
+      fetchImpl: fn,
+    });
+    await client.post('/api/servers', { name: 'a' });
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer bearer-xyz');
+    expect(headers['x-auth-token']).toBeUndefined();
+    expect(headers['Content-Type']).toBe('application/json');
+    expect(calls[0].init.body).toBe(JSON.stringify({ name: 'a' }));
+  });
+
+  it('strips trailing slash from baseUrl', async () => {
+    const { fn, calls } = mockFetch({ body: {} });
+    const client = new ApiClient({ baseUrl: 'http://hub.test/', fetchImpl: fn });
+    await client.get('/api/servers');
+    expect(calls[0].url).toBe('http://hub.test/api/servers');
+  });
+
+  it('throws CliApiError on non-2xx and parses message from JSON body', async () => {
+    const { fn } = mockFetch({
+      status: 403,
+      body: { success: false, message: 'forbidden' },
+    });
+    const client = new ApiClient({ baseUrl: 'http://hub.test', fetchImpl: fn });
+    await expect(client.get('/api/servers')).rejects.toMatchObject({
+      name: 'CliApiError',
+      status: 403,
+      message: 'forbidden',
+    });
+  });
+
+  it('flags 401 errors as requiresLogin', async () => {
+    const { fn } = mockFetch({
+      status: 401,
+      body: { success: false, message: 'No token, authorization denied' },
+    });
+    const client = new ApiClient({ baseUrl: 'http://hub.test', fetchImpl: fn });
+    let caught: unknown;
+    try {
+      await client.get('/api/servers');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(CliApiError);
+    expect((caught as CliApiError).requiresLogin).toBe(true);
+  });
+
+  it('falls back to a synthetic message when body has none', async () => {
+    const { fn } = mockFetch({ status: 500, text: 'oops' });
+    const client = new ApiClient({ baseUrl: 'http://hub.test', fetchImpl: fn });
+    await expect(client.get('/api/servers')).rejects.toThrow(/oops/);
+  });
+
+  it('omits auth headers when no token is configured', async () => {
+    const { fn, calls } = mockFetch({ body: {} });
+    const client = new ApiClient({ baseUrl: 'http://hub.test', fetchImpl: fn });
+    await client.get('/discovery/servers');
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers['x-auth-token']).toBeUndefined();
+    expect(headers.Authorization).toBeUndefined();
+  });
+
+  it('mcpCall routes to /mcp and /mcp/<group>', async () => {
+    const { fn, calls } = mockFetch({ body: { jsonrpc: '2.0' } });
+    const client = new ApiClient({ baseUrl: 'http://hub.test', token: 't', fetchImpl: fn });
+    await client.mcpCall(null, { method: 'tools/call' });
+    await client.mcpCall('$smart', { method: 'tools/call' });
+    await client.mcpCall('my-group', { method: 'tools/call' });
+    expect(calls.map((c) => c.url)).toEqual([
+      'http://hub.test/mcp',
+      'http://hub.test/mcp/%24smart',
+      'http://hub.test/mcp/my-group',
+    ]);
+  });
+});

--- a/tests/cli/parse-args.test.ts
+++ b/tests/cli/parse-args.test.ts
@@ -1,0 +1,60 @@
+import { extractFlags, parseGlobalFlags } from '../../src/cli/parse-args.js';
+import { CliUsageError } from '../../src/cli/errors.js';
+
+describe('parseGlobalFlags', () => {
+  it('extracts valued flags and leaves the subcommand intact', () => {
+    const { globalFlags, rest } = parseGlobalFlags([
+      '--url',
+      'http://hub.test',
+      '--token',
+      'xyz',
+      'servers',
+      'list',
+    ]);
+    expect(globalFlags).toMatchObject({ url: 'http://hub.test', token: 'xyz' });
+    expect(rest).toEqual(['servers', 'list']);
+  });
+
+  it('parses boolean flags and --flag=value form', () => {
+    const { globalFlags, rest } = parseGlobalFlags([
+      '--bearer',
+      '--profile=prod',
+      '--json',
+      'servers',
+    ]);
+    expect(globalFlags.bearer).toBe(true);
+    expect(globalFlags.profile).toBe('prod');
+    expect(globalFlags.json).toBe(true);
+    expect(rest).toEqual(['servers']);
+  });
+
+  it('throws CliUsageError when a valued flag is missing its value', () => {
+    expect(() => parseGlobalFlags(['--url'])).toThrow(CliUsageError);
+  });
+
+  it('passes unknown flags through to rest for subcommand parsing', () => {
+    const { rest } = parseGlobalFlags(['servers', 'add', '--from-file', 'x.json']);
+    expect(rest).toEqual(['servers', 'add', '--from-file', 'x.json']);
+  });
+});
+
+describe('extractFlags', () => {
+  it('separates positional args from valued and boolean flags', () => {
+    const { positional, flags } = extractFlags(
+      ['list', '--limit', '10', '--json', 'foo'],
+      { valued: ['--limit'], boolean: ['--json'] },
+    );
+    expect(positional).toEqual(['list', 'foo']);
+    expect(flags['--limit']).toBe('10');
+    expect(flags['--json']).toBe(true);
+  });
+
+  it('supports --name=value form', () => {
+    const { flags } = extractFlags(['--limit=5'], { valued: ['--limit'] });
+    expect(flags['--limit']).toBe('5');
+  });
+
+  it('throws when a valued flag has no value', () => {
+    expect(() => extractFlags(['--limit'], { valued: ['--limit'] })).toThrow(CliUsageError);
+  });
+});

--- a/tests/cli/profile.test.ts
+++ b/tests/cli/profile.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  configPath,
+  credentialsPath,
+  deleteProfile,
+  getProfile,
+  loadCredentials,
+  saveCredentials,
+  setCurrentProfile,
+  setProfile,
+} from '../../src/cli/profile.js';
+
+describe('profile / credentials', () => {
+  let tmpRoot: string;
+  let originalXdgData: string | undefined;
+  let originalXdgConfig: string | undefined;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mcphub-cli-'));
+    originalXdgData = process.env.XDG_DATA_HOME;
+    originalXdgConfig = process.env.XDG_CONFIG_HOME;
+    originalHome = process.env.HOME;
+    process.env.XDG_DATA_HOME = path.join(tmpRoot, 'data');
+    process.env.XDG_CONFIG_HOME = path.join(tmpRoot, 'config');
+    // Point HOME away from the real one so the legacy ~/.mcphub fallback
+    // can't accidentally pick up the developer's real credentials.
+    process.env.HOME = tmpRoot;
+  });
+
+  afterEach(() => {
+    process.env.XDG_DATA_HOME = originalXdgData;
+    process.env.XDG_CONFIG_HOME = originalXdgConfig;
+    process.env.HOME = originalHome;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns empty credentials when no file exists', () => {
+    const creds = loadCredentials();
+    expect(creds).toEqual({ current: '', profiles: {} });
+  });
+
+  it('resolves XDG paths via env vars', () => {
+    expect(credentialsPath()).toBe(path.join(tmpRoot, 'data', 'mcphub', 'credentials.json'));
+    expect(configPath()).toBe(path.join(tmpRoot, 'config', 'mcphub', 'config.json'));
+  });
+
+  it('prefers legacy ~/.mcphub/credentials.json when it already exists', () => {
+    const legacy = path.join(tmpRoot, '.mcphub');
+    fs.mkdirSync(legacy, { recursive: true });
+    const legacyFile = path.join(legacy, 'credentials.json');
+    fs.writeFileSync(legacyFile, JSON.stringify({ current: 'legacy', profiles: {} }));
+    expect(credentialsPath()).toBe(legacyFile);
+  });
+
+  it('saves and reloads credentials with 0600 permissions on POSIX', () => {
+    const before = loadCredentials();
+    const next = setProfile(before, 'default', {
+      url: 'http://hub.test',
+      tokenKind: 'jwt',
+      token: 'abc',
+      username: 'admin',
+    });
+    saveCredentials(next);
+
+    const reloaded = loadCredentials();
+    expect(reloaded.current).toBe('default');
+    expect(reloaded.profiles.default.token).toBe('abc');
+    expect(reloaded.profiles.default.savedAt).toBeDefined();
+
+    if (process.platform !== 'win32') {
+      const stat = fs.statSync(credentialsPath());
+      expect((stat.mode & 0o777).toString(8)).toBe('600');
+    }
+  });
+
+  it('setProfile keeps existing current; first profile becomes current automatically', () => {
+    const empty = loadCredentials();
+    const a = setProfile(empty, 'a', { url: 'http://a' });
+    expect(a.current).toBe('a');
+    const b = setProfile(a, 'b', { url: 'http://b' });
+    expect(b.current).toBe('a');
+  });
+
+  it('setCurrentProfile throws when target does not exist', () => {
+    expect(() => setCurrentProfile({ current: '', profiles: {} }, 'nope')).toThrow();
+  });
+
+  it('deleteProfile removes the profile and falls back current pointer', () => {
+    let creds = loadCredentials();
+    creds = setProfile(creds, 'a', { url: 'http://a' });
+    creds = setProfile(creds, 'b', { url: 'http://b' });
+    expect(creds.current).toBe('a');
+
+    creds = deleteProfile(creds, 'a');
+    expect(creds.profiles.a).toBeUndefined();
+    expect(creds.current).toBe('b');
+  });
+
+  it('getProfile honors --profile override over current', () => {
+    let creds = loadCredentials();
+    creds = setProfile(creds, 'a', { url: 'http://a' });
+    creds = setProfile(creds, 'b', { url: 'http://b' });
+    expect(getProfile(creds)?.url).toBe('http://a');
+    expect(getProfile(creds, 'b')?.url).toBe('http://b');
+    expect(getProfile(creds, 'missing')).toBeUndefined();
+  });
+
+  it('saveCredentials performs an atomic rename', () => {
+    const credsA = setProfile(loadCredentials(), 'a', { url: 'http://a' });
+    saveCredentials(credsA);
+    const dir = path.dirname(credentialsPath());
+    const stragglers = fs.readdirSync(dir).filter((f) => f.startsWith('credentials.json.tmp.'));
+    expect(stragglers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an official `mcphub` CLI that runs against any mcphub instance's existing HTTP API surface — no server-side changes required. `bin/cli.js` becomes a router: subcommands dispatch to `dist/cli/main.js`, and the no-arg invocation keeps the legacy server-bootstrap behavior so `npx @samanhappy/mcphub` is unaffected.

## What's new

| Command | Purpose |
|---|---|
| `login` / `logout` | JWT login flow; atomic credentials file (XDG paths, `0600`); profile-aware |
| `config` | `show / list / use / set-url / set-token / remove` for local profiles |
| `servers` | `list / get / add / remove / toggle / reload` against `/api/servers*` |
| `groups` | `list / get / add / remove` plus `add-server` / `remove-server` (resolves name → UUID) |
| `keys` | `list / create / delete` bearer keys |
| `call` | JSON-RPC `tools/call` against `/mcp/$smart` or `/mcp/<group>`; `key=value` coercion (numbers, booleans, `null`, `@file` JSON, leading-zero preserved) |
| `export` | Download `mcp_settings.json` to stdout or `--out <path>` |
| `discover` / `install` | Consume the public `/discovery/*` API from #809. `install` supports `--to hub` (POST `/api/servers`), `--to file` (merge into Claude Desktop / OpenClaw-style JSON), `--to stdout` / `--dry-run`; resolves `--type` with friendly errors listing `availableTypes` |

## Design notes

- **Hand-rolled command dispatch** (no Commander dep); lazy `await import()` per subcommand keeps no-arg `mcphub` startup cost negligible
- **Profile resolution** order: `--url`/`--token` flags > `MCPHUB_URL`/`MCPHUB_TOKEN` env > active profile in `credentials.json`
- `tokenKind=jwt` sends `x-auth-token`; `tokenKind=bearer` sends `Authorization: Bearer` (matches existing middleware contract)
- Imports types directly from [src/types/index.ts](src/types/index.ts) (`ServerConfig`, `IGroup`, `BearerKey`, …) so wire shapes stay in sync with the server
- Atomic credentials write (tmp + rename), `0600` file permissions, XDG paths with legacy `~/.mcphub` fallback
- `scripts/verify-dist.js` gains a `dist/cli/main.js` existence check

## Relationship to #809

`discover` / `install` are pure consumers of the public discovery API added by the prototype on [`claude/implement-issue-809-9ReYd`](https://github.com/samanhappy/mcphub/tree/claude/implement-issue-809-9ReYd). They're built so that this PR doesn't depend on #809 being merged — when discovery is disabled (or absent), the CLI surfaces a friendly "ask an admin to set `systemConfig.discovery.enabled=true`" message. Once #809 lands, `install` becomes a one-stop way to bring marketplace servers into the active hub, into a Claude-Desktop-style config file, or to stdout for piping.

## Test plan

- [x] `pnpm test` — 455/455 passing (79 new across 13 CLI suites)
- [x] `pnpm backend:build` — clean
- [x] `node scripts/verify-dist.js` — passes new `dist/cli/main.js` check
- [x] `node bin/cli.js --help` — lists all commands
- [x] `node bin/cli.js` (no args) — still starts the server (backward compatibility)
- [ ] Manual: `pnpm dev` + `node bin/cli.js login --url http://localhost:3000 --username admin --password admin123` + `servers list` against a live hub
- [ ] Manual (once #809 is in): `discover --search github`, `install <name> --to stdout`, `install <name> --to hub --env KEY=VAL --yes`

## Out of scope (deferred)

- End-to-end integration test that spawns the CLI as a subprocess against a real server boot (unit tests cover the full HTTP contract layer; spawn-based integration test left as a follow-up)
- Editor-config import (`mcphub config import` from Cursor / Claude Desktop / VS Code)
- `--insecure` flag for self-signed HTTPS
- Explicit `mcphub serve` subcommand (legacy no-arg start preserved for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)