### PR TITLE
fix(oauth): bridge Better Auth session into /oauth/authorize

### DIFF
--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -9,6 +9,7 @@ import { loadSettings } from '../config/index.js';
 import OAuth2Server from '@node-oauth/oauth2-server';
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET } from '../config/jwt.js';
+import { resolveBetterAuthUser } from '../services/betterAuthSession.js';
 
 const { Request: OAuth2Request, Response: OAuth2Response } = OAuth2Server;
 
@@ -16,6 +17,28 @@ type AuthenticatedUser = {
   username: string;
   isAdmin?: boolean;
 };
+
+/**
+ * Bridge a Better Auth session cookie into req.user for the OAuth Server consent flow.
+ *
+ * The shared `auth` middleware is only mounted under /api/*, so /oauth/authorize never
+ * sees the Better Auth cookie that social-login (GitHub / Google) users carry. Without
+ * this helper, those users end up in a /login ↔ /oauth/authorize redirect loop (GET) or
+ * receive a 401 after clicking "Allow access" (POST). See issue #815.
+ */
+async function resolveBetterAuthUserForAuthorize(
+  req: Request,
+): Promise<AuthenticatedUser | null> {
+  try {
+    const user = await resolveBetterAuthUser(req);
+    if (user) {
+      return { username: user.username, isAdmin: !!user.isAdmin };
+    }
+  } catch (error) {
+    console.warn('Better Auth lookup failed in /oauth/authorize:', error);
+  }
+  return null;
+}
 
 /**
  * Attempt to attach a user to the request based on a JWT token present in header, query, or body.
@@ -274,6 +297,13 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
         user = tokenUser;
       }
     }
+    if (!user) {
+      const betterAuthUser = await resolveBetterAuthUserForAuthorize(req);
+      if (betterAuthUser) {
+        (req as any).user = betterAuthUser;
+        user = betterAuthUser;
+      }
+    }
 
     if (!user) {
       // Redirect to login page with return URL
@@ -364,13 +394,21 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
       return;
     }
 
-    // Get authenticated user (JWT support for browser form submissions)
+    // Get authenticated user (JWT support for browser form submissions, plus
+    // Better Auth session cookie for social-login users — see #815).
     let user = (req as any).user;
     if (!user) {
       const tokenUser = resolveUserFromRequest(req);
       if (tokenUser) {
         (req as any).user = tokenUser;
         user = tokenUser;
+      }
+    }
+    if (!user) {
+      const betterAuthUser = await resolveBetterAuthUserForAuthorize(req);
+      if (betterAuthUser) {
+        (req as any).user = betterAuthUser;
+        user = betterAuthUser;
       }
     }
 

--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -25,6 +25,9 @@ type AuthenticatedUser = {
  * sees the Better Auth cookie that social-login (GitHub / Google) users carry. Without
  * this helper, those users end up in a /login ↔ /oauth/authorize redirect loop (GET) or
  * receive a 401 after clicking "Allow access" (POST). See issue #815.
+ *
+ * On success the resolved user is attached to req.user so the caller does not have to
+ * repeat that assignment at every call site.
  */
 async function resolveBetterAuthUserForAuthorize(
   req: Request,
@@ -32,7 +35,12 @@ async function resolveBetterAuthUserForAuthorize(
   try {
     const user = await resolveBetterAuthUser(req);
     if (user) {
-      return { username: user.username, isAdmin: !!user.isAdmin };
+      const authenticatedUser: AuthenticatedUser = {
+        username: user.username,
+        isAdmin: !!user.isAdmin,
+      };
+      (req as any).user = authenticatedUser;
+      return authenticatedUser;
     }
   } catch (error) {
     console.warn('Better Auth lookup failed in /oauth/authorize:', error);
@@ -298,11 +306,7 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
       }
     }
     if (!user) {
-      const betterAuthUser = await resolveBetterAuthUserForAuthorize(req);
-      if (betterAuthUser) {
-        (req as any).user = betterAuthUser;
-        user = betterAuthUser;
-      }
+      user = await resolveBetterAuthUserForAuthorize(req);
     }
 
     if (!user) {
@@ -405,11 +409,7 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
       }
     }
     if (!user) {
-      const betterAuthUser = await resolveBetterAuthUserForAuthorize(req);
-      if (betterAuthUser) {
-        (req as any).user = betterAuthUser;
-        user = betterAuthUser;
-      }
+      user = await resolveBetterAuthUserForAuthorize(req);
     }
 
     if (!user) {


### PR DESCRIPTION
Closes #815.

## What

Both `getAuthorize` and `postAuthorize` in `src/controllers/oauthServerController.ts` previously authenticated the incoming request only via JWT — either `(req as any).user` (set by the `auth` middleware) or a token in `x-auth-token` / `?token=` / `body.token`. The `auth` middleware is only mounted on `/api/*`, so neither handler ever sees the Better Auth session cookie that social-login (GitHub / Google) users carry.

This PR adds a third lookup — `resolveBetterAuthUser(req)` — after the existing JWT branch in both handlers. The lookup is wrapped in `try / catch` so a Better Auth runtime error falls back to the existing redirect/401 path rather than 500-ing.

## Why

On an MCPHub instance with both `auth.betterAuth.enabled` and `oauthServer.enabled` (e.g. fronting a `claude.ai` custom MCP connector through Dynamic Client Registration), the consent flow currently dead-ends for any user who logs in through GitHub or Google:

- DCR client redirects browser to `GET /oauth/authorize` → user is unauthenticated → 302 to `/login?returnUrl=...`.
- User clicks **Continue with GitHub**, completes the GitHub OAuth dance, Better Auth sets its session cookie. The dashboard would now be reachable.
- `LoginPage.buildRedirectTarget()` only appends `?token=` when `authService.getToken()` returns a stored JWT. Social login never stores one (`/api/better-auth/user` returns user info, no token), so the redirect goes out **without** auth.
- `getAuthorize` sees no `req.user`, no JWT — 302 back to `/login`. Loop.

If the GET side is patched independently, `POST /oauth/authorize` (the **Allow access** form submission) has the same gap and returns:

```json
HTTP/1.1 401 Unauthorized
{"error":"unauthorized","error_description":"User not authenticated"}
```

The full reproducer and three alternative fix options (this PR implements the most localised one) are in #815.

## Compatibility

- When Better Auth is disabled or the user isn't signed in via Better Auth, the new lookup returns `null` immediately and behaviour is unchanged.
- The mapped user respects `IUser.isAdmin`, which `resolveBetterAuthUser` already populates from the local `users` table — so admin-only OAuth Server operations (if any) keep their gating.
- No change to the JWT path, the `auth` middleware, the dashboard auth flow, or the `/api/auth/better/*` endpoints. The change is contained to one file.

## Verification

- `pnpm build` ✓ (no new TypeScript errors)
- `pnpm test tests/controllers/oauthServerController.test.ts src/middlewares/auth.test.ts` ✓ (11/11)
- Manual end-to-end against a `claude.ai` Web custom connector through a Tailscale Funnel:
  - `POST /oauth/register` → 200, `client_id` issued.
  - GitHub login at `/login` (no JWT generated, only Better Auth cookie).
  - `GET /oauth/authorize?...` → consent screen renders (no loop).
  - `POST /oauth/authorize` with `allow=true` → 302 to `https://claude.ai/api/mcp/auth_callback?code=…`.
  - Token exchange → row in `oauth_tokens`.
  - `POST /mcp` `tools/list` with the bearer → tools returned.

Note: the pre-existing flake in `tests/integration/sse-service-real-client.test.ts` (server fixture times out in `beforeAll`) is unrelated to this change — it reproduces on unpatched `upstream/main` as well.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
