### PR TITLE
fix: scope single-server reload to only that server

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1205,11 +1205,21 @@ export const initializeClientsFromSettings = async (
         continue;
       }
 
-      // Check if server is already connected
-      const existingServer = existingServerInfos.find(
-        (s) => s.name === name && s.status === 'connected',
-      );
-      if (existingServer && (!serverName || serverName !== name)) {
+      // Reuse this server's existing runtime state instead of reconnecting when:
+      // - a targeted reload/reconnect (serverName) was requested for a
+      //   *different* server — preserve its current state regardless of
+      //   status. Reloading one server must not reconnect unrelated servers
+      //   (e.g. failed/disconnected ones), which would also leak their
+      //   previous stdio child processes. See #921.
+      // - it is already connected and we are not specifically targeting it
+      //   for reconnect (serverName is undefined, or names a different server).
+      const existingServer = existingServerInfos.find((s) => s.name === name);
+      const isTargetedReload = Boolean(serverName) && serverName !== name;
+      if (
+        existingServer &&
+        (isTargetedReload ||
+          (existingServer.status === 'connected' && serverName !== name))
+      ) {
         nextServerInfos.push({
           ...existingServer,
           enabled: expandedConf.enabled === undefined ? true : expandedConf.enabled,

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1211,14 +1211,14 @@ export const initializeClientsFromSettings = async (
       //   status. Reloading one server must not reconnect unrelated servers
       //   (e.g. failed/disconnected ones), which would also leak their
       //   previous stdio child processes. See #921.
-      // - it is already connected and we are not specifically targeting it
-      //   for reconnect (serverName is undefined, or names a different server).
+      // - a general/full initialization (no serverName) — only preserve this
+      //   server's state if it is already connected.
       const existingServer = existingServerInfos.find((s) => s.name === name);
-      const isTargetedReload = Boolean(serverName) && serverName !== name;
+      const isDifferentServer = Boolean(serverName) && serverName !== name;
       if (
         existingServer &&
-        (isTargetedReload ||
-          (existingServer.status === 'connected' && serverName !== name))
+        (isDifferentServer ||
+          (!serverName && existingServer.status === 'connected'))
       ) {
         nextServerInfos.push({
           ...existingServer,

--- a/tests/services/mcpService-targeted-reload.test.ts
+++ b/tests/services/mcpService-targeted-reload.test.ts
@@ -1,0 +1,204 @@
+// Regression coverage for issue #921: reloading a single server must not
+// reconnect other enabled-but-not-connected (e.g. failed/disconnected) servers
+// as a side effect.
+
+const mockClientConnect = jest.fn().mockResolvedValue(undefined);
+const mockClientClose = jest.fn();
+const mockListTools = jest.fn().mockResolvedValue({ tools: [] });
+const mockGetServerCapabilities = jest.fn(() => ({ tools: {} }));
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: mockClientConnect,
+    close: mockClientClose,
+    getServerCapabilities: mockGetServerCapabilities,
+    getServerVersion: jest.fn(() => ({ version: '1.0.0' })),
+    getInstructions: jest.fn(),
+    listTools: mockListTools,
+    listPrompts: jest.fn().mockResolvedValue({ prompts: [] }),
+    listResources: jest.fn().mockResolvedValue({ resources: [] }),
+  })),
+}));
+
+class MockStreamableHTTPClientTransport {
+  url: URL;
+  close = jest.fn();
+  constructor(url: URL) {
+    this.url = url;
+  }
+}
+
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: MockStreamableHTTPClientTransport,
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: jest.fn(),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthService.js', () => ({
+  initializeAllOAuthClients: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthClientRegistration.js', () => ({
+  registerOAuthClient: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpOAuthProvider.js', () => ({
+  createOAuthProvider: jest.fn(async () => undefined),
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  getServersInGroup: jest.fn(),
+  getServerConfigInGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn(() => ''),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  removeServerToolEmbeddings: jest.fn().mockResolvedValue(undefined),
+  saveToolsAsVectorEmbeddings: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({
+    filterData: (data: any) => data,
+  })),
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  initSmartRoutingService: jest.fn(),
+  getSmartRoutingTools: jest.fn(),
+  handleSearchToolsRequest: jest.fn(),
+  handleDescribeToolRequest: jest.fn(),
+  isSmartRoutingGroup: jest.fn(() => false),
+}));
+
+jest.mock('../../src/services/keepAliveService.js', () => ({
+  setupClientKeepAlive: jest.fn(),
+}));
+
+jest.mock('../../src/services/activityLoggingService.js', () => ({
+  getActivityLoggingService: jest.fn(() => ({
+    logToolCall: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+jest.mock('../../src/services/proxy.js', () => ({
+  createFetchWithProxy: jest.fn(() => jest.fn()),
+  getProxyConfigFromEnv: jest.fn(() => undefined),
+}));
+
+const allServers = [
+  {
+    name: 'target',
+    type: 'streamable-http',
+    url: 'https://example.com/target/mcp',
+    enabled: true,
+    owner: 'admin',
+    visibility: 'public',
+  },
+  {
+    name: 'other-failed-1',
+    type: 'streamable-http',
+    url: 'https://example.com/other1/mcp',
+    enabled: true,
+    owner: 'admin',
+    visibility: 'public',
+  },
+  {
+    name: 'other-failed-2',
+    type: 'streamable-http',
+    url: 'https://example.com/other2/mcp',
+    enabled: true,
+    owner: 'admin',
+    visibility: 'public',
+  },
+];
+
+const mockServerDao = {
+  findAll: jest.fn(async () => allServers),
+  findById: jest.fn(async (name: string) => allServers.find((s) => s.name === name)),
+};
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: jest.fn(() => mockServerDao),
+  getSystemConfigDao: jest.fn(() => ({
+    get: jest.fn(async () => ({})),
+  })),
+  getBuiltinPromptDao: jest.fn(() => ({
+    findEnabled: jest.fn(async () => []),
+  })),
+  getBuiltinResourceDao: jest.fn(() => ({
+    findEnabled: jest.fn(async () => []),
+  })),
+}));
+
+jest.mock('../../src/config/index.js', () => ({
+  expandEnvVars: jest.fn((value: string) => value),
+  replaceEnvVars: jest.fn((value: any) => value),
+  getNameSeparator: jest.fn(() => '::'),
+  default: {
+    mcpHubName: 'test-hub',
+    mcpHubVersion: '1.0.0',
+    initTimeout: 60000,
+  },
+}));
+
+import {
+  reconnectServer,
+  setServerInfosForTest,
+  getServerByName,
+} from '../../src/services/mcpService.js';
+import type { ServerInfo } from '../../src/types/index.js';
+
+const makeDisconnectedServerInfo = (name: string): ServerInfo =>
+  ({
+    name,
+    status: 'disconnected',
+    error: 'previous failure',
+    tools: [],
+    prompts: [],
+    resources: [],
+    enabled: true,
+    createTime: Date.now(),
+    client: { close: jest.fn() },
+    transport: { close: jest.fn() },
+  }) as unknown as ServerInfo;
+
+describe('targeted reload does not reconnect other servers (issue #921)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reconnects only the target server and leaves disconnected peers untouched', async () => {
+    const target = makeDisconnectedServerInfo('target');
+    const other1 = makeDisconnectedServerInfo('other-failed-1');
+    const other2 = makeDisconnectedServerInfo('other-failed-2');
+    setServerInfosForTest([target, other1, other2]);
+
+    await reconnectServer('target');
+
+    // Only the target server should have spawned a new client / attempted
+    // a fresh connection. The two unrelated disconnected servers must NOT be
+    // reconnected as a side effect.
+    expect(mockClientConnect).toHaveBeenCalledTimes(1);
+
+    // The pre-existing clients/transports of the untouched peers must not be
+    // closed by a collateral reconnect (which would orphan them — see #920).
+    expect((other1.client as any).close).not.toHaveBeenCalled();
+    expect((other1.transport as any).close).not.toHaveBeenCalled();
+    expect((other2.client as any).close).not.toHaveBeenCalled();
+    expect((other2.transport as any).close).not.toHaveBeenCalled();
+
+    // The target itself is reconnected (its own state is replaced).
+    expect(getServerByName('other-failed-1')?.status).toBe('disconnected');
+    expect(getServerByName('other-failed-2')?.status).toBe('disconnected');
+  });
+});


### PR DESCRIPTION
## Summary

Reloading a single MCP server was reconnecting **every other enabled-but-not-connected** (e.g. failed/`disconnected`) server as a side effect. The reload was supposed to be scoped to one server, but in practice each other failed server was re-spawned — and since `reconnectServer` only closes the *target* server's client/transport, the collaterally-reconnected servers leaked their previous stdio child processes (same orphan mechanism as #920).

Fixes #921.

## Root cause

`POST /servers/:name/reload` → `reconnectServer(name)` → `initializeClientsFromSettings(false, serverName)`.

`reconnectServer` closes only the target's client/transport, then `initializeClientsFromSettings` loops over **all** servers. The only thing shielding an existing server from being re-spawned was a skip check that required `status === 'connected'`:

```js
const existingServer = existingServerInfos.find(
  (s) => s.name === name && s.status === 'connected',
);
if (existingServer && (!serverName || serverName !== name)) { ...continue }
```

A failed server has `status === 'disconnected'`, so `existingServer` was `undefined`, it fell through, and a new transport was spawned — even though it wasn't the server being reloaded.

## Fix

Reworked the skip condition in `initializeClientsFromSettings` (`src/services/mcpService.ts`) to handle three cases:

1. **Targeted reload for a *different* server** (`serverName` set, `name !== serverName`) → preserve its current state *regardless of status*. This is the #921 fix.
2. **Already connected and not the target** (`status === 'connected' && serverName !== name`) → preserve (covers full-init where `serverName` is undefined, since `undefined !== name`).
3. **This *is* the target** (`serverName === name`) → do **not** skip → reconnect. This preserves the carve-out `reconnectServer` relies on: its target, even if still marked `connected`, must be re-initialized.

## Test coverage

Added `tests/services/mcpService-targeted-reload.test.ts`: sets up three `disconnected` servers, reloads one, and asserts:
- only the target spawns a new client connection (1 connect, not 3),
- the peers' pre-existing clients/transports are not closed (no orphaning),
- the peers remain `disconnected`.

The test fails on `main` (3 connects) and passes with this change.

## Verification

- `npx tsc --noEmit` — clean
- `npx jest` — 740 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)