### PR TITLE
feat: add mcp apps support

### DIFF
--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -77,6 +77,7 @@ const ServerCard = ({ server, onRemove, onEdit, onToggle, onRefresh, onReload }:
   const enabledPrompts = server.prompts?.filter((p) => p.enabled !== false).length || 0;
   const totalResources = server.resources?.length || 0;
   const enabledResources = server.resources?.filter((r) => r.enabled !== false).length || 0;
+  const isMcpApp = server.resources?.some((r) => r.uri?.startsWith('ui://')) ?? false;
 
   const handleToggle = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -334,6 +335,15 @@ const ServerCard = ({ server, onRemove, onEdit, onToggle, onRefresh, onReload }:
                 >
                   {server.name}
                 </span>
+                {isMcpApp && (
+                  <span
+                    className="hub-tag flex-shrink-0"
+                    title={t('server.mcpApp') || 'MCP App — this server exposes interactive UI resources'}
+                    style={{ color: 'var(--hub-accent)', borderColor: 'var(--hub-accent)', opacity: 0.85 }}
+                  >
+                    App
+                  </span>
+                )}
                 {server.error && (
                   <div className="relative" ref={errorPopoverRef}>
                     <button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -89,6 +89,8 @@ export interface Tool {
   description: string;
   inputSchema: ToolInputSchema;
   enabled?: boolean;
+  annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
 }
 
 // Prompt types

--- a/locales/en.json
+++ b/locales/en.json
@@ -117,6 +117,7 @@
     "typeSse": "SSE",
     "typeStreamableHttp": "Streamable HTTP",
     "typeOpenapi": "OpenAPI",
+    "mcpApp": "MCP App — this server exposes interactive UI resources",
     "visibility": "Visibility",
     "visibilityPrivate": "Private — only the owner and admins",
     "visibilityGroup": "Group (reserved — not yet implemented)",

--- a/src/controllers/toolController.ts
+++ b/src/controllers/toolController.ts
@@ -105,3 +105,41 @@ export const callTool = async (req: Request, res: Response): Promise<void> => {
     });
   }
 };
+
+/**
+ * Read a ui:// resource from a specific connected MCP server.
+ * Used by the MCP Apps host to fetch HTML content for sandboxed iframe rendering.
+ */
+export const readServerResource = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { serverName } = req.params;
+    const { uri } = req.body as { uri?: string };
+
+    if (!uri) {
+      res.status(400).json({ success: false, message: 'uri is required' });
+      return;
+    }
+
+    const serverInfo = getServerByName(serverName);
+    if (!serverInfo) {
+      res.status(404).json({ success: false, message: 'Server not found' });
+      return;
+    }
+
+    if (serverInfo.status !== 'connected' || !serverInfo.client) {
+      res.status(503).json({ success: false, message: 'Server not connected' });
+      return;
+    }
+
+    const result = await serverInfo.client.readResource({ uri });
+
+    const response: ApiResponse = { success: true, data: result };
+    res.json(response);
+  } catch (error) {
+    console.error('Error reading server resource:', error);
+    res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : 'Failed to read resource',
+    });
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -77,7 +77,7 @@ import {
   getPublicConfig,
   getMcpSettingsJson,
 } from '../controllers/configController.js';
-import { callTool } from '../controllers/toolController.js';
+import { callTool, readServerResource } from '../controllers/toolController.js';
 import { getPrompt } from '../controllers/promptController.js';
 import {
   listBuiltinPrompts,
@@ -315,6 +315,7 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
 
   // Tool management routes
   authenticatedRouter.post('/tools/call/:server', callTool);
+  authenticatedRouter.post('/servers/:serverName/resources/read', readServerResource);
 
   // Prompt management routes
   authenticatedRouter.post('/mcp/:serverName/prompts/:promptName', getPrompt);

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -25,6 +25,7 @@ import {
   ServerInfo,
   ServerConfig,
   Tool,
+  Resource,
   ProxychainsConfig,
   IGroupServerConfig,
 } from '../types/index.js';
@@ -356,13 +357,16 @@ const normalizeResourceForList = (resource: {
   name?: string | null;
   description?: string | null;
   mimeType?: string | null;
-}) => {
-  return {
+  _meta?: Record<string, unknown> | null;
+}): Resource => {
+  const result: Resource = {
     uri: resource.uri,
     name: resource.name || '',
     description: resource.description || '',
     mimeType: resource.mimeType || '',
   };
+  if (resource._meta) result._meta = resource._meta;
+  return result;
 };
 
 // Store all server information
@@ -933,6 +937,8 @@ const callToolWithReconnect = async (
               name: `${serverInfo.name}${getNameSeparator()}${tool.name}`,
               description: tool.description || '',
               inputSchema: cleanInputSchema(tool.inputSchema || {}),
+              ...(tool.annotations ? { annotations: tool.annotations } : {}),
+              ...((tool as any)._meta ? { _meta: (tool as any)._meta } : {}),
             }));
 
             // Save tools as vector embeddings for search
