### PR TITLE
fix(smart-routing): allow arbitrary args in $smart call_tool schema

### DIFF
--- a/src/services/smartRoutingService.ts
+++ b/src/services/smartRoutingService.ts
@@ -169,6 +169,7 @@ Available servers: ${serversList}`,
             },
             arguments: {
               type: 'object',
+              additionalProperties: true,
               description:
                 'The arguments to pass to the tool based on its inputSchema from describe_tool (optional if tool requires no arguments)',
             },
@@ -228,6 +229,7 @@ Available servers: ${serversList}`,
             },
             arguments: {
               type: 'object',
+              additionalProperties: true,
               description:
                 'The arguments to pass to the tool based on its inputSchema (optional if tool requires no arguments)',
             },


### PR DESCRIPTION
Closes #873.

## Summary

The `call_tool` wrapper in `\$smart` smart-routing mode declares its `arguments` parameter as:

\`\`\`json
{ "type": "object", "description": "..." }
\`\`\`

Some JSON-schema-aware tool-calling stacks read this as *strictly* an object with no allowed properties (no `properties`, no `additionalProperties`), and the model emits `arguments: {}` regardless of what its own reasoning resolved.

This breaks the `$smart` workflow for any tool that takes parameters: `search_tools` finds it, `describe_tool` returns a valid schema, the model assembles correct `arguments`, but the wrapper layer drops them at the boundary because of the over-strict schema.

Adding `additionalProperties: true` keeps the "any-object" intent without dropping the type hint, restoring full argument serialization end-to-end.

## Reproduction

1. MCPHub `1.0.7-full` with `smartRouting.enabled=true`, `progressiveDisclosure=true`.
2. Group containing any tool with required parameters (e.g. `todoist-find-tasks` with `filter`, `limit`).
3. Drive a tool-calling LLM (we hit it with **gpt-oss-120b** served via vLLM through a Bifrost gateway) with: *"find Todoist tasks that are not recurring"*.
4. The model emits a `call_tool` invocation whose function-arguments JSON is `{"toolName":"todoist-find-tasks","arguments":{}}` — the nested object is gone.

## Evidence

Isolated harness, fake tool with identical schema shape, 3 runs each at `temperature=0`:

| Variant | `arguments` schema | full / 3 | empty / 3 |
|---|---|---|---|
| **A** baseline | `{type:"object"}` (current) | **0** | **3** |
| **B** + additionalProperties | `{type:"object", additionalProperties:true}` | **3** | 0 |
| **C** B + `examples` | B + examples | 3 | 0 |
| **D** concrete `properties` | typed properties + additionalProperties | 3 | 0 |
| **F** flat control (no nested object) | params at top level | 3 | 0 |

Variant B (this fix) is sufficient to restore correct argument filling.

## End-to-end verification

I also ran a real HTTP MCP `tools/list` against:

- **Live production MCPHub 1.0.7** — confirmed the broken schema is what's served on the wire.
- **Local patched MCPHub** built from this branch — confirmed `call_tool.inputSchema.properties.arguments` now contains `"additionalProperties": true`.

Verified the model emits populated `arguments` against the patched schema (3/3) via Bifrost → gpt-oss-120b. The fix flows through the smart wrapper as expected.

## Fix

Two-line change to `src/services/smartRoutingService.ts`. The `arguments` parameter is declared in two places (progressive-disclosure branch and standard branch); both get `additionalProperties: true`.

## Why it matters

This affects the entire `$smart` discovery workflow for any client whose tool-calling stack is strict about JSON-schema interpretation. Anecdotally we've seen it with OSS LLMs guided by structured-decoding (Outlines / llguidance / xgrammar) and some OpenAI SDK adapters. Strong-tool-call models like Claude or GPT-4-class APIs tolerate the original schema by ignoring its strictness, which is why this slipped through.

## Environment

- MCPHub: `docker.io/samanhappy/mcphub:1.0.7-full` (NixOS deploy, behind Caddy + Bifrost LLM gateway)
- LLM: `gpt-oss-120b` served via vLLM at `temperature=0.0`
- Embedding: BAAI `bge-m3` for smart-routing vector search