### PR TITLE
fix: handle null/primitive tool result payloads without crashing

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1787,7 +1787,10 @@ function checkAuthError(result: any) {
         // Ignore JSON parse errors and continue
         return;
       }
-      if (errorContent.code === 401) {
+      // JSON.parse can yield null or a primitive (e.g. text "null", "42",
+      // "true") — only an object payload can carry an auth error code, so guard
+      // the property access to avoid crashing on non-object results.
+      if (errorContent && typeof errorContent === 'object' && errorContent.code === 401) {
         throw new Error('Error POSTing to endpoint (HTTP 401 Unauthorized)');
       }
     }

--- a/tests/services/mcpService-null-tool-result.test.ts
+++ b/tests/services/mcpService-null-tool-result.test.ts
@@ -1,0 +1,226 @@
+/// <reference types="jest" />
+
+// Regression test for issue #922: a tool that returns a null (or other
+// non-object JSON) payload as its text content must not crash the hub's
+// tool-call path. The crash originated in checkAuthError, which parsed the
+// text content and dereferenced `.code` on the result without checking that
+// JSON.parse actually returned an object.
+
+const mockCallTool = jest.fn();
+
+const mockClient = {
+  connect: jest.fn().mockResolvedValue(undefined),
+  close: jest.fn(),
+  getServerCapabilities: jest.fn(() => ({ tools: {} })),
+  listTools: jest.fn().mockResolvedValue({ tools: [] }),
+  callTool: mockCallTool,
+};
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn().mockImplementation(() => mockClient),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: jest.fn(),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: jest.fn(),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthService.js', () => ({
+  initializeAllOAuthClients: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthClientRegistration.js', () => ({
+  registerOAuthClient: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpOAuthProvider.js', () => ({
+  createOAuthProvider: jest.fn(async () => undefined),
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  getServersInGroup: jest.fn(),
+  getServerConfigInGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn(() => ''),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  removeServerToolEmbeddings: jest.fn(),
+  saveToolsAsVectorEmbeddings: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({
+    filterData: (data: any) => data,
+  })),
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  initSmartRoutingService: jest.fn(),
+  getSmartRoutingTools: jest.fn(),
+  handleSearchToolsRequest: jest.fn(),
+  handleDescribeToolRequest: jest.fn(),
+  isSmartRoutingGroup: jest.fn(() => false),
+}));
+
+const mockLogToolCall = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/services/activityLoggingService.js', () => ({
+  getActivityLoggingService: jest.fn(() => ({
+    logToolCall: mockLogToolCall,
+  })),
+}));
+
+jest.mock('../../src/services/keepAliveService.js', () => ({
+  setupClientKeepAlive: jest.fn(),
+}));
+
+jest.mock('../../src/services/proxy.js', () => ({
+  createFetchWithProxy: jest.fn(() => jest.fn()),
+  getProxyConfigFromEnv: jest.fn(() => undefined),
+}));
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: jest.fn(() => ({
+    findAll: jest.fn(async () => []),
+    findById: jest.fn(async () => undefined),
+  })),
+  getSystemConfigDao: jest.fn(() => ({
+    get: jest.fn(async () => ({})),
+  })),
+  getBuiltinPromptDao: jest.fn(() => ({
+    findEnabled: jest.fn(async () => []),
+  })),
+  getBuiltinResourceDao: jest.fn(() => ({
+    findEnabled: jest.fn(async () => []),
+  })),
+}));
+
+jest.mock('../../src/config/index.js', () => ({
+  expandEnvVars: jest.fn((value: string) => value),
+  replaceEnvVars: jest.fn((value: any) => value),
+  getNameSeparator: jest.fn(() => '::'),
+  default: {
+    mcpHubName: 'test-hub',
+    mcpHubVersion: '1.0.0',
+    initTimeout: 60000,
+  },
+}));
+
+import * as mcpService from '../../src/services/mcpService.js';
+
+describe('handleCallToolRequest null / primitive tool result payloads (issue #922)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createServerInfo = (callToolImpl: jest.Mock) => ({
+    name: 'null-server',
+    status: 'connected',
+    enabled: true,
+    tools: [{ name: 'null-server::do_thing' }],
+    client: { callTool: callToolImpl, close: jest.fn() },
+    transport: {},
+    options: {},
+  });
+
+  const callWithPayload = async (text: string) => {
+    const callTool = jest.fn().mockResolvedValue({
+      content: [{ type: 'text', text }],
+      isError: false,
+    });
+    const serverInfo = createServerInfo(callTool) as any;
+
+    const getServerByNameSpy = jest
+      .spyOn(mcpService, 'getServerByName')
+      .mockReturnValue(serverInfo);
+
+    const result = await mcpService.handleCallToolRequest(
+      {
+        params: {
+          name: 'call_tool',
+          arguments: {
+            toolName: 'null-server::do_thing',
+            arguments: {},
+          },
+        },
+      },
+      {
+        sessionId: 'session-1',
+        server: 'null-server',
+      },
+    );
+
+    getServerByNameSpy.mockRestore();
+    return { result, callTool };
+  };
+
+  it('passes through a null JSON payload without throwing', async () => {
+    const { result, callTool } = await callWithPayload('null');
+
+    expect(callTool).toHaveBeenCalledTimes(1);
+    // Raw text content is returned unchanged.
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'null' }],
+      isError: false,
+    });
+  });
+
+  it('passes through a primitive number payload without throwing', async () => {
+    const { result } = await callWithPayload('42');
+    expect(result).toEqual({
+      content: [{ type: 'text', text: '42' }],
+      isError: false,
+    });
+  });
+
+  it('passes through a boolean payload without throwing', async () => {
+    const { result } = await callWithPayload('true');
+    expect(result).toEqual({
+      content: [{ type: 'text', text: 'true' }],
+      isError: false,
+    });
+  });
+
+  it('still surfaces a genuine { code: 401 } payload as an auth error', async () => {
+    // A real auth-error object must keep triggering the 401 path — the null
+    // guard must not swallow legitimate error objects.
+    const callTool = jest.fn().mockResolvedValue({
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({ code: 401, message: 'Unauthorized' }),
+        },
+      ],
+      isError: false,
+    });
+    const serverInfo = createServerInfo(callTool) as any;
+
+    const getServerByNameSpy = jest
+      .spyOn(mcpService, 'getServerByName')
+      .mockReturnValue(serverInfo);
+
+    const result = await mcpService.handleCallToolRequest(
+      {
+        params: {
+          name: 'call_tool',
+          arguments: { toolName: 'null-server::do_thing', arguments: {} },
+        },
+      },
+      { sessionId: 'session-1', server: 'null-server' },
+    );
+
+    getServerByNameSpy.mockRestore();
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('401');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #922 — the hub's tool-call path crashed when an MCP server tool returned a `null` (or other non-object JSON) payload as its text content.

