### PR TITLE
feat(servers): add per-server visibility column for non-admin access

### DIFF
--- a/docs/features/authentication.mdx
+++ b/docs/features/authentication.mdx
@@ -15,6 +15,16 @@ MCPHub supports several stacked authentication paths. The same middleware (`src/
 
 All persistent user records are stored as `{ username, password, isAdmin }`. There are no `manager` or `viewer` roles; permissions are binary (admin or not). Social accounts that log in via Better Auth live in a separate `mcphub_better_auth_*` table but are mapped to the same `username` / `isAdmin` shape at request time.
 
+### Per-server visibility
+
+Each server has a `visibility` column (`private` / `public`, with `group` reserved for a future user→group plumbing) that controls which non-admin users see the server in `tools/list` and the dashboard. Admins always see every server regardless of this setting; the field only affects the filter applied by `dataService.filterData` to non-admin requests.
+
+- `'private'` (default): only the server's `owner` (and admins) can see it. Servers seeded from `mcp_settings.json` migrate in with `'private'` to preserve the historical admin-only behaviour.
+- `'public'`: every authenticated user can see and call the server. Use this for servers you want to share across all users of the same MCPHub instance — including social-login users created by Better Auth.
+- `'group'`: reserved. Stored if set but treated as `'private'` by the filter until user→group membership ships.
+
+The visibility is editable per server from the dashboard (Server form → Visibility). For deployments where every user should see every server (single-user self-hosted, small trusted team), an operator can set the relevant servers to `'public'` from the dashboard.
+
 ## Login (JWT)
 
 The dashboard and any script that does not present a bearer key uses the JWT flow:

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -79,6 +79,10 @@ const ServerForm = ({
     headers: [],
     passthroughHeaders:
       initialData?.config?.passthroughHeaders?.join(', ') || '',
+    visibility: (initialData?.config?.visibility ?? 'private') as
+      | 'private'
+      | 'group'
+      | 'public',
     options: {
       timeout:
         (initialData &&
@@ -302,6 +306,37 @@ const ServerForm = ({
             className="w-full py-2 px-3 form-input"
             placeholder={t('server.descriptionPlaceholder')}
           />
+        </div>
+
+        <div className="mb-4">
+          <label className="block text-sm font-medium mb-1.5 text-[var(--hub-ink-2)]" htmlFor="visibility">
+            {t('server.visibility', 'Visibility')}
+          </label>
+          <select
+            id="visibility"
+            name="visibility"
+            value={formData.visibility || 'private'}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                visibility: e.target.value as 'private' | 'public',
+              }))
+            }
+            className="w-full py-2 px-3 form-input"
+          >
+            <option value="private">
+              {t('server.visibilityPrivate', 'Private — only the owner and admins')}
+            </option>
+            <option value="public">
+              {t('server.visibilityPublic', 'Public — every authenticated user')}
+            </option>
+          </select>
+          <p className="text-xs text-gray-500 mt-1">
+            {t(
+              'server.visibilityDescription',
+              "Controls which non-admin users see this server in tools/list. Admins always see all servers regardless of this setting.",
+            )}
+          </p>
         </div>
 
         <div className="mb-4">

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -319,7 +319,7 @@ const ServerForm = ({
             onChange={(e) =>
               setFormData((prev) => ({
                 ...prev,
-                visibility: e.target.value as 'private' | 'public',
+                visibility: e.target.value as 'private' | 'group' | 'public',
               }))
             }
             className="w-full py-2 px-3 form-input"
@@ -327,6 +327,15 @@ const ServerForm = ({
             <option value="private">
               {t('server.visibilityPrivate', 'Private — only the owner and admins')}
             </option>
+            {formData.visibility === 'group' && (
+              // 'group' is a reserved enum value; the filter doesn't yet honour it.
+              // Surface it as a disabled option so a server pre-set to 'group' (e.g.
+              // via direct DB update or a future user→group migration) renders
+              // intelligibly rather than silently falling back to 'private' in the UI.
+              <option value="group" disabled>
+                {t('server.visibilityGroup', 'Group (reserved — not yet implemented)')}
+              </option>
+            )}
             <option value="public">
               {t('server.visibilityPublic', 'Public — every authenticated user')}
             </option>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -166,6 +166,8 @@ export interface ServerConfig {
   headers?: Record<string, string>;
   passthroughHeaders?: string[];
   enabled?: boolean;
+  // Per-server visibility for non-admin users. See issue #817. 'group' reserved.
+  visibility?: 'private' | 'group' | 'public';
   enableKeepAlive?: boolean; // Enable keep-alive for this server (requires global enable as well)
   keepAliveInterval?: number; // Keep-alive ping interval in milliseconds (default: 60000ms)
   tools?: Record<string, { enabled: boolean; description?: string }>; // Tool-specific configurations with enable/disable state and custom descriptions
@@ -306,6 +308,8 @@ export interface ServerFormData {
   env: EnvVar[];
   headers: EnvVar[];
   passthroughHeaders?: string;
+  // Visibility for non-admin users. See issue #817. 'group' is reserved.
+  visibility?: 'private' | 'group' | 'public';
   options?: {
     timeout?: number;
     resetTimeoutOnProgress?: boolean;

--- a/frontend/src/utils/serverFormPayload.ts
+++ b/frontend/src/utils/serverFormPayload.ts
@@ -153,6 +153,7 @@ export const buildServerPayload = ({
     type: serverType,
     description,
     options,
+    visibility: formData.visibility ?? 'private',
   };
 
   if (serverType === 'openapi') {

--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -66,6 +66,7 @@ export class ServerDaoDbImpl implements ServerDao {
       headers: entity.headers,
       enabled: entity.enabled !== undefined ? entity.enabled : true,
       owner: entity.owner,
+      visibility: entity.visibility ?? 'private',
       enableKeepAlive: entity.enableKeepAlive,
       keepAliveInterval: entity.keepAliveInterval,
       tools: entity.tools,
@@ -113,6 +114,7 @@ export class ServerDaoDbImpl implements ServerDao {
     assignNullable('headers');
     assign('enabled');
     assignNullable('owner');
+    assign('visibility');
     if (hasOwn('enableKeepAlive')) {
       updateData.enableKeepAlive = entity.enableKeepAlive ?? false;
     }
@@ -206,6 +208,7 @@ export class ServerDaoDbImpl implements ServerDao {
     headers?: Record<string, string>;
     enabled: boolean;
     owner?: string;
+    visibility?: 'private' | 'group' | 'public';
     enableKeepAlive?: boolean;
     keepAliveInterval?: number;
     tools?: Record<string, { enabled: boolean; description?: string }>;
@@ -228,6 +231,7 @@ export class ServerDaoDbImpl implements ServerDao {
       headers: server.headers,
       enabled: server.enabled,
       owner: server.owner,
+      visibility: server.visibility ?? 'private',
       enableKeepAlive: server.enableKeepAlive,
       keepAliveInterval: server.keepAliveInterval,
       tools: server.tools,

--- a/src/db/entities/Server.ts
+++ b/src/db/entities/Server.ts
@@ -44,6 +44,14 @@ export class Server {
   @Column({ type: 'varchar', length: 255, nullable: true })
   owner?: string;
 
+  // Per-server visibility for non-admin users.
+  //   'private' — only the owner (or admins) can see this server. Default.
+  //   'public'  — every authenticated user can see this server.
+  //   'group'   — reserved for group-scoped visibility once user→group membership lands.
+  // See issue #817.
+  @Column({ type: 'varchar', length: 16, default: 'private' })
+  visibility: 'private' | 'group' | 'public';
+
   @Column({ type: 'boolean', default: false })
   enableKeepAlive?: boolean;
 

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -9,7 +9,14 @@ export class DataService {
     if (!currentUser || currentUser.isAdmin) {
       return data;
     } else {
-      return data.filter((item) => item.owner === currentUser?.username);
+      return data.filter((item) => {
+        if (item.owner === currentUser?.username) return true;
+        // visibility introduced in #817: 'public' is visible to every authenticated
+        // user, 'group' is reserved for a future user→group join (treat as 'private'
+        // for now so the enum value is safe to set ahead of group plumbing).
+        if (item.visibility === 'public') return true;
+        return false;
+      });
     }
   }
 

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -970,6 +970,7 @@ export const initializeClientsFromSettings = async (
         nextServerInfos.push({
           name,
           owner: expandedConf.owner,
+          visibility: expandedConf.visibility,
           status: 'disconnected',
           error: null,
           tools: [],
@@ -1005,6 +1006,7 @@ export const initializeClientsFromSettings = async (
           nextServerInfos.push({
             name,
             owner: expandedConf.owner,
+            visibility: expandedConf.visibility,
             status: 'disconnected',
             error: 'Missing OpenAPI specification URL or schema',
             tools: [],
@@ -1019,6 +1021,7 @@ export const initializeClientsFromSettings = async (
         const serverInfo: ServerInfo = {
           name,
           owner: expandedConf.owner,
+          visibility: expandedConf.visibility,
           status: 'connecting',
           error: null,
           tools: [],
@@ -1110,6 +1113,7 @@ export const initializeClientsFromSettings = async (
       const serverInfo: ServerInfo = {
         name,
         owner: expandedConf.owner,
+        visibility: expandedConf.visibility,
         status: 'connecting',
         error: null,
         tools: [],
@@ -1327,6 +1331,7 @@ export const getServersInfo = async (
       filteredServerInfos.push({
         name: server.name,
         owner: server.owner,
+        visibility: server.visibility,
         // Newly created servers that are enabled should appear as "connecting"
         // until the MCP client initialization completes. Disabled servers remain
         // in the "disconnected" state.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -303,6 +303,10 @@ export interface ProxychainsConfig {
   configPath?: string; // Path to custom proxychains4 configuration file (optional, overrides above settings)
 }
 
+// Visibility level for a server, used by non-admin filtering. See issue #817.
+// 'group' is reserved; group membership plumbing arrives in a follow-up.
+export type ServerVisibility = 'private' | 'group' | 'public';
+
 // Configuration details for an individual server
 export interface ServerConfig {
   type?: 'stdio' | 'sse' | 'streamable-http' | 'openapi'; // Type of server
@@ -315,6 +319,12 @@ export interface ServerConfig {
   passthroughHeaders?: string[]; // Header names to pass through from MCP requests to upstream SSE/streamable-http servers
   enabled?: boolean; // Flag to enable/disable the server
   owner?: string; // Owner of the server, defaults to 'admin' user
+  // Per-server visibility for non-admin users.
+  //   'private' — only the owner (or admins) can see this server. Default.
+  //   'public'  — every authenticated user can see this server.
+  //   'group'   — reserved for group-scoped visibility once user→group membership lands.
+  // See issue #817.
+  visibility?: ServerVisibility;
   enableKeepAlive?: boolean; // Enable keep-alive for this server (requires global enable as well)
   keepAliveInterval?: number; // Keep-alive ping interval in milliseconds (default: 60000ms for SSE servers)
   tools?: Record<string, { enabled: boolean; description?: string }>; // Tool-specific configurations with enable/disable state and custom descriptions
@@ -421,6 +431,7 @@ export interface ServerInfo {
   version?: string; // Upstream server version reported during MCP initialization
   instructions?: string; // Upstream server instructions reported during MCP initialization
   owner?: string; // Owner of the server, defaults to 'admin' user
+  visibility?: ServerVisibility; // Carried over from ServerConfig so dataService.filterData can apply #817 visibility rules at runtime.
   status: 'connected' | 'connecting' | 'disconnected' | 'oauth_required'; // Current connection status
   error: string | null; // Error message if any
   tools: Tool[]; // List of tools available on the server

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -76,6 +76,7 @@ export async function migrateToDatabase(): Promise<boolean> {
             headers: config.headers,
             enabled: config.enabled !== undefined ? config.enabled : true,
             owner: config.owner,
+            visibility: config.visibility ?? 'private',
             enableKeepAlive: config.enableKeepAlive,
             keepAliveInterval: config.keepAliveInterval,
             tools: config.tools,

--- a/src/utils/serverConfigPersistence.ts
+++ b/src/utils/serverConfigPersistence.ts
@@ -165,11 +165,17 @@ export const normalizeServerConfigForPersistence = (config: ServerConfig): Serve
   const oauth = normalizeOAuth(config.oauth);
   const openapi = normalizeOpenApi(config.openapi);
 
+  // Default visibility to 'private' so file-defined and freshly-created servers behave
+  // identically to the pre-#817 implicit admin-only behaviour. Operators opt servers in
+  // to 'public' (or eventually 'group') from the dashboard.
+  const visibility = config.visibility ?? 'private';
+
   const normalized: ServerConfig = {
     ...config,
     type: normalizedType,
     description,
     owner,
+    visibility,
     options,
   };
 

--- a/tests/services/dataService.test.ts
+++ b/tests/services/dataService.test.ts
@@ -1,0 +1,108 @@
+import { DataService } from '../../src/services/dataService.js';
+import { IUser } from '../../src/types/index.js';
+
+const admin: IUser = { username: 'admin', isAdmin: true, password: '' };
+const alice: IUser = { username: 'alice', isAdmin: false, password: '' };
+const bob: IUser = { username: 'bob', isAdmin: false, password: '' };
+
+// One row per (owner, visibility) cell so each test can name what it expects directly.
+const rows = {
+  alicePrivate: { name: 'alicePrivate', owner: 'alice', visibility: 'private' },
+  alicePublic: { name: 'alicePublic', owner: 'alice', visibility: 'public' },
+  aliceGroup: { name: 'aliceGroup', owner: 'alice', visibility: 'group' },
+  bobPrivate: { name: 'bobPrivate', owner: 'bob', visibility: 'private' },
+  bobPublic: { name: 'bobPublic', owner: 'bob', visibility: 'public' },
+  bobGroup: { name: 'bobGroup', owner: 'bob', visibility: 'group' },
+  systemPrivate: { name: 'systemPrivate', owner: undefined, visibility: 'private' },
+  systemPublic: { name: 'systemPublic', owner: undefined, visibility: 'public' },
+  systemGroup: { name: 'systemGroup', owner: undefined, visibility: 'group' },
+  // Pre-migration / legacy row that doesn't have visibility set yet. The DAO
+  // defaults this to 'private' on read, but the filter should also be defensive
+  // about rows that come from non-DAO paths (in-memory tests, raw queries).
+  legacyNoVisibility: { name: 'legacyNoVisibility', owner: undefined },
+};
+
+const allRows = Object.values(rows);
+
+describe('DataService.filterData (visibility, #817)', () => {
+  const dataService = new DataService();
+
+  describe('admin', () => {
+    it('returns every row regardless of visibility', () => {
+      const result = dataService.filterData(allRows, admin);
+      expect(result.map((r) => r.name).sort()).toEqual(allRows.map((r) => r.name).sort());
+    });
+  });
+
+  describe('no user supplied (unscoped fallback)', () => {
+    it('returns every row (callers that pass no user expect un-filtered data)', () => {
+      const result = dataService.filterData(allRows);
+      expect(result.map((r) => r.name).sort()).toEqual(allRows.map((r) => r.name).sort());
+    });
+  });
+
+  describe('non-admin user (alice)', () => {
+    it('sees her own private rows', () => {
+      expect(dataService.filterData([rows.alicePrivate], alice)).toEqual([rows.alicePrivate]);
+    });
+
+    it('sees her own public rows', () => {
+      expect(dataService.filterData([rows.alicePublic], alice)).toEqual([rows.alicePublic]);
+    });
+
+    it('sees her own group rows (owner match takes precedence over the group implementation gap)', () => {
+      // Once user→group membership ships and the filter learns to check it, this
+      // case stays correct because the owner-match branch fires before the
+      // visibility branch.
+      expect(dataService.filterData([rows.aliceGroup], alice)).toEqual([rows.aliceGroup]);
+    });
+
+    it('does NOT see another user\'s private rows', () => {
+      expect(dataService.filterData([rows.bobPrivate], alice)).toEqual([]);
+    });
+
+    it('sees another user\'s public rows', () => {
+      expect(dataService.filterData([rows.bobPublic], alice)).toEqual([rows.bobPublic]);
+    });
+
+    it('does NOT see another user\'s group rows yet (reserved value, not implemented)', () => {
+      expect(dataService.filterData([rows.bobGroup], alice)).toEqual([]);
+    });
+
+    it('does NOT see system (owner=null) private rows', () => {
+      expect(dataService.filterData([rows.systemPrivate], alice)).toEqual([]);
+    });
+
+    it('sees system (owner=null) public rows', () => {
+      expect(dataService.filterData([rows.systemPublic], alice)).toEqual([rows.systemPublic]);
+    });
+
+    it('does NOT see system group rows (reserved value)', () => {
+      expect(dataService.filterData([rows.systemGroup], alice)).toEqual([]);
+    });
+
+    it('does NOT see legacy rows whose visibility is undefined', () => {
+      // Pre-migration safety: if a row somehow reaches the filter without a
+      // visibility column populated, treat it as private rather than leaking it.
+      expect(dataService.filterData([rows.legacyNoVisibility], alice)).toEqual([]);
+    });
+
+    it('returns the union of owner-match and public when given the full dataset', () => {
+      const result = dataService.filterData(allRows, alice);
+      const names = result.map((r) => r.name).sort();
+      expect(names).toEqual(
+        ['alicePrivate', 'alicePublic', 'aliceGroup', 'bobPublic', 'systemPublic'].sort(),
+      );
+    });
+  });
+
+  describe('a different non-admin user (bob) sees the symmetric set', () => {
+    it('symmetry check: bob sees his own rows + everyone\'s public rows', () => {
+      const result = dataService.filterData(allRows, bob);
+      const names = result.map((r) => r.name).sort();
+      expect(names).toEqual(
+        ['bobPrivate', 'bobPublic', 'bobGroup', 'alicePublic', 'systemPublic'].sort(),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #817.

## What

Adds a `visibility` column to the `servers` table (and `ServerConfig`) so non-admin users can see servers without needing to be promoted to admin. The values are:

- **`'private'`** (default): only the server's `owner` and admins can see it.
- **`'public'`**: every authenticated user can see and call the server.
- **`'group'`**: reserved enum value. Stored if set but treated as `'private'` by the filter until user→group membership ships, so the column doesn't need a second migration when that feature lands.

`dataService.filterData` now returns, for non-admin users, the union of `owner === user.username` and `visibility === 'public'`. Admins are unaffected — the existing `isAdmin` short-circuit returns the full list as before.

## Why

Today there's no third state between "admin sees everything" and "non-admin sees only their own servers." `mcp_settings.json`-defined servers land in the DB with `owner = NULL`, so a non-admin user — including a freshly created Better Auth social-login user — gets an empty `tools/list` and a `claude.ai` connector that silently fails to expose anything. Either the operator promotes the user to admin globally (over-privileged) or they can't use the connector at all.

Option (2) from the [#817 discussion](https://github.com/samanhappy/mcphub/issues/817#issuecomment-4478231824) — per-server visibility — is the right place to land because it decouples global admin privileges from the simple need to access default upstream servers, and it scales from single-user self-hosted (set everything to `public`) up to multi-tenant (keep things `private` and opt servers into `public` deliberately).

## Migration

Fully additive. The new column defaults to `'private'`, so existing `owner = NULL` rows that were only visible to admins via the `isAdmin` short-circuit remain admin-only on upgrade. Non-admin users were never seeing those rows, so nothing they could see disappears. Operators can flip specific servers to `'public'` from the dashboard once they decide to share them.

```sql
-- TypeORM `synchronize: true` (current default in `src/db/connection.ts`) does this
-- automatically on next boot:
ALTER TABLE servers ADD COLUMN visibility VARCHAR(16) NOT NULL DEFAULT 'private';
```

Deployments running with `synchronize: false` and managed migration files need to apply the equivalent column-add as a migration; the column is non-nullable with a string default, so backfilling existing rows is implicit.

## What changed

- `src/db/entities/Server.ts` — new `visibility` column with `default: 'private'`.
- `src/types/index.ts` — new `ServerVisibility` type + `visibility` on `ServerConfig`.
- `src/services/dataService.ts` — non-admin branch of `filterData` now also accepts `visibility === 'public'`.
- `src/services/mcpService.ts` — runtime `ServerInfo` objects carry `visibility` from `ServerConfig` so `dataService.filterData` (which is called on `serverInfos` in `handleListToolsRequest` via `getFilteredServerInfosForGroup`, and on `getServersInfo`'s output) sees the value at filter time.
- `src/types/index.ts` — `ServerInfo` gains a `visibility?: ServerVisibility` field that mirrors the `ServerConfig` column.
- `src/dao/ServerDaoDbImpl.ts` — wires `visibility` through `create` / `update` / `mapToServerConfig`, with a `'private'` default on read so callers always receive a defined value.
- `src/utils/serverConfigPersistence.ts` — `normalizeServerConfigForPersistence` defaults missing `visibility` to `'private'`.
- `src/utils/migration.ts` — `mcp_settings.json` → DB seeding passes `visibility` through, defaulting to `'private'`.
- `frontend/src/types/index.ts` — `ServerFormData` and `ServerConfig` carry `visibility`.
- `frontend/src/components/ServerForm.tsx` — new Visibility selector (Private / Public) under the description field, with an explanatory subtitle.
- `frontend/src/utils/serverFormPayload.ts` — submitted payload includes `visibility`.
- `docs/features/authentication.mdx` — documents the new field and migration default.

## Tests

`tests/services/dataService.test.ts` covers the full (visibility × user role) matrix:

- Admin sees everything regardless of visibility.
- No-user fallback returns the full list (unchanged behaviour).
- Non-admin owner sees their own private / public / group rows (owner-match wins over visibility).
- Non-admin non-owner sees public rows from other users and from the system; never sees their private or group rows.
- Pre-migration rows whose `visibility` is `undefined` stay hidden from non-admin (defensive — DAO defaults to `'private'` on read, but the filter handles raw rows too).
- Symmetric test with a different non-admin user confirms the filter isn't accidentally user-specific in an unintended way.

```text
Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

`pnpm build` is clean. `pnpm test tests/services/dataService.test.ts tests/controllers/serverController.test.ts src/middlewares/auth.test.ts` → 21/21 pass.

The key flow for this PR — operator marks a `mcp_settings.json`-seeded server (`owner = NULL`) as `'public'` so a Better Auth-created non-admin user can see it — is covered explicitly by the `systemPublic` fixture and the "sees system (owner=null) public rows" case. That's the scenario from #817 the change is built to unblock.

### Frontend (manual verification)

There's no React component test harness in `frontend/` yet, so the UI side was verified manually:

- Creating a new server defaults the Visibility field to **Private**, which round-trips to `visibility: 'private'` in the resulting `servers` row.
- Editing an existing server with `visibility: 'public'` pre-populates the selector to **Public** (the `initialData?.config?.visibility ?? 'private'` initializer in `ServerForm.tsx`).
- Submitting either option persists through `buildServerPayload` → `POST /api/servers` → DAO → DB without normalisation stripping the field.

### End-to-end verification against a live MCPHub instance

Built the branch into a local Docker image (`docker build -t mcphub-feat-visibility:local .`), swapped it into a running compose stack that fronts three configured servers (`toggl` / `todo` / `hcgateway`), and exercised the full path with a non-admin user's OAuth bearer token:

1. TypeORM `synchronize: true` added the `visibility` column on startup; all three existing rows defaulted to `'private'` as designed.
2. With every server `'private'` and the user demoted (`isAdmin = false`), `POST /mcp/...` `tools/list` returned `0` tools — matching pre-#817 behaviour for non-admins.
3. `UPDATE servers SET visibility = 'public' WHERE name = 'toggl'` + container restart (to force the in-memory `serverInfos` reload from DAO — this caching is pre-existing behaviour, not new in this PR).
4. Same non-admin token now sees:
   - `/mcp` aggregated → 16 tools (just the toggl tools)
   - `/mcp/toggl` → 16 tools
   - `/mcp/todo` → 0 tools (still private)
   - `/mcp/hcgateway` → 0 tools (still private)
5. A diagnostic log injected into `dataService.filterData` confirmed the items reaching the filter had `visibility: 'public'` on the public row and `visibility: 'private'` on the others — proving the propagation chain (`Server` entity → `ServerConfig` → `expandedConf` → `ServerInfo`) carries the value through every hop.

This is the actual `claude.ai` connector scenario the issue describes: a Better Auth-created social-login user with `isAdmin = false` can now use a `mcp_settings.json`-defined server by having the operator flip its visibility to `'public'`, instead of needing the user themselves promoted to admin.

## Follow-ups (deliberately out of scope)

- **`'group'` filter implementation.** Requires a user→group join (no `users_groups` table today). The enum value is reserved here so this lands as a smaller follow-up: add the join + extend the filter, no schema migration needed in the `servers` table.
- **Dashboard "Authorized clients" page** / per-user revocation of approvals — tracked separately in #823.
- **Consent screen surfacing of the target server** — tracked in #821; orthogonal to the permission model.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
