### PR TITLE
feat: add Context Footprint — per-server/group token cost in the dashboard

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,37 @@
+# MCPHub
+
+Domain glossary for MCPHub — a hub that aggregates multiple MCP servers behind a single HTTP/SSE surface. This file is the canonical source for project-specific vocabulary; use these terms (and avoid the listed synonyms) in code, issues, and UI copy.
+
+## Language
+
+**Definition Cost**:
+The number of tokens a single exposed item (a Tool, Prompt, or Resource) adds to a model's context window when its definition is listed to that model. For a tool, measured over its name, description, and complete input schema; for prompts and resources, over their listed definition fields. An estimate, not a billed figure, because the true count depends on the consuming client's model and framing. A tool's Definition Cost is dominated by its input schema.
+_Avoid_: token size, tool weight, context usage
+
+**Context Footprint**:
+The total Definition Cost a Server or Group imposes on a connecting client, reported as a pair of co-equal numbers: its Exposed Footprint and its Gross Footprint. This is what the cost feature surfaces per Server and per Group.
+_Avoid_: total cost, total size, token total
+
+**Exposed Footprint**:
+The Context Footprint counting only the items a client actually receives — for a Server, its enabled items; for a Group, the items each member server has selected into that group (and enabled). The number you actually pay.
+_Avoid_: effective cost, net cost
+
+**Gross Footprint**:
+The Context Footprint counting every item a Server reports, ignoring enabled/selection state — the maximum potential cost. For a Group, the sum of its member servers' Gross Footprints. Shown alongside Exposed Footprint so the savings from curation are visible.
+_Avoid_: total cost, raw cost, full cost
+
+**Connection Mode**:
+How a client consumes a Group or all-servers scope, which determines what definitions it registers: **Direct** (registers every exposed item's definition — costs the Exposed Footprint) or **Smart Routing** (registers only Meta-tools — costs the Smart Routing Footprint). The cost feature reports a number per applicable mode.
+_Avoid_: routing type, access mode
+
+**Meta-tool**:
+One of the fixed scaffolding tools Smart Routing registers in place of the underlying tools: `search_tools` and `call_tool` always, plus `describe_tool` under Progressive Disclosure. A Meta-tool's definition is not constant — its description embeds the in-scope server names and group name, so its Definition Cost varies slightly by scope.
+_Avoid_: virtual tool, proxy tool, system tool
+
+**Smart Routing Footprint**:
+The Context Footprint of a scope under Smart Routing — the summed Definition Cost of its Meta-tool set (two Meta-tools normally, three under Progressive Disclosure) as constructed for that scope. Far smaller than the Direct/Exposed Footprint; this contrast is the feature's headline value.
+_Avoid_: smart cost, routing cost
+
+**Progressive Disclosure**:
+A global Smart Routing mode that adds the `describe_tool` Meta-tool and keeps tool schemas out of search results, fetching them on demand. It raises the upfront Smart Routing Footprint by one Meta-tool while shrinking each search response — a trade this feature measures only on the upfront (definition) side.
+_Avoid_: lazy disclosure, deferred schema, PD (in UI copy)

--- a/docs/adr/0001-cl100k-tokenizer-for-definition-cost.md
+++ b/docs/adr/0001-cl100k-tokenizer-for-definition-cost.md
@@ -1,0 +1,9 @@
+# Estimate Definition Cost with the cl100k_base tokenizer
+
+For the Context Footprint feature we compute every item's Definition Cost using `gpt-tokenizer` (OpenAI's cl100k_base BPE), even though MCPHub mostly serves non-GPT clients (Claude, etc.) whose true token counts differ by ~10–20%. We chose it because it is synchronous, offline, deterministic, and already a dependency — unlike the embedding tokenizers in `tokenTruncation.ts`, whose HuggingFace backend downloads a model and whose Gemini backend needs an API key and a network round-trip, neither acceptable for rendering a page. The displayed number is therefore explicitly an **estimate**, labelled as such in the UI, and is meant for *relative* comparison (tool vs tool, Direct vs Smart Routing), not as an exact per-client bill.
+
+## Considered Options
+
+- **Per-model selector (GPT/Claude/Gemini)** — rejected for v1: no offline JS tokenizer for Claude/Gemini in the deps, so it means new dependencies or network calls.
+- **Reuse the configured embedding tokenizer** — rejected: may force network/API-key use just to render the UI, and embedding tokenizers aren't chat tokenizers, so it's slower without being more honest.
+- **Char-based heuristic** — rejected: visibly wrong for JSON-heavy schemas, undermines a feature whose whole point is token precision.

--- a/docs/adr/0002-definition-cost-is-upfront-only.md
+++ b/docs/adr/0002-definition-cost-is-upfront-only.md
@@ -1,0 +1,7 @@
+# Definition Cost measures upfront registered definitions only
+
+The Context Footprint feature counts only the token cost of definitions a client registers **upfront** (tool/prompt/resource definitions, or Smart Routing's Meta-tool definitions). A consequence: enabling **Progressive Disclosure** *raises* the reported Smart Routing Footprint, because it adds a third Meta-tool (`describe_tool`) to the upfront set. This is intentional and correct under our definition. Progressive Disclosure's actual benefit is **dynamic** — it shrinks each `search_tools` response by deferring tool schemas — and that per-search saving is deliberately out of scope, because modelling it would require speculative assumptions (results per search, sessions per task) that would make the headline numbers unfalsifiable.
+
+## Consequences
+
+A reader comparing the three numbers (Direct → Smart Routing → Smart Routing + PD) will see PD as slightly *more* expensive and may assume a bug. The PD row carries a tooltip explaining it adds a meta-tool for smaller per-search responses, and this ADR exists so the decision isn't silently "corrected" later. If a future version wants to show PD's dynamic win, it should add a **separate** modelled metric rather than fold assumptions into Definition Cost.

--- a/frontend/src/components/AddGroupForm.tsx
+++ b/frontend/src/components/AddGroupForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useGroupData } from '@/hooks/useGroupData';
 import { useServerData } from '@/hooks/useServerData';
+import { useCostData } from '@/hooks/useCostData';
 import { GroupFormData, Server, IGroupServerConfig } from '@/types';
 import { ServerToolConfig } from './ServerToolConfig';
 