@@ -1210,11 +1216,16 @@ export const initializeClientsFromSettings = async (
               .listTools({}, initRequestOptions || requestOptions)
               .then((tools) => {
                 console.log(`Successfully listed ${tools.tools.length} tools for server: ${name}`);
-                serverInfo.tools = tools.tools.map((tool) => ({
-                  name: `${name}${getNameSeparator()}${tool.name}`,
-                  description: tool.description || '',
-                  inputSchema: cleanInputSchema(tool.inputSchema || {}),
-                }));
+                serverInfo.tools = tools.tools.map((tool) => {
+                  const rawMeta = (tool as any)._meta;
+                  return {
+                    name: `${name}${getNameSeparator()}${tool.name}`,
+                    description: tool.description || '',
+                    inputSchema: cleanInputSchema(tool.inputSchema || {}),
+                    ...(tool.annotations ? { annotations: tool.annotations } : {}),
+                    ...(rawMeta ? { _meta: rawMeta } : {}),
+                  };
+                });
                 // Save tools as vector embeddings for search
                 saveToolsAsVectorEmbeddings(name, serverInfo.tools, {
                   reportProgress: options?.reportEmbeddingProgress === true && serverName === name,
@@ -1275,6 +1286,7 @@ export const initializeClientsFromSettings = async (
                     name: resource.name,
                     description: resource.description,
                     mimeType: resource.mimeType,
+                    _meta: (resource as any)._meta,
                   }),
                 );
               })
@@ -2398,9 +2410,11 @@ export const handleListResourceTemplatesRequest = async (_: any, extra: any) => 
   };
 };
 
