### PR TITLE
fix: fall back to default OAuth config when stored config is empty

### DIFF
--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -10,6 +10,7 @@ import OAuth2Server from '@node-oauth/oauth2-server';
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET } from '../config/jwt.js';
 import { resolveBetterAuthUser } from '../services/betterAuthSession.js';
+import { cloneDefaultOAuthServerConfig } from '../constants/oauthServerDefaults.js';
 
 const { Request: OAuth2Request, Response: OAuth2Response } = OAuth2Server;
 
@@ -527,9 +528,13 @@ export const getUserInfo = async (req: Request, res: Response): Promise<void> =>
 export const getMetadata = async (req: Request, res: Response): Promise<void> => {
   try {
     const systemConfig = await getSystemConfigDao().get();
-    const oauthConfig = systemConfig?.oauthServer;
+    const storedConfig = systemConfig?.oauthServer;
+    // Fall back to defaults when the stored config has no explicit 'enabled' flag
+    // (e.g. first DB-mode startup where SystemConfigRepository creates oauthServer: {})
+    const oauthConfig =
+      storedConfig && 'enabled' in storedConfig ? storedConfig : cloneDefaultOAuthServerConfig();
 
-    if (!oauthConfig || !oauthConfig.enabled) {
+    if (!oauthConfig.enabled) {
       res.status(404).json({ error: 'OAuth server not configured' });
       return;
     }
@@ -572,9 +577,13 @@ export const getMetadata = async (req: Request, res: Response): Promise<void> =>
 export const getProtectedResourceMetadata = async (req: Request, res: Response): Promise<void> => {
   try {
     const systemConfig = await getSystemConfigDao().get();
-    const oauthConfig = systemConfig?.oauthServer;
+    const storedConfig = systemConfig?.oauthServer;
+    // Fall back to defaults when the stored config has no explicit 'enabled' flag
+    // (e.g. first DB-mode startup where SystemConfigRepository creates oauthServer: {})
+    const oauthConfig =
+      storedConfig && 'enabled' in storedConfig ? storedConfig : cloneDefaultOAuthServerConfig();
 
-    if (!oauthConfig || !oauthConfig.enabled) {
+    if (!oauthConfig.enabled) {
       res.status(404).json({ error: 'OAuth server not configured' });
       return;
     }

--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -529,10 +529,8 @@ export const getMetadata = async (req: Request, res: Response): Promise<void> =>
   try {
     const systemConfig = await getSystemConfigDao().get();
     const storedConfig = systemConfig?.oauthServer;
-    // Fall back to defaults when the stored config has no explicit 'enabled' flag
-    // (e.g. first DB-mode startup where SystemConfigRepository creates oauthServer: {})
-    const oauthConfig =
-      storedConfig && 'enabled' in storedConfig ? storedConfig : cloneDefaultOAuthServerConfig();
+    // Merge stored config with defaults so partial configs still inherit all default values
+    const oauthConfig = { ...cloneDefaultOAuthServerConfig(), ...storedConfig };
 
     if (!oauthConfig.enabled) {
       res.status(404).json({ error: 'OAuth server not configured' });
@@ -578,10 +576,8 @@ export const getProtectedResourceMetadata = async (req: Request, res: Response):
   try {
     const systemConfig = await getSystemConfigDao().get();
     const storedConfig = systemConfig?.oauthServer;
-    // Fall back to defaults when the stored config has no explicit 'enabled' flag
-    // (e.g. first DB-mode startup where SystemConfigRepository creates oauthServer: {})
-    const oauthConfig =
-      storedConfig && 'enabled' in storedConfig ? storedConfig : cloneDefaultOAuthServerConfig();
+    // Merge stored config with defaults so partial configs still inherit all default values
+    const oauthConfig = { ...cloneDefaultOAuthServerConfig(), ...storedConfig };
 
     if (!oauthConfig.enabled) {
       res.status(404).json({ error: 'OAuth server not configured' });

--- a/src/db/repositories/SystemConfigRepository.ts
+++ b/src/db/repositories/SystemConfigRepository.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import { SystemConfig } from '../entities/SystemConfig.js';
 import { getAppDataSource } from '../connection.js';
+import { cloneDefaultOAuthServerConfig } from '../../constants/oauthServerDefaults.js';
 
 /**
  * Repository for SystemConfig entity
@@ -30,7 +31,7 @@ export class SystemConfigRepository {
         mcpRouter: {},
         nameSeparator: '-',
         oauth: {},
-        oauthServer: {},
+        oauthServer: cloneDefaultOAuthServerConfig(),
         auth: {},
         enableSessionRebuild: false,
       });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -156,6 +156,7 @@ import {
   authenticatedRouteRateLimiter,
   hostedInternalEventRateLimiter,
   templateRateLimiter,
+  mcpConnectionRateLimiter,
 } from '../utils/rateLimit.js';
 
 const router = express.Router();
@@ -194,12 +195,12 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
   app.get('/oauth/callback', handleOAuthCallback);
 
   // OAuth Authorization Server endpoints (no auth required for OAuth flow)
-  app.get('/oauth/authorize', getAuthorize);
-  app.post('/oauth/authorize', express.urlencoded({ extended: true }), postAuthorize);
-  app.post('/oauth/token', express.urlencoded({ extended: true }), postToken); // Public endpoint for token exchange
-  app.get('/oauth/userinfo', getUserInfo); // Validates OAuth token
-  app.get('/.well-known/oauth-authorization-server', getMetadata); // Public metadata endpoint
-  app.get('/.well-known/oauth-protected-resource', getProtectedResourceMetadata); // Public protected resource metadata
+  app.get('/oauth/authorize', mcpConnectionRateLimiter, getAuthorize);
+  app.post('/oauth/authorize', express.urlencoded({ extended: true }), mcpConnectionRateLimiter, postAuthorize);
+  app.post('/oauth/token', express.urlencoded({ extended: true }), mcpConnectionRateLimiter, postToken); // Public endpoint for token exchange
+  app.get('/oauth/userinfo', mcpConnectionRateLimiter, getUserInfo); // Validates OAuth token
+  app.get('/.well-known/oauth-authorization-server', mcpConnectionRateLimiter, getMetadata); // Public metadata endpoint
+  app.get('/.well-known/oauth-protected-resource', mcpConnectionRateLimiter, getProtectedResourceMetadata); // Public protected resource metadata
 
   // RFC 7591 Dynamic Client Registration endpoints (public for registration)
   app.post('/oauth/register', registerClient); // Register new OAuth client

--- a/src/services/oauthServerService.ts
+++ b/src/services/oauthServerService.ts
@@ -13,6 +13,7 @@ import {
 } from '../models/OAuth.js';
 import crypto from 'crypto';
 import { safeCompare } from '../utils/safeCompare.js';
+import { cloneDefaultOAuthServerConfig } from '../constants/oauthServerDefaults.js';
 
 const { Request, Response } = OAuth2Server;
 
@@ -288,13 +289,20 @@ let oauth: OAuth2Server | null = null;
  * Initialize OAuth server
  */
 export const initOAuthServer = async (): Promise<void> => {
+  // Reset to ensure clean state on re-initialization
+  oauth = null;
+
   const systemConfigDao = getSystemConfigDao();
   const systemConfig = await systemConfigDao.get();
-  const oauthConfig = systemConfig?.oauthServer;
-  const requireState = oauthConfig?.requireState === true;
+  const storedConfig = systemConfig?.oauthServer;
+  // Fall back to defaults when the stored config has no explicit 'enabled' flag
+  // (e.g. first DB-mode startup where SystemConfigRepository creates oauthServer: {})
+  const oauthConfig =
+    storedConfig && 'enabled' in storedConfig ? storedConfig : cloneDefaultOAuthServerConfig();
+  const requireState = oauthConfig.requireState === true;
 
-  if (!oauthConfig || !oauthConfig.enabled) {
-    console.log('OAuth authorization server is disabled or not configured');
+  if (!oauthConfig.enabled) {
+    console.log('OAuth authorization server is disabled');
     return;
   }
 

--- a/src/services/oauthServerService.ts
+++ b/src/services/oauthServerService.ts
@@ -295,10 +295,8 @@ export const initOAuthServer = async (): Promise<void> => {
   const systemConfigDao = getSystemConfigDao();
   const systemConfig = await systemConfigDao.get();
   const storedConfig = systemConfig?.oauthServer;
-  // Fall back to defaults when the stored config has no explicit 'enabled' flag
-  // (e.g. first DB-mode startup where SystemConfigRepository creates oauthServer: {})
-  const oauthConfig =
-    storedConfig && 'enabled' in storedConfig ? storedConfig : cloneDefaultOAuthServerConfig();
+  // Merge stored config with defaults so partial configs still inherit all default values
+  const oauthConfig = { ...cloneDefaultOAuthServerConfig(), ...storedConfig };
   const requireState = oauthConfig.requireState === true;
 
   if (!oauthConfig.enabled) {

--- a/tests/controllers/oauthServerController.metadata.test.ts
+++ b/tests/controllers/oauthServerController.metadata.test.ts
@@ -186,4 +186,21 @@ describe('oauthServerController metadata endpoints', () => {
     expect(mockStatus).toHaveBeenCalledWith(404);
     expect(mockJson).toHaveBeenCalledWith({ error: 'OAuth server not configured' });
   });
+
+  it('merges partial config with defaults so missing fields inherit default values', async () => {
+    getSystemConfigMock.mockResolvedValue({
+      oauthServer: { enabled: true },
+    });
+
+    await getMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopes_supported: ['read', 'write'],
+        code_challenge_methods_supported: ['S256', 'plain'],
+        token_endpoint_auth_methods_supported: ['none'],
+      }),
+    );
+  });
 });

--- a/tests/controllers/oauthServerController.metadata.test.ts
+++ b/tests/controllers/oauthServerController.metadata.test.ts
@@ -100,4 +100,90 @@ describe('oauthServerController metadata endpoints', () => {
       bearer_methods_supported: ['header'],
     });
   });
+
+  it('returns default metadata when oauthServer is an empty object (first DB-mode startup)', async () => {
+    getSystemConfigMock.mockResolvedValue({
+      oauthServer: {},
+    });
+
+    await getMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization_endpoint: 'https://localhost:3000/oauth/authorize',
+        token_endpoint: 'https://localhost:3000/oauth/token',
+        scopes_supported: ['read', 'write'],
+        code_challenge_methods_supported: ['S256', 'plain'],
+      }),
+    );
+  });
+
+  it('returns default metadata when oauthServer is undefined', async () => {
+    getSystemConfigMock.mockResolvedValue({});
+
+    await getMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization_endpoint: 'https://localhost:3000/oauth/authorize',
+        token_endpoint: 'https://localhost:3000/oauth/token',
+        scopes_supported: ['read', 'write'],
+      }),
+    );
+  });
+
+  it('returns default protected resource metadata when oauthServer is an empty object', async () => {
+    getSystemConfigMock.mockResolvedValue({
+      oauthServer: {},
+    });
+
+    await getProtectedResourceMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization_servers: ['https://localhost:3000'],
+        scopes_supported: ['read', 'write'],
+        bearer_methods_supported: ['header'],
+      }),
+    );
+  });
+
+  it('returns default protected resource metadata when oauthServer is undefined', async () => {
+    getSystemConfigMock.mockResolvedValue({});
+
+    await getProtectedResourceMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorization_servers: ['https://localhost:3000'],
+        scopes_supported: ['read', 'write'],
+      }),
+    );
+  });
+
+  it('returns 404 when oauthServer.enabled is explicitly false', async () => {
+    getSystemConfigMock.mockResolvedValue({
+      oauthServer: { enabled: false },
+    });
+
+    await getMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).toHaveBeenCalledWith(404);
+    expect(mockJson).toHaveBeenCalledWith({ error: 'OAuth server not configured' });
+  });
+
+  it('returns 404 for protected resource when oauthServer.enabled is explicitly false', async () => {
+    getSystemConfigMock.mockResolvedValue({
+      oauthServer: { enabled: false },
+    });
+
+    await getProtectedResourceMetadata(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).toHaveBeenCalledWith(404);
+    expect(mockJson).toHaveBeenCalledWith({ error: 'OAuth server not configured' });
+  });
 });