## Problem

Any MCP tool returning `{ content: [{ type: "text", text: "null" }] }` (or a JSON-stringified `null`) crashed MCPHub with:

```
TypeError | Cannot read properties of null (reading 'code')
```

This affected the `$smart` route and every other route, since the crash is in `checkAuthError` on the shared path (`callToolWithReconnect` → `handleCallToolRequest`). Not specific to any one server — reproducible with any tool handler that returns a `null`/primitive result.

## Root cause

`checkAuthError` in [src/services/mcpService.ts](src/services/mcpService.ts) parses every tool result's text content and dereferences `.code`:

```ts
errorContent = JSON.parse(text);   // JSON.parse("null") → null
...
if (errorContent.code === 401) {   // null.code → throws
```

## Fix

Guard the property access so only object payloads are inspected for an auth error code. Non-object payloads (`null`, numbers, booleans, strings) now pass through unchanged; a genuine `{ code: 401 }` object still raises the auth error as before.

```ts
if (errorContent && typeof errorContent === 'object' && errorContent.code === 401) {
```

## Test plan

- [x] Added `tests/services/mcpService-null-tool-result.test.ts` (TDD — written failing first, reproducing the exact crash).
  - `null` payload → passes through, no throw (was crashing).
  - `42` / `true` primitive payloads → pass through, no throw.
  - `{ code: 401 }` object → still surfaces as an auth error (guards against the fix swallowing legitimate errors).
- [x] Full mcpService test suite: 13 suites, 77 tests pass.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)