-export const handleReadResourceRequest = async (request: any, _extra: any) => {
+export const handleReadResourceRequest = async (request: any, extra: any) => {
   try {
     const { uri } = request.params;
+    const sessionId = extra?.sessionId || '';
+    const group = RequestContextService.getInstance().getGroupContext() || extra?.group || getGroup(sessionId) || undefined;
 
     // Check built-in resources first
     const builtinResource = await getBuiltinResourceDao().findByUri(uri);
@@ -2416,24 +2430,48 @@ export const handleReadResourceRequest = async (request: any, _extra: any) => {
       };
     }
 
-    // Find the server that owns this resource
-    const server = serverInfos.find(
-      (serverInfo) =>
-        serverInfo.status === 'connected' &&
-        serverInfo.enabled !== false &&
-        serverInfo.resources?.find((resource) => resource.uri === uri),
+    // When routing is scoped to a single server, use it directly.
+    if (extra?.server) {
+      const target = getServerByName(extra.server);
+      if (!target || target.status !== 'connected' || !target.client) {
+        throw new Error(`Server not available: ${extra.server}`);
+      }
+      const result = await target.client.readResource({ uri });
+      if (!result) throw new Error(`Failed to read resource: ${uri}`);
+      return result;
+    }
+
+    // Get servers scoped to the current group (or all servers if no group).
+    const { filteredServerInfos } = await getFilteredServerInfosForGroup(group);
+
+    // Find the server that has this resource pre-registered.
+    const owner = filteredServerInfos.find(
+      (s) => s.status === 'connected' &&
+        s.enabled !== false &&
+        s.resources?.some((r) => r.uri === uri),
     );
 
-    if (!server) {
-      throw new Error(`Resource not found: ${uri}`);
+    if (owner?.client) {
+      const result = await owner.client.readResource({ uri });
+      if (!result) throw new Error(`Failed to read resource: ${uri}`);
+      return result;
     }
 
-    const result = await server.client?.readResource({ uri });
-    if (!result) {
-      throw new Error(`Failed to read resource: ${uri}`);
+    // ui:// resources are generated dynamically at tool-call time and are never
+    // pre-registered. Try each server in scope until one answers.
+    if (uri.startsWith('ui://')) {
+      for (const candidate of filteredServerInfos) {
+        if (candidate.status !== 'connected' || !candidate.client) continue;
+        try {
+          const result = await candidate.client.readResource({ uri });
+          if (result) return result;
+        } catch {
+          // this candidate doesn't own the resource; try the next
+        }
+      }
     }
 
-    return result;
+    throw new Error(`Resource not found: ${uri}`);
   } catch (error) {
     console.error('Error handling ReadResourceRequest', summarizeErrorForLogging(error));
     const safeErrorText = formatErrorForLogging(error);

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -579,7 +579,7 @@ const getHttpErrorStatusCode = (error: unknown): number | undefined => {
 
 const isRecoverableHttp4xxError = (error: unknown): boolean => {
   const statusCode = getHttpErrorStatusCode(error);
-  if (statusCode !== undefined) {
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
     return statusCode === 401 || statusCode === 404;
   }
 
@@ -587,7 +587,8 @@ const isRecoverableHttp4xxError = (error: unknown): boolean => {
     ? (error as { message: string }).message
     : '';
 
-  return /Error POSTing to endpoint \(HTTP 40[14]/.test(message);
+  return /Error POSTing to endpoint \(HTTP 40[14]/.test(message) ||
+    message.includes('No valid session ID');
 };
 
 const summarizeContentItemForLogging = (item: unknown): Record<string, unknown> => {
@@ -1569,9 +1570,15 @@ const filterToolsByConfig = async (serverName: string, tools: Tool[]): Promise<T
   });
 };
 
-// Get server by tool name
+// Get server by tool name (matches both prefixed and unprefixed tool names)
 const getServerByTool = (toolName: string): ServerInfo | undefined => {
-  return serverInfos.find((serverInfo) => serverInfo.tools.some((tool) => tool.name === toolName));
+  return serverInfos.find((serverInfo) =>
+    serverInfo.tools.some(
+      (tool) =>
+        tool.name === toolName ||
+        tool.name === `${serverInfo.name}${getNameSeparator()}${toolName}`,
+    ),
+  );
 };
 
 // Add new server

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -480,6 +480,8 @@ export interface Tool {
   description: string; // Brief description of the tool
   inputSchema: Record<string, unknown>; // Input schema for the tool
   enabled?: boolean; // Whether the tool is enabled (optional, defaults to true)
+  annotations?: Record<string, unknown>; // Standard MCP tool annotations
+  _meta?: Record<string, unknown>; // Passthrough metadata (e.g. 'ui/resourceUri' for MCP Apps)
 }
 
 export interface Prompt {
@@ -502,6 +504,7 @@ export interface Resource {
   name?: string; // Human-readable name
   description?: string; // Brief description of the resource
   mimeType?: string; // MIME type of the resource content
+  _meta?: Record<string, unknown>; // MCP Apps metadata (e.g., ui CSP config)
 }
 
 // Built-in prompt defined via configuration

--- a/tests/routes/index.test.ts
+++ b/tests/routes/index.test.ts
@@ -101,6 +101,7 @@ jest.mock('../../src/controllers/configController.js', () => ({
 
 jest.mock('../../src/controllers/toolController.js', () => ({
   callTool: routeHandler,
+  readServerResource: routeHandler,
 }));
 
 jest.mock('../../src/controllers/promptController.js', () => ({
@@ -282,6 +283,7 @@ describe('initRoutes authenticated API rate limiting', () => {
 
     expect(authenticatedLimiterIndex).toBeGreaterThanOrEqual(0);
     expect(routerContainsRoute(protectedRouter!, 'get', '/servers/:name')).toBe(true);
+    expect(routerContainsRoute(protectedRouter!, 'post', '/servers/:serverName/resources/read')).toBe(true);
     expect(routerContainsRoute(protectedRouter!, 'put', '/oauth/clients/:clientId')).toBe(true);
     expect(routerContainsRoute(protectedRouter!, 'delete', '/oauth/clients/:clientId')).toBe(true);
   });


### PR DESCRIPTION
This PR adds

  * /resources/read api endpoint to read the html ui
  * _meta properties for the mcp apps client to find the ui
  * a badge in mcphub UI to show if a server is an mcp app

Code co-written with claude sonnet 4.5