--- a/tests/services/oauthServerInit.test.ts
+++ b/tests/services/oauthServerInit.test.ts
@@ -70,4 +70,14 @@ describe('initOAuthServer', () => {
 
     expect(getOAuthServer()).not.toBeNull();
   });
+
+  it('initializes with merged defaults when stored config is partial (only enabled)', async () => {
+    mockGet.mockResolvedValue({
+      oauthServer: { enabled: true },
+    });
+
+    await initOAuthServer();
+
+    expect(getOAuthServer()).not.toBeNull();
+  });
 });

--- a/tests/services/oauthServerInit.test.ts
+++ b/tests/services/oauthServerInit.test.ts
@@ -1,0 +1,73 @@
+jest.mock('@node-oauth/oauth2-server', () => {
+  return jest.fn().mockImplementation(() => ({}));
+});
+
+jest.mock('../../src/dao/index.js', () => ({
+  getSystemConfigDao: jest.fn(),
+  getBearerKeyDao: jest.fn(),
+}));
+
+jest.mock('../../src/models/User.js', () => ({
+  findUserByUsername: jest.fn(),
+  verifyPassword: jest.fn(),
+}));
+
+jest.mock('../../src/models/OAuth.js', () => ({
+  findOAuthClientById: jest.fn(),
+  saveAuthorizationCode: jest.fn(),
+  getAuthorizationCode: jest.fn(),
+  revokeAuthorizationCode: jest.fn(),
+  saveToken: jest.fn(),
+  getToken: jest.fn(),
+  revokeToken: jest.fn(),
+}));
+
+import * as daoModule from '../../src/dao/index.js';
+import { initOAuthServer, getOAuthServer } from '../../src/services/oauthServerService.js';
+
+describe('initOAuthServer', () => {
+  const mockGet = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (daoModule.getSystemConfigDao as jest.Mock).mockReturnValue({ get: mockGet });
+  });
+
+  it('initializes with default config when oauthServer is an empty object (first DB-mode startup)', async () => {
+    mockGet.mockResolvedValue({ oauthServer: {} });
+
+    await initOAuthServer();
+
+    expect(getOAuthServer()).not.toBeNull();
+  });
+
+  it('initializes with default config when oauthServer is undefined', async () => {
+    mockGet.mockResolvedValue({});
+
+    await initOAuthServer();
+
+    expect(getOAuthServer()).not.toBeNull();
+  });
+
+  it('does not initialize when oauthServer.enabled is explicitly false', async () => {
+    mockGet.mockResolvedValue({ oauthServer: { enabled: false } });
+
+    await initOAuthServer();
+
+    expect(getOAuthServer()).toBeNull();
+  });
+
+  it('initializes with stored config when oauthServer.enabled is explicitly true', async () => {
+    mockGet.mockResolvedValue({
+      oauthServer: {
+        enabled: true,
+        accessTokenLifetime: 7200,
+        requireClientSecret: true,
+      },
+    });
+
+    await initOAuthServer();
+
+    expect(getOAuthServer()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #863. OAuth metadata endpoints fall back to default config when stored config is empty (DB mode first startup). See commit message for details.