@@ -14,6 +15,7 @@ const AddGroupForm = ({ onAdd, onCancel }: AddGroupFormProps) => {
   const { t } = useTranslation();
   const { createGroup } = useGroupData();
   const { allServers } = useServerData();
+  const { serverCosts } = useCostData();
   const [availableServers, setAvailableServers] = useState<Server[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -104,6 +106,7 @@ const AddGroupForm = ({ onAdd, onCancel }: AddGroupFormProps) => {
                   value={formData.servers as IGroupServerConfig[]}
                   onChange={(servers) => setFormData((prev) => ({ ...prev, servers }))}
                   className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-gray-50 dark:bg-gray-800"
+                  serverCosts={serverCosts}
                 />
               </div>
             </div>

--- a/frontend/src/components/EditGroupForm.tsx
+++ b/frontend/src/components/EditGroupForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Group, GroupFormData, Server, IGroupServerConfig } from '@/types';
 import { useGroupData } from '@/hooks/useGroupData';
 import { useServerData } from '@/hooks/useServerData';
+import { useCostData } from '@/hooks/useCostData';
 import { ServerToolConfig } from './ServerToolConfig';
 
 interface EditGroupFormProps {
@@ -15,6 +16,7 @@ const EditGroupForm = ({ group, onEdit, onCancel }: EditGroupFormProps) => {
   const { t } = useTranslation();
   const { updateGroup } = useGroupData();
   const { allServers } = useServerData();
+  const { serverCosts } = useCostData();
   const [availableServers, setAvailableServers] = useState<Server[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -110,6 +112,7 @@ const EditGroupForm = ({ group, onEdit, onCancel }: EditGroupFormProps) => {
                   value={formData.servers as IGroupServerConfig[]}
                   onChange={(servers) => setFormData((prev) => ({ ...prev, servers }))}
                   className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-gray-50 dark:bg-gray-800"
+                  serverCosts={serverCosts}
                 />
               </div>
             </div>

--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -1,16 +1,18 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Edit3, Trash2, Copy, Check, Link as LinkIcon, FileCode, ChevronDown } from 'lucide-react';
-import { Group, Server, IGroupServerConfig } from '@/types';
+import { Group, Server, IGroupServerConfig, GroupCost } from '@/types';
 import DeleteDialog from '@/components/ui/DeleteDialog';
 import { useToast } from '@/contexts/ToastContext';
 import { useSettingsData } from '@/hooks/useSettingsData';
+import { formatTokens, percentSaved } from '@/utils/contextCost';
 
 interface GroupCardProps {
   group: Group;
   servers: Server[];
   onEdit: (group: Group) => void;
   onDelete: (groupId: string) => void;
+  cost?: GroupCost;
 }
 
 const getServerNames = (servers: string[] | IGroupServerConfig[]): string[] =>
@@ -55,7 +57,7 @@ const copyText = async (value: string): Promise<boolean> => {
   }
 };
 
-const GroupCard = ({ group, servers, onEdit, onDelete }: GroupCardProps) => {
+const GroupCard = ({ group, servers, onEdit, onDelete, cost }: GroupCardProps) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { installConfig, nameSeparator } = useSettingsData();
@@ -357,11 +359,34 @@ const GroupCard = ({ group, servers, onEdit, onDelete }: GroupCardProps) => {
           color: 'var(--hub-ink-3)',
         }}
       >
-        <div className="hub-mono">
-          <span style={{ color: 'var(--hub-ink-2)' }}>{groupServers.length}</span>{' '}
-          {t('nav.servers').toLowerCase()} ·{' '}
-          <span style={{ color: 'var(--hub-ink-2)' }}>{totalVisibleTools}</span>{' '}
-          {t('server.tools').toLowerCase()}
+        <div>
+          <div className="hub-mono">
+            <span style={{ color: 'var(--hub-ink-2)' }}>{groupServers.length}</span>{' '}
+            {t('nav.servers').toLowerCase()} ·{' '}
+            <span style={{ color: 'var(--hub-ink-2)' }}>{totalVisibleTools}</span>{' '}
+            {t('server.tools').toLowerCase()}
+          </div>
+          {cost && (
+            <div className="hub-mono mt-1" style={{ fontSize: 11.5, color: 'var(--hub-ink-3)' }}>
+              <div title={t('cost.estimate')}>
+                {t('cost.totalFootprint')}: {formatTokens(cost.direct.exposed)}/{formatTokens(cost.direct.gross)}
+              </div>
+              {cost.smartRouting && (
+                <>
+                  <div>
+                    {t('cost.smartRouting')}: {formatTokens(cost.smartRouting.base)}{' '}
+                    ({t('cost.saved', { percent: percentSaved(cost.direct.exposed, cost.smartRouting.base) })})
+                  </div>
+                  <div title={t('cost.smartRoutingPdHint')}>
+                    {t('cost.smartRoutingPd')}: {formatTokens(cost.smartRouting.progressiveDisclosure)}
+                  </div>
+                </>
+              )}
+              {cost.connectedCount < cost.totalCount && (
+                <div>{t('cost.connectedOf', { connected: cost.connectedCount, total: cost.totalCount })}</div>
+              )}
+            </div>
+          )}
         </div>
         <button
           className="hub-btn ghost sm"

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -15,7 +15,8 @@ import {
   Trash2,
   type LucideIcon,
 } from 'lucide-react';
-import { Server } from '@/types';
+import { Server, ServerCost } from '@/types';
+import { formatTokens } from '@/utils/contextCost';
 import { ServerStatusDot } from '@/components/ui/StatusDot';
 import ToolCard from '@/components/ui/ToolCard';
 import PromptCard from '@/components/ui/PromptCard';
@@ -33,6 +34,7 @@ import {
 
 interface ServerCardProps {
   server: Server;
+  cost?: ServerCost;
   onRemove: (serverName: string) => void;
   onEdit: (server: Server) => void;
   onToggle?: (server: Server, enabled: boolean) => Promise<boolean>;
@@ -128,6 +130,7 @@ const serverExposesMcpApp = (server: Server) => {
 
 const ServerCard = ({
   server,
+  cost,
   onRemove,
   onEdit,
   onToggle,
@@ -142,7 +145,9 @@ const ServerCard = ({
   const baseUrl = installConfig?.baseUrl?.replace(/\/+$/, '') || '';
 
   const [expanded, setExpanded] = useState(false);
-  const [expandedTab, setExpandedTab] = useState<'tools' | 'prompts' | 'resources' | null>(null);
+  const [expandedTab, setExpandedTab] = useState<'tools' | 'prompts' | 'resources' | 'cost' | null>(
+    null,
+  );
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isToggling, setIsToggling] = useState(false);
   const [isUpdatingVisibility, setIsUpdatingVisibility] = useState(false);
@@ -631,6 +636,23 @@ const ServerCard = ({
             );
           })}
 
+          {/* Context Footprint stat */}
+          {cost && cost.connected ? (
+            <span
+              className="hub-server-capability-stat hub-mono hub-num"
+              title={`${t('cost.exposed')} ${cost.exposed} / ${t('cost.gross')} ${cost.gross} · ${t('cost.estimate')}`}
+            >
+              <span className="text-[var(--hub-ink-3)]">Σ</span>
+              <span className="hub-server-capability-value">
+                {formatTokens(cost.exposed)}/{formatTokens(cost.gross)}
+              </span>
+            </span>
+          ) : cost ? (
+            <span className="hub-server-capability-stat hub-mono is-empty" title={t('cost.notConnected')}>
+              <span className="hub-server-capability-value">—</span>
+            </span>
+          ) : null}
+
           {/* Toggle switch */}
           <div className="flex items-center justify-center">
             <LoadingControl
@@ -751,6 +773,29 @@ const ServerCard = ({
                 );
               })}
 
+              {/* Context cost tab */}
+              {cost && cost.connected && (
+                <button
+                  onClick={() => setExpandedTab(expandedTab === 'cost' ? null : 'cost')}
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[12px] transition-colors hover:bg-[var(--hub-surface-hover)]"
+                  style={{
+                    background: expandedTab === 'cost' ? 'var(--hub-surface)' : 'transparent',
+                    border: '1px solid ' + (expandedTab === 'cost' ? 'var(--hub-line)' : 'transparent'),
+                    color: expandedTab === 'cost' ? 'var(--hub-ink)' : 'var(--hub-ink-2)',
+                  }}
+                  title={t('cost.estimate')}
+                >
+                  <span style={{ color: 'var(--hub-ink-3)' }}>Σ</span>
+                  <span>{t('cost.totalFootprint')}</span>
+                  <span
+                    className="hub-mono hub-num"
+                    style={{ color: 'var(--hub-ink-3)', fontSize: 11 }}
+                  >
+                    {formatTokens(cost.exposed)}/{formatTokens(cost.gross)}
+                  </span>
+                </button>
+              )}
+
               {/* Endpoint inline, pushed to the right */}
               <div className="ml-auto max-w-full flex-shrink-0">
                 <div className="hub-endpoint" style={{ height: 26 }}>
@@ -777,6 +822,22 @@ const ServerCard = ({
               </div>
             </div>
 
+            {/* Context Footprint breakdown */}
+            {expandedTab === 'cost' && cost?.connected && (
+              <div className="mt-2 space-y-1">
+                {[...cost.items].sort((a, b) => b.cost - a.cost).map((item) => (
+                  <div
+                    key={`${item.kind}:${item.name}`}
+                    className="flex items-center justify-between hub-mono"
+                    style={{ fontSize: 11.5, color: item.enabled ? 'var(--hub-ink-2)' : 'var(--hub-ink-3)' }}
+                  >
+                    <span className="truncate">{item.name}</span>
+                    <span className="hub-num flex-shrink-0">{formatTokens(item.cost)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
             {expandedTab === 'tools' && server.tools && (
               <div className="space-y-3 mt-2">
                 {server.tools.map((tool, index) => (
@@ -787,6 +848,7 @@ const ServerCard = ({
                     readOnly={!canManage}
                     onToggle={handleToolToggle}
                     onDescriptionUpdate={handleToolDescriptionUpdate}
+                    cost={cost?.items.find((i) => i.kind === 'tool' && i.name === tool.name)?.cost}
                   />
                 ))}
               </div>
@@ -801,6 +863,7 @@ const ServerCard = ({
                     readOnly={!canManage}
                     onToggle={handlePromptToggle}
                     onDescriptionUpdate={handlePromptDescriptionUpdate}
+                    cost={cost?.items.find((i) => i.kind === 'prompt' && i.name === prompt.name)?.cost}
                   />
                 ))}
               </div>
@@ -820,6 +883,7 @@ const ServerCard = ({
                         readOnly={!canManage}
                         onToggle={handleResourceToggle}
                         onDescriptionUpdate={handleResourceDescriptionUpdate}
+                        cost={cost?.items.find((i) => i.kind === 'resource' && i.name === resource.uri)?.cost}
                       />
                     ))}
                   </div>

--- a/frontend/src/components/ServerToolConfig.tsx
+++ b/frontend/src/components/ServerToolConfig.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { IGroupServerConfig, Prompt, Resource, Server, Tool } from '@/types';
+import { IGroupServerConfig, Prompt, Resource, Server, ServerCost, Tool } from '@/types';
 import { Wrench, MessageSquare, FileText } from 'lucide-react';
 import { cn } from '@/utils/cn';
 import { useSettingsData } from '@/hooks/useSettingsData';
+import { formatTokens } from '@/utils/contextCost';
 
 type CapabilityKey = 'tools' | 'prompts' | 'resources';
 
@@ -24,13 +25,15 @@ interface ServerToolConfigProps {
   value: string[] | IGroupServerConfig[];
   onChange: (value: IGroupServerConfig[]) => void;
   className?: string;
+  serverCosts?: ServerCost[];
 }
 
 export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   servers,
   value,
   onChange,
-  className
+  className,
+  serverCosts = [],
 }) => {
   const { t } = useTranslation();
   const { nameSeparator } = useSettingsData();
@@ -173,6 +176,24 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
     }));
   };
 
+  const costMapForServer = (serverName: string): Map<string, number> => {
+    const sc = serverCosts.find((c) => c.name === serverName);
+    const map = new Map<string, number>();
+    sc?.items.forEach((i) => map.set(i.name, i.cost));
+    return map;
+  };
+
+  const getSelectedCapabilityCost = (server: Server, capability: CapabilityKey): number => {
+    const costMap = costMapForServer(server.name);
+    return getCapabilityItems(server, capability)
+      .filter((item) => isCapabilityItemSelected(server.name, capability, item.value))
+      .reduce((sum, item) => sum + (costMap.get(item.key) ?? 0), 0);
+  };
+
+  const getServerSelectedCost = (server: Server): number =>
+    (['tools', 'prompts', 'resources'] as CapabilityKey[])
+      .reduce((sum, cap) => sum + getSelectedCapabilityCost(server, cap), 0);
+
   const toggleCapabilityItem = (serverName: string, capability: CapabilityKey, itemValue: string) => {
     const server = availableServers.find(s => s.name === serverName);
     if (!server) return;
@@ -274,6 +295,7 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
           const serverConfig = normalizedValue.find(config => config.name === server.name);
           const summaryBadges = getServerSummaryBadges(server);
           const serverCapabilities = capabilityConfigs.filter(({ key }) => getCapabilityItems(server, key).length > 0);
+          const costMap = costMapForServer(server.name);
 
           return (
             <div key={server.name} className="border border-gray-200 dark:border-gray-700 rounded-lg hover:border-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors">
@@ -300,6 +322,11 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
                 </div>
 
                 <div className="flex items-center space-x-3">
+                  {getServerSelectedCost(server) > 0 && (
+                    <span className="text-sm text-gray-400 hub-mono" title={t('cost.estimate')}>
+                      Σ {formatTokens(getServerSelectedCost(server))}
+                    </span>
+                  )}
                   {summaryBadges.map(({ key, count }) => (
                     <span key={key} className="text-sm text-green-600 flex items-center gap-1">
                       {key === 'tools' ? <Wrench size={14} /> : key === 'prompts' ? <MessageSquare size={14} /> : <FileText size={14} />} {count}
@@ -346,6 +373,11 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
                                     : `(${t(countKey)} ${selectedCount}/${items.length})`}
                                 </span>
                               )}
+                              {serverConfig && getSelectedCapabilityCost(server, key) > 0 && (
+                                <span className="text-xs text-gray-400 hub-mono" title={t('cost.estimate')}>
+                                  Σ {formatTokens(getSelectedCapabilityCost(server, key))}
+                                </span>
+                              )}
                               <button
                                 type="button"
                                 onClick={() => {
@@ -381,6 +413,11 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
                                   {item.description && (
                                     <span className="text-gray-400 text-xs truncate">
                                       {item.description}
+                                    </span>
+                                  )}
+                                  {costMap.get(item.key) != null && (
+                                    <span className="text-xs text-gray-400 hub-mono whitespace-nowrap ml-auto flex-shrink-0" title={t('cost.estimate')}>
+                                      Σ {formatTokens(costMap.get(item.key)!)}
                                     </span>
                                   )}
                                 </label>

--- a/frontend/src/components/ServerToolConfig.tsx
+++ b/frontend/src/components/ServerToolConfig.tsx
@@ -176,12 +176,20 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
     }));
   };
 
-  const costMapForServer = (serverName: string): Map<string, number> => {
-    const sc = serverCosts.find((c) => c.name === serverName);
-    const map = new Map<string, number>();
-    sc?.items.forEach((i) => map.set(i.name, i.cost));
-    return map;
-  };
+  // Build one nested map (server -> item name -> cost) once per serverCosts change,
+  // so per-render lookups don't rebuild a Map on every call (avoids O(N^2) churn).
+  const serverCostsMap = React.useMemo(() => {
+    const outerMap = new Map<string, Map<string, number>>();
+    serverCosts.forEach((sc) => {
+      const innerMap = new Map<string, number>();
+      sc.items.forEach((i) => innerMap.set(i.name, i.cost));
+      outerMap.set(sc.name, innerMap);
+    });
+    return outerMap;
+  }, [serverCosts]);
+
+  const costMapForServer = (serverName: string): Map<string, number> =>
+    serverCostsMap.get(serverName) ?? new Map<string, number>();
 
   const getSelectedCapabilityCost = (server: Server, capability: CapabilityKey): number => {
     const costMap = costMapForServer(server.name);

--- a/frontend/src/components/ui/PromptCard.tsx
+++ b/frontend/src/components/ui/PromptCard.tsx
@@ -21,6 +21,7 @@ import DynamicForm from './DynamicForm';
 import PromptResult from './PromptResult';
 import { useToast } from '@/contexts/ToastContext';
 import ResetDescriptionButton from './ResetDescriptionButton';
+import { formatTokens } from '@/utils/contextCost';
 
 interface PromptCardProps {
   server: string;
@@ -32,9 +33,10 @@ interface PromptCardProps {
     description: string,
     options?: { restored?: boolean },
   ) => void;
+  cost?: number;
 }
 
-const PromptCard = ({ prompt, server, readOnly = false, onToggle, onDescriptionUpdate }: PromptCardProps) => {
+const PromptCard = ({ prompt, server, readOnly = false, onToggle, onDescriptionUpdate, cost }: PromptCardProps) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { nameSeparator } = useSettingsData();
@@ -278,6 +280,15 @@ const PromptCard = ({ prompt, server, readOnly = false, onToggle, onDescriptionU
           </span>
         </div>
         <div className="flex items-center gap-1.5 flex-shrink-0">
+          {cost != null && (
+            <span
+              className="hub-mono flex-shrink-0"
+              style={{ fontSize: 11, color: 'var(--hub-ink-3)' }}
+              title={t('cost.estimate')}
+            >
+              Σ {formatTokens(cost)}
+            </span>
+          )}
           <div onClick={(e) => e.stopPropagation()}>
             {prompt.enabled !== undefined && (
               <Switch

--- a/frontend/src/components/ui/ResourceCard.tsx
+++ b/frontend/src/components/ui/ResourceCard.tsx
@@ -4,6 +4,7 @@ import { Check, ChevronDown, ChevronRight, Edit } from '@/components/icons/Lucid
 import { Resource } from '@/types';
 import { Switch } from './ToggleGroup';
 import ResetDescriptionButton from './ResetDescriptionButton';
+import { formatTokens } from '@/utils/contextCost';
 
 interface ResourceCardProps {
   resource: Resource;
@@ -14,9 +15,10 @@ interface ResourceCardProps {
     description: string,
     options?: { restored?: boolean },
   ) => Promise<void> | void;
+  cost?: number;
 }
 
-const ResourceCard = ({ resource, readOnly = false, onToggle, onDescriptionUpdate }: ResourceCardProps) => {
+const ResourceCard = ({ resource, readOnly = false, onToggle, onDescriptionUpdate, cost }: ResourceCardProps) => {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
@@ -149,6 +151,15 @@ const ResourceCard = ({ resource, readOnly = false, onToggle, onDescriptionUpdat
         </div>
 
         <div className="flex items-center gap-1.5 flex-shrink-0">
+          {cost != null && (
+            <span
+              className="hub-mono flex-shrink-0"
+              style={{ fontSize: 11, color: 'var(--hub-ink-3)' }}
+              title={t('cost.estimate')}
+            >
+              Σ {formatTokens(cost)}
+            </span>
+          )}
           <div onClick={(e) => e.stopPropagation()}>
             <Switch
               checked={resource.enabled !== false}

--- a/frontend/src/components/ui/ToolCard.tsx
+++ b/frontend/src/components/ui/ToolCard.tsx
@@ -22,6 +22,7 @@ import { Switch } from './ToggleGroup';
 import DynamicForm from './DynamicForm';
 import ToolResult from './ToolResult';
 import ResetDescriptionButton from './ResetDescriptionButton';
+import { formatTokens } from '@/utils/contextCost';
 
 interface ToolCardProps {
   server: string;
@@ -33,6 +34,7 @@ interface ToolCardProps {
     description: string,
     options?: { restored?: boolean },
   ) => void;
+  cost?: number;
 }
 
 // Helper to check for "empty" values
@@ -44,7 +46,7 @@ function isEmptyValue(value: any): boolean {
   return false;
 }
 
-const ToolCard = ({ tool, server, readOnly = false, onToggle, onDescriptionUpdate }: ToolCardProps) => {
+const ToolCard = ({ tool, server, readOnly = false, onToggle, onDescriptionUpdate, cost }: ToolCardProps) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
   const { nameSeparator } = useSettingsData();
@@ -311,6 +313,15 @@ const ToolCard = ({ tool, server, readOnly = false, onToggle, onDescriptionUpdat
           </span>
         </div>
         <div className="flex items-center gap-1.5 flex-shrink-0">
+          {cost != null && (
+            <span
+              className="hub-mono flex-shrink-0"
+              style={{ fontSize: 11, color: 'var(--hub-ink-3)' }}
+              title={t('cost.estimate')}
+            >
+              Σ {formatTokens(cost)}
+            </span>
+          )}
           <div onClick={(e) => e.stopPropagation()}>
             <Switch
               checked={tool.enabled ?? true}

--- a/frontend/src/hooks/useCostData.ts
+++ b/frontend/src/hooks/useCostData.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from 'react';
+import { apiGet } from '../utils/fetchInterceptor';
+import type { ApiResponse, ServerCost, GroupCost } from '@/types';
+
+export const useCostData = () => {
+  const [serverCosts, setServerCosts] = useState<ServerCost[]>([]);
+  const [groupCosts, setGroupCosts] = useState<GroupCost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchCosts = useCallback(async () => {
+    try {
+      setLoading(true);
+      const [servers, groups] = await Promise.all([
+        apiGet('/cost/servers') as Promise<ApiResponse<ServerCost[]>>,
+        apiGet('/cost/groups') as Promise<ApiResponse<GroupCost[]>>,
+      ]);
+      if (servers?.success && Array.isArray(servers.data)) setServerCosts(servers.data);
+      if (groups?.success && Array.isArray(groups.data)) setGroupCosts(groups.data);
+    } catch (err) {
+      console.error('Error fetching context footprint:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCosts();
+  }, [fetchCosts]);
+
+  return { serverCosts, groupCosts, loading, refetch: fetchCosts };
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -232,7 +232,7 @@
     fit-content(92px)
     fit-content(72px)
     minmax(94px, 108px)
-    repeat(3, 88px)
+    repeat(4, 88px)
     44px
     28px;
 }
@@ -346,7 +346,7 @@
       fit-content(88px)
       fit-content(66px)
       minmax(90px, 102px)
-      repeat(3, 80px)
+      repeat(4, 80px)
       44px
       28px;
   }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,8 @@ import { RefreshCw, Plus, ChevronRight, AlertCircle } from 'lucide-react';
 import { useServerData } from '@/hooks/useServerData';
 import { useGroupData } from '@/hooks/useGroupData';
 import { useSettingsData } from '@/hooks/useSettingsData';
+import { useCostData } from '@/hooks/useCostData';
+import { formatTokens } from '@/utils/contextCost';
 import { Server } from '@/types';
 import { EndpointCopy } from '@/components/ui/EndpointCopy';
 import { ServerStatusDot } from '@/components/ui/StatusDot';
@@ -63,6 +65,7 @@ const DashboardPage: React.FC = () => {
   });
   const { groups } = useGroupData();
   const { installConfig } = useSettingsData();
+  const { serverCosts } = useCostData();
 
   const [hasLoaded, setHasLoaded] = React.useState(false);
   const loadingStartedRef = React.useRef(false);
@@ -93,6 +96,11 @@ const DashboardPage: React.FC = () => {
       tools: allServers.reduce((acc, s) => acc + (s.tools?.length || 0), 0),
     }),
     [allServers],
+  );
+
+  const footprint = useMemo(
+    () => serverCosts.filter((c) => c.connected).reduce((acc, c) => acc + c.exposed, 0),
+    [serverCosts],
   );
 
   const recentServers = useMemo(() => allServers.slice(0, 6), [allServers]);
@@ -150,8 +158,8 @@ const DashboardPage: React.FC = () => {
 
       {/* Stat row */}
       {showSkeleton ? (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
-          {Array.from({ length: 5 }).map((_, i) => (
+        <div className="grid grid-cols-2 md:grid-cols-6 gap-3 mb-6">
+          {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
               className="hub-card animate-pulse"
@@ -160,12 +168,13 @@ const DashboardPage: React.FC = () => {
           ))}
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-6 gap-3 mb-6">
           <Stat label={t('pages.dashboard.totalServers')} value={stats.total} />
           <Stat label={t('pages.dashboard.onlineServers')} value={stats.online} tone="ok" />
           <Stat label={t('pages.dashboard.connectingServers')} value={stats.connecting} tone="warn" />
           <Stat label={t('pages.dashboard.offlineServers')} value={stats.offline} tone="err" />
           <Stat label={t('pages.dashboard.disabledServers')} value={stats.disabled} tone="muted" />
+          <Stat label={t('cost.totalFootprint')} value={formatTokens(footprint)} />
         </div>
       )}
 

--- a/frontend/src/pages/GroupsPage.tsx
+++ b/frontend/src/pages/GroupsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus, Download, Upload, AlertCircle, X } from 'lucide-react';
 import { Group } from '@/types';
@@ -10,6 +10,7 @@ import GroupCard from '@/components/GroupCard';
 import GroupImportForm from '@/components/GroupImportForm';
 import TemplateExportForm from '@/components/TemplateExportForm';
 import TemplateImportForm from '@/components/TemplateImportForm';
+import { useCostData } from '@/hooks/useCostData';
 
 const GroupsPage: React.FC = () => {
   const { t } = useTranslation();
@@ -22,6 +23,12 @@ const GroupsPage: React.FC = () => {
     triggerRefresh,
   } = useGroupData();
   const { allServers } = useServerData({ refreshOnMount: true });
+  const { groupCosts, refetch: refetchCost } = useCostData();
+
+  // Re-fetch context footprint whenever group definitions or server connection state change.
+  useEffect(() => {
+    refetchCost();
+  }, [groups, allServers, refetchCost]);
 
   const [editingGroup, setEditingGroup] = useState<Group | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
@@ -98,6 +105,7 @@ const GroupsPage: React.FC = () => {
               servers={allServers}
               onEdit={setEditingGroup}
               onDelete={handleDeleteGroup}
+              cost={groupCosts.find((c) => c.id === group.id)}
             />
           ))}
           <button

--- a/frontend/src/pages/ServersPage.tsx
+++ b/frontend/src/pages/ServersPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Plus, RefreshCw, Search, Upload, FileCode, AlertCircle, X } from 'lucide-react';
@@ -10,6 +10,7 @@ import McpbUploadForm from '@/components/McpbUploadForm';
 import JSONImportForm from '@/components/JSONImportForm';
 import Pagination from '@/components/ui/Pagination';
 import { useServerData } from '@/hooks/useServerData';
+import { useCostData } from '@/hooks/useCostData';
 
 type Filter = 'all' | 'online' | 'issues';
 
@@ -35,6 +36,13 @@ const ServersPage: React.FC = () => {
     handleServerReload,
     triggerRefresh,
   } = useServerData({ refreshOnMount: true });
+
+  const { serverCosts, refetch: refetchCost } = useCostData();
+
+  // Re-fetch context footprint whenever server data changes (toggle, reload, edit).
+  useEffect(() => {
+    refetchCost();
+  }, [servers, refetchCost]);
 
   const [editingServer, setEditingServer] = useState<Server | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -222,6 +230,7 @@ const ServersPage: React.FC = () => {
               <ServerCard
                 key={server.name}
                 server={server}
+                cost={serverCosts.find((c) => c.name === server.name)}
                 onRemove={handleServerRemove}
                 onEdit={handleEditClick}
                 onToggle={handleServerToggle}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -738,3 +738,33 @@ export interface TemplateImportDetail {
   action: 'created' | 'skipped' | 'failed';
   message?: string;
 }
+
+// Context Footprint cost DTOs
+export interface ItemCost {
+  kind: 'tool' | 'prompt' | 'resource';
+  name: string;
+  cost: number;
+  enabled: boolean;
+}
+
+export interface ServerCost {
+  name: string;
+  connected: boolean;
+  exposed: number;
+  gross: number;
+  items: ItemCost[];
+}
+
+export interface SmartRoutingCost {
+  base: number;
+  progressiveDisclosure: number;
+}
+
+export interface GroupCost {
+  id: string;
+  name: string;
+  connectedCount: number;
+  totalCount: number;
+  direct: { exposed: number; gross: number };
+  smartRouting: SmartRoutingCost | null;
+}

--- a/frontend/src/utils/contextCost.ts
+++ b/frontend/src/utils/contextCost.ts
@@ -1,0 +1,14 @@
+/** Display helpers for the Context Footprint feature. */
+
+/** Compact token formatting: 940 -> "940", 4200 -> "4.2k". */
+export function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}
+
+/** Integer percent reduction from `direct` to `smart`, clamped to [0, 100]. */
+export function percentSaved(direct: number, smart: number): number {
+  if (direct <= 0) return 0;
+  const pct = Math.round(((direct - smart) / direct) * 100);
+  return Math.max(0, Math.min(100, pct));
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1132,5 +1132,18 @@
     "serversInGroup": "server(s)",
     "envVarsNeeded": "Required Environment Variables — set these before using the imported servers:",
     "importResult": "Servers: {{serversCreated}} created, {{serversSkipped}} skipped. Groups: {{groupsCreated}} created, {{groupsSkipped}} skipped."
+  },
+  "cost": {
+    "exposed": "Exposed",
+    "gross": "Gross",
+    "estimate": "Estimated tokens (cl100k) — approximate",
+    "direct": "Direct",
+    "smartRouting": "Smart routing",
+    "smartRoutingPd": "Smart routing + progressive disclosure",
+    "smartRoutingPdHint": "Adds the describe_tool meta-tool — higher upfront cost, but smaller per-search responses",
+    "saved": "{{percent}}% less",
+    "notConnected": "Not connected",
+    "connectedOf": "{{connected}} of {{total}} servers connected",
+    "totalFootprint": "Context footprint"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1122,5 +1122,18 @@
     "serversInGroup": "serveur(s)",
     "envVarsNeeded": "Variables d'environnement requises — définissez-les avant d'utiliser les serveurs importés :",
     "importResult": "Serveurs : {{serversCreated}} créés, {{serversSkipped}} ignorés. Groupes : {{groupsCreated}} créés, {{groupsSkipped}} ignorés."
+  },
+  "cost": {
+    "exposed": "Exposé",
+    "gross": "Brut",
+    "estimate": "Tokens estimés (cl100k) — approximatif",
+    "direct": "Direct",
+    "smartRouting": "Routage intelligent",
+    "smartRoutingPd": "Routage intelligent + divulgation progressive",
+    "smartRoutingPdHint": "Ajoute le méta-outil describe_tool — coût initial plus élevé, mais des réponses plus légères par recherche",
+    "saved": "{{percent}}% de moins",
+    "notConnected": "Non connecté",
+    "connectedOf": "{{connected}} sur {{total}} serveurs connectés",
+    "totalFootprint": "Empreinte contextuelle"
   }
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -1121,5 +1121,18 @@
     "serversInGroup": "sunucu",
     "envVarsNeeded": "Gerekli Ortam Değişkenleri — içe aktarılan sunucuları kullanmadan önce bunları ayarlayın:",
     "importResult": "Sunucular: {{serversCreated}} oluşturuldu, {{serversSkipped}} atlandı. Gruplar: {{groupsCreated}} oluşturuldu, {{groupsSkipped}} atlandı."
+  },
+  "cost": {
+    "exposed": "Gösterilen",
+    "gross": "Toplam",
+    "estimate": "Tahmini token sayısı (cl100k) — yaklaşık",
+    "direct": "Doğrudan",
+    "smartRouting": "Akıllı yönlendirme",
+    "smartRoutingPd": "Akıllı yönlendirme + aşamalı açıklama",
+    "smartRoutingPdHint": "describe_tool meta-aracını ekler — daha yüksek başlangıç maliyeti, ancak arama başına daha küçük yanıtlar",
+    "saved": "{{percent}}% daha az",
+    "notConnected": "Bağlı değil",
+    "connectedOf": "{{total}} sunucudan {{connected}} tanesi bağlı",
+    "totalFootprint": "Bağlam ayak izi"
   }
 }

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -1134,5 +1134,18 @@
     "serversInGroup": "个服务器",
     "envVarsNeeded": "所需环境变量 — 请在使用导入的服务器前设置这些变量：",
     "importResult": "服务器：创建 {{serversCreated}} 个，跳过 {{serversSkipped}} 个。分组：创建 {{groupsCreated}} 个，跳过 {{groupsSkipped}} 个。"
+  },
+  "cost": {
+    "exposed": "已暴露",
+    "gross": "总量",
+    "estimate": "预估 Token 数（cl100k）— 近似值",
+    "direct": "直接",
+    "smartRouting": "智能路由",
+    "smartRoutingPd": "智能路由 + 渐进式披露",
+    "smartRoutingPdHint": "添加 describe_tool 元工具 — 前期成本较高，但每次搜索的响应更小",
+    "saved": "减少 {{percent}}%",
+    "notConnected": "未连接",
+    "connectedOf": "{{total}} 个服务器中已连接 {{connected}} 个",
+    "totalFootprint": "上下文占用"
   }
 }

--- a/src/controllers/contextCostController.ts
+++ b/src/controllers/contextCostController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { ApiResponse } from '../types/index.js';
+import { getServerCosts, getGroupCosts } from '../services/contextCostService.js';
+
+export const getServerCostsHandler = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const data = await getServerCosts();
+    const response: ApiResponse = { success: true, data };
+    res.json(response);
+  } catch (error) {
+    console.error('Failed to get server context footprint:', error);
+    res.status(500).json({ success: false, message: 'Failed to get server context footprint' });
+  }
+};
+
+export const getGroupCostsHandler = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const data = await getGroupCosts();
+    const response: ApiResponse = { success: true, data };
+    res.json(response);
+  } catch (error) {
+    console.error('Failed to get group context footprint:', error);
+    res.status(500).json({ success: false, message: 'Failed to get group context footprint' });
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -22,6 +22,7 @@ import {
   resetResourceDescription,
   updateSystemConfig,
 } from '../controllers/serverController.js';
+import { getServerCostsHandler, getGroupCostsHandler } from '../controllers/contextCostController.js';
 import {
   getGroups,
   getGroup,
@@ -257,6 +258,10 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
     resetResourceDescription,
   );
   authenticatedRouter.put('/system-config', updateSystemConfig);
+
+  // Context Footprint cost routes
+  authenticatedRouter.get('/cost/servers', getServerCostsHandler);
+  authenticatedRouter.get('/cost/groups', getGroupCostsHandler);
 
   // Group management routes
   authenticatedRouter.get('/groups', getGroups);

--- a/src/services/contextCostService.ts
+++ b/src/services/contextCostService.ts
@@ -24,11 +24,13 @@ export async function serverCostFromInfo(info: ServerInfo): Promise<ServerCost> 
 
   // Resources have no per-item enabled flag upstream, so resource exposed == gross by design.
   // Tools and prompts carry an explicit `enabled` boolean set by getServersInfo.
-  const items: ItemCost[] = [
-    ...(await Promise.all((info.tools ?? []).map((t) => itemCostForTool(t)))),
-    ...(await Promise.all((info.prompts ?? []).map((p) => itemCostForPrompt(p)))),
-    ...(await Promise.all((info.resources ?? []).map((r) => itemCostForResource(r)))),
-  ];
+  // Count all three kinds concurrently rather than awaiting each batch in sequence.
+  const [tools, prompts, resources] = await Promise.all([
+    Promise.all((info.tools ?? []).map((t) => itemCostForTool(t))),
+    Promise.all((info.prompts ?? []).map((p) => itemCostForPrompt(p))),
+    Promise.all((info.resources ?? []).map((r) => itemCostForResource(r))),
+  ]);
+  const items: ItemCost[] = [...tools, ...prompts, ...resources];
 
   const gross = items.reduce((sum, i) => sum + i.cost, 0);
   const exposed = items.filter((i) => i.enabled).reduce((sum, i) => sum + i.cost, 0);

--- a/src/services/contextCostService.ts
+++ b/src/services/contextCostService.ts
@@ -1,0 +1,130 @@
+/**
+ * Context Footprint aggregation.
+ *
+ * Turns runtime server/group state into the token cost numbers surfaced by the
+ * GUI. Live-only: cost is computed for connected servers; disconnected servers
+ * report connected=false with a zero footprint. No persistence.
+ */
+import type { ServerInfo, ServerCost, ItemCost, GroupCost, IGroupServerConfig, SmartRoutingCost } from '../types/index.js';
+import { itemCostForTool, itemCostForPrompt, itemCostForResource, countTokens, serializeToolDefinition } from '../utils/tokenCost.js';
+import { getServersInfo } from './mcpService.js';
+import { getNameSeparator } from '../config/index.js';
+import { getAllGroups, normalizeGroupServers } from './groupService.js';
+import { getSmartRoutingConfig } from '../utils/smartRouting.js';
+import { getSmartRoutingMetaToolDefinitions } from './smartRoutingService.js';
+
+const isConnected = (info: ServerInfo): boolean =>
+  info.status === 'connected' && info.enabled !== false;
+
+/** Compute a single server's Context Footprint from its runtime ServerInfo. */
+export async function serverCostFromInfo(info: ServerInfo): Promise<ServerCost> {
+  if (!isConnected(info)) {
+    return { name: info.name, connected: false, exposed: 0, gross: 0, items: [] };
+  }
+
+  // Resources have no per-item enabled flag upstream, so resource exposed == gross by design.
+  // Tools and prompts carry an explicit `enabled` boolean set by getServersInfo.
+  const items: ItemCost[] = [
+    ...(await Promise.all((info.tools ?? []).map((t) => itemCostForTool(t)))),
+    ...(await Promise.all((info.prompts ?? []).map((p) => itemCostForPrompt(p)))),
+    ...(await Promise.all((info.resources ?? []).map((r) => itemCostForResource(r)))),
+  ];
+
+  const gross = items.reduce((sum, i) => sum + i.cost, 0);
+  const exposed = items.filter((i) => i.enabled).reduce((sum, i) => sum + i.cost, 0);
+
+  return { name: info.name, connected: true, exposed, gross, items };
+}
+
+/**
+ * Context Footprint for every server visible to the current user.
+ * Delegates visibility/enabled filtering to getServersInfo.
+ */
+export async function getServerCosts(): Promise<ServerCost[]> {
+  const infos = await getServersInfo();
+  return Promise.all(infos.map((info) => serverCostFromInfo(info as ServerInfo)));
+}
+
+/** Strip server-name prefix from a prefixed item name (e.g. "s1-toolA" → "toolA"). */
+const shortName = (full: string, server: string, sep: string): string => {
+  const prefix = `${server}${sep}`;
+  return full.startsWith(prefix) ? full.slice(prefix.length) : full;
+};
+
+/**
+ * Whether an item's short name is selected by the group's per-server config.
+ * `undefined` selection means the field was absent — treat same as 'all'.
+ */
+const isSelected = (selection: string[] | 'all' | undefined, short: string): boolean =>
+  selection === undefined || selection === 'all' || selection.includes(short);
+
+/** Compute the Smart Routing meta-tool token cost for a group scope. */
+const smartRoutingCostFor = async (groupName: string): Promise<SmartRoutingCost> => {
+  const ref = `$smart/${groupName}`;
+  const sumCost = async (tools: any[]): Promise<number> => {
+    const counts = await Promise.all(
+      tools.map((t) =>
+        countTokens(
+          serializeToolDefinition({ name: t.name, description: t.description, inputSchema: t.inputSchema }),
+        ),
+      ),
+    );
+    return counts.reduce((a, b) => a + b, 0);
+  };
+  const [baseTools, pdTools] = await Promise.all([
+    getSmartRoutingMetaToolDefinitions(ref, false),
+    getSmartRoutingMetaToolDefinitions(ref, true),
+  ]);
+  return { base: await sumCost(baseTools), progressiveDisclosure: await sumCost(pdTools) };
+};
+
+/** Per-group Context Footprint — Direct (gross/exposed) + Smart Routing costs. */
+export async function getGroupCosts(): Promise<GroupCost[]> {
+  const [serverCosts, groups, smartConfig] = await Promise.all([
+    getServerCosts(),
+    getAllGroups(),
+    getSmartRoutingConfig(),
+  ]);
+  const sep = getNameSeparator();
+  const costByServer = new Map(serverCosts.map((c) => [c.name, c]));
+  const smartEnabled = smartConfig.enabled === true;
+
+  return Promise.all(
+    groups.map(async (group) => {
+      const members: IGroupServerConfig[] = normalizeGroupServers(group.servers);
+      let exposed = 0;
+      let gross = 0;
+      let connectedCount = 0;
+
+      for (const member of members) {
+        const sc = costByServer.get(member.name);
+        if (!sc || !sc.connected) continue;
+        connectedCount += 1;
+        for (const item of sc.items) {
+          gross += item.cost;
+          const selection =
+            item.kind === 'tool'
+              ? member.tools
+              : item.kind === 'prompt'
+                ? member.prompts
+                : member.resources;
+          // Resources use URIs as names (not prefixed); tools/prompts are prefixed
+          const key =
+            item.kind === 'resource' ? item.name : shortName(item.name, member.name, sep);
+          if (item.enabled && isSelected(selection, key)) {
+            exposed += item.cost;
+          }
+        }
+      }
+
+      return {
+        id: group.id,
+        name: group.name,
+        connectedCount,
+        totalCount: members.length,
+        direct: { exposed, gross },
+        smartRouting: smartEnabled ? await smartRoutingCostFor(group.name) : null,
+      };
+    }),
+  );
+}

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -6,7 +6,7 @@ import { UserContextService } from './userContextService.js';
 import { getGroupDao, getServerDao, getSystemConfigDao } from '../dao/index.js';
 
 // Helper function to normalize group servers configuration
-const normalizeGroupServers = (servers: string[] | IGroupServerConfig[]): IGroupServerConfig[] => {
+export const normalizeGroupServers = (servers: string[] | IGroupServerConfig[]): IGroupServerConfig[] => {
   return servers.map((server) => {
     if (typeof server === 'string') {
       // Backward compatibility: string format means all tools

--- a/src/services/smartRoutingService.ts
+++ b/src/services/smartRoutingService.ts
@@ -64,43 +64,14 @@ const cleanInputSchema = (schema: any): any => {
 };
 
 /**
- * Generate the list of smart routing tools based on configuration
+ * Build meta-tool definitions for a given scope.
+ * Pure function — no I/O, no config reads.
  */
-export const getSmartRoutingTools = async (
-  group: string | undefined,
-): Promise<{ tools: any[] }> => {
-  // Extract target group if pattern is $smart/{group}
-  const targetGroup = group?.startsWith('$smart/') ? group.substring(7) : undefined;
-
-  // Get smart routing config to check progressive disclosure setting
-  const smartRoutingConfig = await getSmartRoutingConfig();
-  const progressiveDisclosure = smartRoutingConfig.progressiveDisclosure ?? false;
-
-  // Get info about available servers, filtered by target group if specified
-  let availableServers = getServerInfos().filter(
-    (server) => server.status === 'connected' && server.enabled !== false,
-  );
-
-  // If a target group is specified, filter servers to only those in the group
-  if (targetGroup) {
-    const serversInGroup = await getServersInGroup(targetGroup);
-    if (serversInGroup && serversInGroup.length > 0) {
-      availableServers = availableServers.filter((server) => serversInGroup.includes(server.name));
-    }
-  }
-
-  // Create simple server information with only server names
-  const serversList = availableServers
-    .map((server) => {
-      return `${server.name}`;
-    })
-    .join(', ');
-
-  const scopeDescription = targetGroup
-    ? `servers in the "${targetGroup}" group`
-    : 'all available servers';
-
-  // Base tools that are always available
+export const buildSmartRoutingMetaTools = (
+  scopeDescription: string,
+  serversList: string,
+  progressiveDisclosure: boolean,
+): any[] => {
   const tools: any[] = [];
 
   if (progressiveDisclosure) {
@@ -245,7 +216,67 @@ Available servers: ${serversList}`,
     );
   }
 
-  return { tools };
+  return tools;
+};
+
+/**
+ * Compute the scope (server list + scope description) for a smart routing group.
+ */
+const computeSmartRoutingScope = async (
+  group: string | undefined,
+): Promise<{ scopeDescription: string; serversList: string }> => {
+  // Extract target group if pattern is $smart/{group}
+  const targetGroup = group?.startsWith('$smart/') ? group.substring(7) : undefined;
+
+  // Get info about available servers, filtered by target group if specified
+  let availableServers = getServerInfos().filter(
+    (server) => server.status === 'connected' && server.enabled !== false,
+  );
+
+  // If a target group is specified, filter servers to only those in the group
+  if (targetGroup) {
+    const serversInGroup = await getServersInGroup(targetGroup);
+    if (serversInGroup && serversInGroup.length > 0) {
+      availableServers = availableServers.filter((server) => serversInGroup.includes(server.name));
+    }
+  }
+
+  // Create simple server information with only server names
+  const serversList = availableServers
+    .map((server) => {
+      return `${server.name}`;
+    })
+    .join(', ');
+
+  const scopeDescription = targetGroup
+    ? `servers in the "${targetGroup}" group`
+    : 'all available servers';
+
+  return { scopeDescription, serversList };
+};
+
+/** Meta-tool definitions for a scope, for an explicit PD mode (for cost only). */
+export const getSmartRoutingMetaToolDefinitions = async (
+  group: string | undefined,
+  progressiveDisclosure: boolean,
+): Promise<any[]> => {
+  const { scopeDescription, serversList } = await computeSmartRoutingScope(group);
+  return buildSmartRoutingMetaTools(scopeDescription, serversList, progressiveDisclosure);
+};
+
+/**
+ * Generate the list of smart routing tools based on configuration
+ */
+export const getSmartRoutingTools = async (
+  group: string | undefined,
+): Promise<{ tools: any[] }> => {
+  // Get smart routing config to check progressive disclosure setting
+  const smartRoutingConfig = await getSmartRoutingConfig();
+  const progressiveDisclosure = smartRoutingConfig.progressiveDisclosure ?? false;
+
+  const { scopeDescription, serversList } = await computeSmartRoutingScope(group);
+
+  return { tools: buildSmartRoutingMetaTools(scopeDescription, serversList, progressiveDisclosure) };
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -700,3 +700,33 @@ export interface TemplateImportDetail {
   action: 'created' | 'skipped' | 'failed';
   message?: string;
 }
+
+// ─── Context Footprint (token cost) feature ───────────────────────────────
+export interface ItemCost {
+  kind: 'tool' | 'prompt' | 'resource';
+  name: string;
+  cost: number;
+  enabled: boolean;
+}
+
+export interface ServerCost {
+  name: string;
+  connected: boolean;
+  exposed: number;
+  gross: number;
+  items: ItemCost[];
+}
+
+export interface SmartRoutingCost {
+  base: number;
+  progressiveDisclosure: number;
+}
+
+export interface GroupCost {
+  id: string;
+  name: string;
+  connectedCount: number;
+  totalCount: number;
+  direct: { exposed: number; gross: number };
+  smartRouting: SmartRoutingCost | null;
+}

--- a/src/utils/tokenCost.ts
+++ b/src/utils/tokenCost.ts
@@ -1,0 +1,93 @@
+/**
+ * Token cost estimation for the Context Footprint feature.
+ *
+ * Estimates a Definition Cost — the tokens a tool/prompt/resource definition
+ * adds to a model's context window — using cl100k_base via gpt-tokenizer.
+ * This is an ESTIMATE for relative comparison, not a per-client-model exact
+ * count. See docs/adr/0001-cl100k-tokenizer-for-definition-cost.md.
+ */
+import type { Tool, Prompt, Resource, ItemCost } from '../types/index.js';
+
+// Lazily-loaded cl100k encoder (matches the dynamic-import pattern in tokenTruncation.ts,
+// which is proven to work under the ts-jest ESM preset).
+let encodeFn: ((text: string) => number[]) | null = null;
+
+async function getEncoder(): Promise<(text: string) => number[]> {
+  if (!encodeFn) {
+    const mod = await import('gpt-tokenizer');
+    encodeFn = mod.encode;
+  }
+  return encodeFn;
+}
+
+/** Count cl100k tokens in a string. */
+export async function countTokens(text: string): Promise<number> {
+  const encode = await getEncoder();
+  return encode(text).length;
+}
+
+/**
+ * Serialize a tool definition to the JSON a client forwards to the model:
+ * name + description + full inputSchema. Deterministic key order.
+ */
+export function serializeToolDefinition(tool: Pick<Tool, 'name' | 'description' | 'inputSchema'>): string {
+  return JSON.stringify({
+    name: tool.name,
+    description: tool.description ?? '',
+    inputSchema: tool.inputSchema ?? {},
+  });
+}
+
+export function serializePromptDefinition(
+  prompt: Pick<Prompt, 'name' | 'description' | 'arguments'>,
+): string {
+  return JSON.stringify({
+    name: prompt.name,
+    description: prompt.description ?? '',
+    arguments: prompt.arguments ?? [],
+  });
+}
+
+export function serializeResourceDefinition(
+  resource: Pick<Resource, 'uri' | 'name' | 'description' | 'mimeType'>,
+): string {
+  return JSON.stringify({
+    uri: resource.uri,
+    name: resource.name ?? '',
+    description: resource.description ?? '',
+    mimeType: resource.mimeType ?? '',
+  });
+}
+
+const isExposed = (enabled: boolean | undefined): boolean => enabled !== false;
+
+export async function itemCostForTool(tool: Tool): Promise<ItemCost> {
+  return {
+    kind: 'tool',
+    name: tool.name,
+    cost: await countTokens(serializeToolDefinition(tool)),
+    enabled: isExposed(tool.enabled),
+  };
+}
+
+// NOTE: The base Prompt and Resource interfaces in src/types/index.ts do not carry an
+// `enabled` field (that lives on BuiltinPrompt / BuiltinResource). The functions below
+// accept an intersection with `{ enabled?: boolean }` so callers can pass enriched
+// objects without losing type safety.
+export async function itemCostForPrompt(prompt: Prompt & { enabled?: boolean }): Promise<ItemCost> {
+  return {
+    kind: 'prompt',
+    name: prompt.name,
+    cost: await countTokens(serializePromptDefinition(prompt)),
+    enabled: isExposed(prompt.enabled),
+  };
+}
+
+export async function itemCostForResource(resource: Resource & { enabled?: boolean }): Promise<ItemCost> {
+  return {
+    kind: 'resource',
+    name: resource.uri,
+    cost: await countTokens(serializeResourceDefinition(resource)),
+    enabled: isExposed(resource.enabled),
+  };
+}

--- a/src/utils/tokenCost.ts
+++ b/src/utils/tokenCost.ts
@@ -9,15 +9,15 @@
 import type { Tool, Prompt, Resource, ItemCost } from '../types/index.js';
 
 // Lazily-loaded cl100k encoder (matches the dynamic-import pattern in tokenTruncation.ts,
-// which is proven to work under the ts-jest ESM preset).
-let encodeFn: ((text: string) => number[]) | null = null;
+// which is proven to work under the ts-jest ESM preset). Cache the import promise itself
+// so concurrent callers share a single in-flight import instead of each firing their own.
+let encoderPromise: Promise<(text: string) => number[]> | null = null;
 
-async function getEncoder(): Promise<(text: string) => number[]> {
-  if (!encodeFn) {
-    const mod = await import('gpt-tokenizer');
-    encodeFn = mod.encode;
+function getEncoder(): Promise<(text: string) => number[]> {
+  if (!encoderPromise) {
+    encoderPromise = import('gpt-tokenizer').then((mod) => mod.encode);
   }
-  return encodeFn;
+  return encoderPromise;
 }
 
 /** Count cl100k tokens in a string. */

--- a/tests/controllers/contextCostController.test.ts
+++ b/tests/controllers/contextCostController.test.ts
@@ -1,0 +1,58 @@
+const mockGetServerCosts = jest.fn();
+const mockGetGroupCosts = jest.fn();
+
+jest.mock('../../src/services/contextCostService.js', () => ({
+  getServerCosts: mockGetServerCosts,
+  getGroupCosts: mockGetGroupCosts,
+}));
+
+import type { Request, Response } from 'express';
+import { getServerCostsHandler, getGroupCostsHandler } from '../../src/controllers/contextCostController.js';
+
+const mockRes = () => {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+};
+
+describe('getServerCostsHandler', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('responds with success and the server costs', async () => {
+    mockGetServerCosts.mockResolvedValue([
+      { name: 's1', connected: true, exposed: 100, gross: 150, items: [] },
+    ]);
+    const res = mockRes();
+    await getServerCostsHandler({} as Request, res);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: [{ name: 's1', connected: true, exposed: 100, gross: 150, items: [] }],
+    });
+  });
+
+  it('responds 500 on service error', async () => {
+    mockGetServerCosts.mockRejectedValue(new Error('boom'));
+    const res = mockRes();
+    await getServerCostsHandler({} as Request, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe('getGroupCostsHandler', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('responds with success and the group costs', async () => {
+    mockGetGroupCosts.mockResolvedValue([]);
+    const res = mockRes();
+    await getGroupCostsHandler({} as Request, res);
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: [] });
+  });
+
+  it('responds 500 on service error', async () => {
+    mockGetGroupCosts.mockRejectedValue(new Error('boom'));
+    const res = mockRes();
+    await getGroupCostsHandler({} as Request, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/tests/frontend/contextCost.test.ts
+++ b/tests/frontend/contextCost.test.ts
@@ -1,0 +1,24 @@
+import { formatTokens, percentSaved } from '../../frontend/src/utils/contextCost';
+
+describe('formatTokens', () => {
+  it('formats small counts as plain integers', () => {
+    expect(formatTokens(0)).toBe('0');
+    expect(formatTokens(940)).toBe('940');
+  });
+  it('formats thousands with a k suffix and one decimal', () => {
+    expect(formatTokens(4200)).toBe('4.2k');
+    expect(formatTokens(12000)).toBe('12.0k');
+  });
+});
+
+describe('percentSaved', () => {
+  it('returns the integer percent reduction from direct to smart', () => {
+    expect(percentSaved(4200, 180)).toBe(96);
+  });
+  it('returns 0 when direct is 0 (no basis for comparison)', () => {
+    expect(percentSaved(0, 0)).toBe(0);
+  });
+  it('never returns negative (PD can exceed base; clamp at 0)', () => {
+    expect(percentSaved(100, 130)).toBe(0);
+  });
+});

--- a/tests/routes/index.test.ts
+++ b/tests/routes/index.test.ts
@@ -201,6 +201,11 @@ jest.mock('../../src/controllers/templateController.js', () => ({
   importConfigTemplate: routeHandler,
 }));
 
+jest.mock('../../src/controllers/contextCostController.js', () => ({
+  getServerCostsHandler: routeHandler,
+  getGroupCostsHandler: routeHandler,
+}));
+
 jest.mock('../../src/middlewares/auth.js', () => ({
   auth: authMiddleware,
 }));

--- a/tests/services/contextCostService.test.ts
+++ b/tests/services/contextCostService.test.ts
@@ -1,0 +1,268 @@
+const mockGetServersInfo = jest.fn();
+const mockGetAllGroups = jest.fn();
+const mockNormalizeGroupServers = jest.fn();
+const mockGetSmartRoutingConfig = jest.fn();
+const mockGetSmartRoutingMetaToolDefinitions = jest.fn();
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  getServersInfo: mockGetServersInfo,
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  getAllGroups: mockGetAllGroups,
+  normalizeGroupServers: mockNormalizeGroupServers,
+}));
+
+jest.mock('../../src/utils/smartRouting.js', () => ({
+  getSmartRoutingConfig: mockGetSmartRoutingConfig,
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  getSmartRoutingMetaToolDefinitions: mockGetSmartRoutingMetaToolDefinitions,
+}));
+
+// getNameSeparator lives in config/index.js — mock the whole module
+jest.mock('../../src/config/index.js', () => ({
+  getNameSeparator: () => '-',
+}));
+
+import { serverCostFromInfo, getServerCosts, getGroupCosts } from '../../src/services/contextCostService.js';
+import { countTokens, serializeToolDefinition } from '../../src/utils/tokenCost.js';
+import type { ServerInfo, IGroupServerConfig } from '../../src/types/index.js';
+
+// The real default separator (confirmed from src/config/index.ts)
+const SEP = '-';
+
+const baseInfo = (overrides: Partial<ServerInfo>): ServerInfo =>
+  ({
+    name: 'srv',
+    status: 'connected',
+    error: null,
+    tools: [],
+    prompts: [],
+    resources: [],
+    ...overrides,
+  }) as ServerInfo;
+
+describe('serverCostFromInfo', () => {
+  it('reports connected=false and zero footprint for a disconnected server', async () => {
+    const cost = await serverCostFromInfo(baseInfo({ status: 'disconnected' }));
+    expect(cost.connected).toBe(false);
+    expect(cost.exposed).toBe(0);
+    expect(cost.gross).toBe(0);
+    expect(cost.items).toEqual([]);
+  });
+
+  it('sums all tools into gross and only enabled tools into exposed', async () => {
+    const enabledTool = { name: 'a', description: 'aa', inputSchema: { type: 'object' }, enabled: true };
+    const disabledTool = { name: 'b', description: 'bb', inputSchema: { type: 'object' }, enabled: false };
+    const cost = await serverCostFromInfo(baseInfo({ tools: [enabledTool, disabledTool] }));
+
+    const costA = await countTokens(serializeToolDefinition(enabledTool));
+    const costB = await countTokens(serializeToolDefinition(disabledTool));
+
+    expect(cost.connected).toBe(true);
+    expect(cost.gross).toBe(costA + costB);
+    expect(cost.exposed).toBe(costA);
+    expect(cost.items).toHaveLength(2);
+  });
+
+  it('includes prompts and resources in the footprint', async () => {
+    const cost = await serverCostFromInfo(
+      baseInfo({
+        tools: [{ name: 't', description: '', inputSchema: {}, enabled: true }],
+        prompts: [{ name: 'p', description: 'pp', enabled: true } as any],
+        resources: [{ uri: 'file://r', name: 'r', enabled: true } as any],
+      }),
+    );
+    expect(cost.items.map((i) => i.kind).sort()).toEqual(['prompt', 'resource', 'tool']);
+    expect(cost.exposed).toBeGreaterThan(0);
+  });
+});
+
+describe('getServerCosts', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('maps each server from getServersInfo to a ServerCost', async () => {
+    mockGetServersInfo.mockResolvedValue([
+      { name: 's1', status: 'connected', error: null, tools: [{ name: 't', description: '', inputSchema: {}, enabled: true }], prompts: [], resources: [] },
+      { name: 's2', status: 'disconnected', error: null, tools: [], prompts: [], resources: [] },
+    ]);
+
+    const costs = await getServerCosts();
+    expect(costs.map((c) => c.name)).toEqual(['s1', 's2']);
+    expect(costs[0].connected).toBe(true);
+    expect(costs[1].connected).toBe(false);
+  });
+});
+
+describe('getGroupCosts', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('(a) direct.exposed < direct.gross when group selects a tool subset; smartRouting null when disabled', async () => {
+    // Two enabled tools on server s1, prefixed with separator
+    const toolA = { name: `s1${SEP}a`, description: 'tool a description', inputSchema: { type: 'object', properties: {} }, enabled: true };
+    const toolB = { name: `s1${SEP}b`, description: 'tool b description', inputSchema: { type: 'object', properties: {} }, enabled: true };
+
+    mockGetServersInfo.mockResolvedValue([
+      { name: 's1', status: 'connected', error: null, tools: [toolA, toolB], prompts: [], resources: [] },
+    ]);
+
+    // Group selects only tool 'a' (short name, not prefixed)
+    const memberConfig: IGroupServerConfig = { name: 's1', tools: ['a'], prompts: 'all', resources: 'all' };
+    mockGetAllGroups.mockResolvedValue([
+      { id: 'g1', name: 'group1', servers: [memberConfig] },
+    ]);
+    mockNormalizeGroupServers.mockImplementation((servers: string[] | IGroupServerConfig[]) => {
+      // Return the already-normalized config as-is
+      return servers.map((s: string | IGroupServerConfig) =>
+        typeof s === 'string'
+          ? { name: s, tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const }
+          : { tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const, ...s },
+      );
+    });
+
+    mockGetSmartRoutingConfig.mockResolvedValue({ enabled: false });
+
+    const costs = await getGroupCosts();
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].id).toBe('g1');
+    expect(costs[0].name).toBe('group1');
+    expect(costs[0].connectedCount).toBe(1);
+    expect(costs[0].totalCount).toBe(1);
+    // gross = cost(toolA) + cost(toolB); exposed = cost(toolA) only
+    expect(costs[0].direct.gross).toBeGreaterThan(0);
+    expect(costs[0].direct.exposed).toBeGreaterThan(0);
+    expect(costs[0].direct.gross).toBeGreaterThan(costs[0].direct.exposed);
+    // smart routing disabled → null
+    expect(costs[0].smartRouting).toBeNull();
+  });
+
+  it('(c) resource selection by URI: only selected resource contributes to exposed; both contribute to gross', async () => {
+    const resA = { uri: 'file://a', name: 'Resource A', description: 'resource a' };
+    const resB = { uri: 'file://b', name: 'Resource B', description: 'resource b' };
+
+    mockGetServersInfo.mockResolvedValue([
+      { name: 's1', status: 'connected', error: null, tools: [], prompts: [], resources: [resA, resB] },
+    ]);
+
+    // Group selects only resource file://a by raw URI
+    const memberConfig: IGroupServerConfig = { name: 's1', tools: 'all', prompts: 'all', resources: ['file://a'] };
+    mockGetAllGroups.mockResolvedValue([
+      { id: 'g3', name: 'group3', servers: [memberConfig] },
+    ]);
+    mockNormalizeGroupServers.mockImplementation((servers: string[] | IGroupServerConfig[]) =>
+      servers.map((s: string | IGroupServerConfig) =>
+        typeof s === 'string'
+          ? { name: s, tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const }
+          : { tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const, ...s },
+      ),
+    );
+
+    mockGetSmartRoutingConfig.mockResolvedValue({ enabled: false });
+
+    const costs = await getGroupCosts();
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].id).toBe('g3');
+    // gross includes both resources; exposed includes only file://a
+    expect(costs[0].direct.gross).toBeGreaterThan(0);
+    expect(costs[0].direct.exposed).toBeGreaterThan(0);
+    expect(costs[0].direct.gross).toBeGreaterThan(costs[0].direct.exposed);
+  });
+
+  it('(d) disconnected member inflates totalCount but not exposed/gross', async () => {
+    const tool = { name: 's1-t', description: 'a tool', inputSchema: { type: 'object' }, enabled: true };
+
+    mockGetServersInfo.mockResolvedValue([
+      { name: 's1', status: 'connected', error: null, tools: [tool], prompts: [], resources: [] },
+      { name: 's2', status: 'disconnected', error: null, tools: [tool], prompts: [], resources: [] },
+    ]);
+
+    mockGetAllGroups.mockResolvedValue([
+      {
+        id: 'g4',
+        name: 'group4',
+        servers: [
+          { name: 's1', tools: 'all', prompts: 'all', resources: 'all' },
+          { name: 's2', tools: 'all', prompts: 'all', resources: 'all' },
+        ],
+      },
+    ]);
+    mockNormalizeGroupServers.mockImplementation((servers: string[] | IGroupServerConfig[]) =>
+      servers.map((s: string | IGroupServerConfig) =>
+        typeof s === 'string'
+          ? { name: s, tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const }
+          : { tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const, ...s },
+      ),
+    );
+
+    mockGetSmartRoutingConfig.mockResolvedValue({ enabled: false });
+
+    const costs = await getGroupCosts();
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].connectedCount).toBe(1);
+    expect(costs[0].totalCount).toBe(2);
+    // Only s1 is connected — its tool contributes; s2 contributes nothing
+    expect(costs[0].direct.gross).toBeGreaterThan(0);
+    expect(costs[0].direct.exposed).toBeGreaterThan(0);
+  });
+
+  it('(b) smartRouting footprint is present and progressiveDisclosure > base when smart routing enabled', async () => {
+    mockGetServersInfo.mockResolvedValue([
+      { name: 's1', status: 'connected', error: null, tools: [], prompts: [], resources: [] },
+    ]);
+
+    mockGetAllGroups.mockResolvedValue([
+      { id: 'g2', name: 'group2', servers: [{ name: 's1', tools: 'all', prompts: 'all', resources: 'all' }] },
+    ]);
+    mockNormalizeGroupServers.mockImplementation((servers: string[] | IGroupServerConfig[]) =>
+      servers.map((s: string | IGroupServerConfig) =>
+        typeof s === 'string'
+          ? { name: s, tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const }
+          : { tools: 'all' as const, prompts: 'all' as const, resources: 'all' as const, ...s },
+      ),
+    );
+
+    mockGetSmartRoutingConfig.mockResolvedValue({ enabled: true });
+
+    // PD mode returns 3 tools (more tokens); base returns 2 tools (fewer tokens)
+    const baseTool = (name: string) => ({
+      name,
+      description: 'short desc',
+      inputSchema: { type: 'object', properties: { q: { type: 'string', description: 'query' } } },
+    });
+    const pdTool = (name: string) => ({
+      name,
+      description: 'A much longer description with lots of detail about this tool that increases token count significantly beyond the base version',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'The search query for finding relevant tools' },
+          limit: { type: 'integer', description: 'Maximum number of results' },
+          threshold: { type: 'number', description: 'Similarity threshold' },
+        },
+        required: ['query'],
+      },
+    });
+
+    mockGetSmartRoutingMetaToolDefinitions.mockImplementation(
+      (_group: string | undefined, progressiveDisclosure: boolean) => {
+        if (progressiveDisclosure) {
+          return Promise.resolve([pdTool('search_tools'), pdTool('describe_tool'), pdTool('call_tool')]);
+        }
+        return Promise.resolve([baseTool('search_tools'), baseTool('call_tool')]);
+      },
+    );
+
+    const costs = await getGroupCosts();
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].smartRouting).not.toBeNull();
+    expect(costs[0].smartRouting!.base).toBeGreaterThan(0);
+    expect(costs[0].smartRouting!.progressiveDisclosure).toBeGreaterThan(0);
+    expect(costs[0].smartRouting!.progressiveDisclosure).toBeGreaterThan(costs[0].smartRouting!.base);
+  });
+});

--- a/tests/services/smartRoutingService-metatools.test.ts
+++ b/tests/services/smartRoutingService-metatools.test.ts
@@ -1,0 +1,46 @@
+// Mock all transitive dependencies before importing smartRoutingService
+jest.mock('../../src/services/groupService.js', () => ({
+  getServersInGroup: jest.fn(),
+  getServerConfigInGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  searchToolsByVector: jest.fn(),
+  saveToolsAsVectorEmbeddings: jest.fn(),
+}));
+
+jest.mock('../../src/utils/smartRouting.js', () => ({
+  getSmartRoutingConfig: jest.fn(() => Promise.resolve({ progressiveDisclosure: false })),
+}));
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: jest.fn(() => ({
+    findById: jest.fn(),
+    findAll: jest.fn(() => Promise.resolve([])),
+  })),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn(),
+}));
+
+import { buildSmartRoutingMetaTools } from '../../src/services/smartRoutingService.js';
+
+describe('buildSmartRoutingMetaTools', () => {
+  it('returns 2 tools (search_tools, call_tool) in standard mode', () => {
+    const tools = buildSmartRoutingMetaTools('all available servers', 'srv-a, srv-b', false);
+    expect(tools.map((t) => t.name)).toEqual(['search_tools', 'call_tool']);
+  });
+
+  it('returns 3 tools (adds describe_tool) under progressive disclosure', () => {
+    const tools = buildSmartRoutingMetaTools('all available servers', 'srv-a, srv-b', true);
+    expect(tools.map((t) => t.name)).toEqual(['search_tools', 'describe_tool', 'call_tool']);
+  });
+
+  it('embeds the scope description and server list into search_tools', () => {
+    const tools = buildSmartRoutingMetaTools('servers in the "x" group', 'srv-a', false);
+    const search = tools.find((t) => t.name === 'search_tools')!;
+    expect(search.description).toContain('servers in the "x" group');
+    expect(search.description).toContain('srv-a');
+  });
+});

--- a/tests/utils/tokenCost.test.ts
+++ b/tests/utils/tokenCost.test.ts
@@ -1,0 +1,79 @@
+import {
+  countTokens,
+  serializeToolDefinition,
+  serializePromptDefinition,
+  serializeResourceDefinition,
+  itemCostForTool,
+} from '../../src/utils/tokenCost.js';
+
+describe('tokenCost', () => {
+  it('counts tokens of a string with cl100k (non-zero, deterministic)', async () => {
+    const a = await countTokens('hello world');
+    const b = await countTokens('hello world');
+    expect(a).toBeGreaterThan(0);
+    expect(a).toBe(b);
+  });
+
+  it('counts more tokens for longer text', async () => {
+    const short = await countTokens('a');
+    const long = await countTokens('the quick brown fox jumps over the lazy dog repeatedly');
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it('serializes a tool definition as JSON of name, description, inputSchema', () => {
+    const text = serializeToolDefinition({
+      name: 'fetch_url',
+      description: 'Fetch a URL',
+      inputSchema: { type: 'object', properties: { url: { type: 'string' } }, required: ['url'] },
+    });
+    const parsed = JSON.parse(text);
+    expect(parsed).toEqual({
+      name: 'fetch_url',
+      description: 'Fetch a URL',
+      inputSchema: { type: 'object', properties: { url: { type: 'string' } }, required: ['url'] },
+    });
+  });
+
+  it('serializes a tool with a large schema to more characters than a small one', () => {
+    const small = serializeToolDefinition({ name: 't', description: 'd', inputSchema: {} });
+    const big = serializeToolDefinition({
+      name: 't',
+      description: 'd',
+      inputSchema: { type: 'object', properties: { a: { type: 'string' }, b: { type: 'number' } } },
+    });
+    expect(big.length).toBeGreaterThan(small.length);
+  });
+
+  it('tolerates missing description/inputSchema', () => {
+    const text = serializeToolDefinition({ name: 'bare' } as any);
+    const parsed = JSON.parse(text);
+    expect(parsed.name).toBe('bare');
+    expect(parsed.description).toBe('');
+    expect(parsed.inputSchema).toEqual({});
+  });
+
+  it('serializes prompt and resource definitions', () => {
+    expect(JSON.parse(serializePromptDefinition({ name: 'p', description: 'pd', arguments: [] }))).toEqual({
+      name: 'p',
+      description: 'pd',
+      arguments: [],
+    });
+    expect(
+      JSON.parse(serializeResourceDefinition({ uri: 'file://x', name: 'r', description: 'rd', mimeType: 'text/plain' })),
+    ).toEqual({ uri: 'file://x', name: 'r', description: 'rd', mimeType: 'text/plain' });
+  });
+
+  it('itemCostForTool returns an ItemCost with kind=tool and the tool token count', async () => {
+    const tool = { name: 'fetch_url', description: 'Fetch a URL', inputSchema: { type: 'object' }, enabled: true };
+    const item = await itemCostForTool(tool);
+    expect(item.kind).toBe('tool');
+    expect(item.name).toBe('fetch_url');
+    expect(item.enabled).toBe(true);
+    expect(item.cost).toBe(await countTokens(serializeToolDefinition(tool)));
+  });
+
+  it('treats enabled === undefined as exposed (enabled: true)', async () => {
+    const item = await itemCostForTool({ name: 'x', description: '', inputSchema: {} } as any);
+    expect(item.enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description

Implements #896.

Adds **Context Footprint** — a feature that surfaces the estimated token cost each MCP server and group adds to a connecting client's context window, so operators can see and curate how much context their tool definitions consume.

- **Per tool / prompt / resource** — a *Definition Cost*: a cl100k token estimate of the item's name + description + full input schema.
- **Per server** — *Exposed* (enabled items) vs *Gross* (all items) footprint, with an expandable per-item breakdown.
- **Per group** — the Direct *Context footprint* respecting the group's tool/prompt/resource selection, plus the **Smart Routing** meta-tool footprint (base and Progressive Disclosure) when Smart Routing is enabled.
- Inline costs on the **server cards**, in the group **"Configure Tools"** selector (with a live selected-total), and an **all-servers total on the Dashboard**.
- Two new authenticated endpoints: `GET /api/cost/servers`, `GET /api/cost/groups`.

The estimate reuses the existing `gpt-tokenizer` dependency (cl100k_base) — offline, deterministic, **no new dependencies**. It is labelled in the UI as an estimate (rationale in ADR-0001).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Unit tests pass — added coverage for the tokenizer/serializers (`tests/utils/tokenCost.test.ts`), the aggregation service incl. group tool-subset, resource-by-URI, disconnected-member, and Smart-Routing base-vs-PD cases (`tests/services/contextCostService.test.ts`), the controller (`tests/controllers/contextCostController.test.ts`), the Smart Routing meta-tool builder (`tests/services/smartRoutingService-metatools.test.ts`), and the frontend formatters (`tests/frontend/contextCost.test.ts`).
- [x] Manual testing completed — verified end-to-end against a running hub: server-card footprints + breakdown, group Configure Tools with per-item costs and a live selected-total, Dashboard total, and live refresh when toggling servers/tools.
- [ ] Integration / E2E — n/a; no DB-backed paths changed, and the Smart Routing numbers are covered by unit tests.
- CI gate green locally (matches `.github/workflows/ci.yml`): `pnpm lint`, `pnpm backend:build`, `pnpm test:ci` — **686 tests, 112 suites**, rebased on current `main`.

## Documentation

- [x] Code is self-documenting, with comments on the non-obvious decisions (tokenizer choice, upfront-only semantics).
- [x] Added two ADRs (`docs/adr/0001-cl100k-tokenizer-for-definition-cost.md`, `docs/adr/0002-definition-cost-is-upfront-only.md`) and `CONTEXT.md` glossary entries, per the project's "document decisions in ADR" guidance.
- [x] i18n — added a `cost` namespace to all four locales (en/zh/fr/tr).
- [ ] README / API reference — no change required (additive, self-describing endpoints). Happy to add API-reference docs if maintainers prefer.

## Checklist

- [x] Follows the project's style guidelines (ESLint/Prettier clean; ESM `.js` imports; TS strict; no new `any`)
- [x] Self-reviewed
- [x] Commented hard-to-understand areas
- [x] Made corresponding documentation changes (ADRs, CONTEXT.md, i18n)
- [x] No new warnings
- [x] Added tests proving the feature works
- [x] New and existing tests pass locally

## Screenshots

**Server cards — `Σ exposed/gross` footprint stat:**

![Servers overview](https://raw.githubusercontent.com/Dworf/mcphub/screenshots/01-servers-overview.png)

**A server's Tools tab — per-tool `Σ` cost, right-aligned by each toggle:**

![Tools per-item cost](https://raw.githubusercontent.com/Dworf/mcphub/screenshots/02-server-tools-per-item-cost.png)

**"Σ Context footprint" tab → per-item breakdown:**

![Cost breakdown](https://raw.githubusercontent.com/Dworf/mcphub/screenshots/03-server-cost-breakdown.png)

**Group card — "Context footprint":**

![Group card](https://raw.githubusercontent.com/Dworf/mcphub/screenshots/04-group-card-footprint.png)

**Group "Configure Tools" — per-item costs, per-server `Σ`, and the live "(All/Selected) Σ" total:**

![Configure Tools](https://raw.githubusercontent.com/Dworf/mcphub/screenshots/05-configure-tools-per-item.png)

**Dashboard — all-servers "Context footprint" tile:**

![Dashboard](https://raw.githubusercontent.com/Dworf/mcphub/screenshots/06-dashboard-footprint-total.png)

## Additional Notes

- The Smart Routing change extracts a pure `buildSmartRoutingMetaTools()` builder and is **behavior-preserving** for the live `$smart` path — guarded by the existing `tests/services/mcpService-smart-routing-group.test.ts`.
- **Live-only by design**: footprints are computed for connected servers (disconnected → "—"); no persistence, so no dual-datasource/migration changes.
- Per ADR-0002, enabling **Progressive Disclosure** intentionally shows a *higher* upfront Smart Routing Footprint (it adds the `describe_tool` meta-tool); its dynamic per-search saving is deliberately out of scope so the headline numbers stay falsifiable. A tooltip explains this in the UI.
- Open to feedback on scope, naming, and whether to gate this behind a setting.
