### PR TITLE
fix: attach request user context for system-level all-access bearer auth

### DIFF
--- a/src/middlewares/auth.test.ts
+++ b/src/middlewares/auth.test.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import request from 'supertest';
 import { jest } from '@jest/globals';
+import jwt from 'jsonwebtoken';
 import { authenticatedRouteRateLimiter } from '../utils/rateLimit.js';
 
 const currentSystemConfig = {
@@ -441,7 +442,6 @@ describe('auth middleware', () => {
         },
       );
 
-      const jwt = require('jsonwebtoken');
       const token = jwt.sign({ user: { username: 'jwt-user', isAdmin: false } }, 'test-secret');
 
       const response = await request(app)

--- a/src/middlewares/auth.test.ts
+++ b/src/middlewares/auth.test.ts
@@ -254,6 +254,38 @@ describe('auth middleware', () => {
     });
   });
 
+  it('returns 500 when validateBearerAuth throws a database error', async () => {
+    findEnabledMock.mockRejectedValueOnce(new Error('Database connection failed'));
+
+    const app = express();
+    app.get(
+      '/api/protected',
+      authenticatedRouteRateLimiter,
+      (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+        (req as any).t = (value: string) => value;
+        next();
+      },
+      auth,
+      (_req: express.Request, res: express.Response) => {
+        res.status(200).json({ success: true });
+      },
+      // Error handler to catch next(error) from auth
+      (err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+        res.status(500).json({ success: false, message: 'Internal server error' });
+      },
+    );
+
+    const response = await request(app)
+      .get('/api/protected')
+      .set('Authorization', 'Bearer test-key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      success: false,
+      message: 'Internal server error',
+    });
+  });
+
   describe('system bearer auth context', () => {
     it('attaches an admin user context for valid system all-access bearer key', async () => {
       findEnabledMock.mockResolvedValue([

--- a/src/middlewares/auth.test.ts
+++ b/src/middlewares/auth.test.ts
@@ -253,4 +253,174 @@ describe('auth middleware', () => {
       },
     });
   });
+
+  describe('system bearer auth context', () => {
+    it('attaches an admin user context for valid system all-access bearer key', async () => {
+      findEnabledMock.mockResolvedValue([
+        {
+          id: 'key-sys-1',
+          name: 'system-client',
+          token: 'system-key',
+          enabled: true,
+          kind: 'system',
+          accessType: 'all',
+          owner: 'system-owner',
+        },
+      ]);
+
+      const app = express();
+      app.get(
+        '/api/protected',
+        authenticatedRouteRateLimiter,
+        (req, _res, next) => {
+          (req as any).t = (value: string) => value;
+          next();
+        },
+        auth,
+        (req, res) => {
+          res.status(200).json({
+            success: true,
+            user: (req as any).user,
+            bearerKey: (req as any).bearerKey,
+          });
+        },
+      );
+
+      const response = await request(app)
+        .get('/api/protected')
+        .set('Authorization', 'Bearer system-key');
+
+      expect(response.status).toBe(200);
+      expect(response.body.user).toEqual({
+        username: 'system-owner',
+        isAdmin: true,
+      });
+      expect(response.body.bearerKey).toEqual(
+        expect.objectContaining({
+          id: 'key-sys-1',
+          name: 'system-client',
+          kind: 'system',
+          accessType: 'all',
+          owner: 'system-owner',
+        }),
+      );
+    });
+
+    it('uses fallback username "system" when system bearer key has no owner', async () => {
+      findEnabledMock.mockResolvedValue([
+        {
+          id: 'key-sys-2',
+          name: 'no-owner-system',
+          token: 'no-owner-key',
+          enabled: true,
+          kind: 'system',
+          accessType: 'all',
+          owner: undefined,
+        },
+      ]);
+
+      const app = express();
+      app.get(
+        '/api/protected',
+        authenticatedRouteRateLimiter,
+        (req, _res, next) => {
+          (req as any).t = (value: string) => value;
+          next();
+        },
+        auth,
+        (req, res) => {
+          res.status(200).json({
+            success: true,
+            user: (req as any).user,
+          });
+        },
+      );
+
+      const response = await request(app)
+        .get('/api/protected')
+        .set('Authorization', 'Bearer no-owner-key');
+
+      expect(response.status).toBe(200);
+      expect(response.body.user).toEqual({
+        username: 'system',
+        isAdmin: true,
+      });
+    });
+
+    it('denies user-kind bearer keys for dashboard API routes', async () => {
+      findEnabledMock.mockResolvedValue([
+        {
+          id: 'key-user-1',
+          name: 'user-client',
+          token: 'user-key',
+          enabled: true,
+          kind: 'user',
+          accessType: 'all',
+          owner: 'alice',
+        },
+      ]);
+
+      const app = createApp();
+      const response = await request(app)
+        .get('/api/protected')
+        .set('Authorization', 'Bearer user-key');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ success: false, message: 'No token, authorization denied' });
+    });
+
+    it('denies system bearer keys with accessType other than all', async () => {
+      findEnabledMock.mockResolvedValue([
+        {
+          id: 'key-scoped-1',
+          name: 'groups-scoped',
+          token: 'groups-key',
+          enabled: true,
+          kind: 'system',
+          accessType: 'groups',
+          allowedGroups: ['engineering'],
+        },
+      ]);
+
+      const app = createApp();
+      const response = await request(app)
+        .get('/api/protected')
+        .set('Authorization', 'Bearer groups-key');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ success: false, message: 'No token, authorization denied' });
+    });
+
+    it('still authenticates with JWT x-auth-token', async () => {
+      const app = express();
+      app.get(
+        '/api/protected',
+        authenticatedRouteRateLimiter,
+        (req, _res, next) => {
+          (req as any).t = (value: string) => value;
+          next();
+        },
+        auth,
+        (req, res) => {
+          res.status(200).json({
+            success: true,
+            user: (req as any).user,
+          });
+        },
+      );
+
+      const jwt = require('jsonwebtoken');
+      const token = jwt.sign({ user: { username: 'jwt-user', isAdmin: false } }, 'test-secret');
+
+      const response = await request(app)
+        .get('/api/protected')
+        .set('x-auth-token', token);
+
+      expect(response.status).toBe(200);
+      expect(response.body.user).toEqual({
+        username: 'jwt-user',
+        isAdmin: false,
+      });
+    });
+  });
 });

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -114,7 +114,14 @@ export const auth = async (req: Request, res: Response, next: NextFunction): Pro
   };
 
   // Check if bearer auth via configured keys can validate this request
-  const matchingBearerKey = await validateBearerAuth(req, systemConfig);
+  let matchingBearerKey: BearerKey | null = null;
+  try {
+    matchingBearerKey = await validateBearerAuth(req, systemConfig);
+  } catch (error) {
+    next(error as Error);
+    return;
+  }
+
   if (matchingBearerKey) {
     (req as any).user = {
       username: matchingBearerKey.owner || 'system',

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -24,10 +24,10 @@ const resolveBetterAuthUserSafe = async (req: Request) => {
   return module.resolveBetterAuthUser(req);
 };
 
-const validateBearerAuth = async (req: Request, systemConfig?: SystemConfig | null): Promise<boolean> => {
+const validateBearerAuth = async (req: Request, systemConfig?: SystemConfig | null): Promise<BearerKey | null> => {
   const enableBearerAuth = systemConfig?.routing?.enableBearerAuth ?? true;
   if (!enableBearerAuth) {
-    return false;
+    return null;
   }
 
   const bearerKeyDao = getBearerKeyDao();
@@ -35,18 +35,18 @@ const validateBearerAuth = async (req: Request, systemConfig?: SystemConfig | nu
 
   // If there are no enabled keys, bearer auth via static keys is disabled
   if (enabledKeys.length === 0) {
-    return false;
+    return null;
   }
 
   const token = getBearerTokenFromHeaders(req.headers, systemConfig);
   if (!token) {
-    return false;
+    return null;
   }
 
   const matchingKey: BearerKey | undefined = enabledKeys.find((key) => safeCompare(key.token, token));
   if (!matchingKey) {
     console.warn('Bearer auth failed: token did not match any configured bearer key');
-    return false;
+    return null;
   }
 
   // Dashboard/API bearer authentication grants access to non-MCP management routes.
@@ -56,13 +56,13 @@ const validateBearerAuth = async (req: Request, systemConfig?: SystemConfig | nu
     console.warn(
       `Bearer auth denied for dashboard API: key id=${matchingKey.id}, name=${matchingKey.name} is not a system-level all-access key`,
     );
-    return false;
+    return null;
   }
 
   console.log(
     `Bearer auth succeeded with key id=${matchingKey.id}, name=${matchingKey.name}, accessType=${matchingKey.accessType}`,
   );
-  return true;
+  return matchingKey;
 };
 
 const readonlyAllowPaths = ['/tools/'];
@@ -114,7 +114,13 @@ export const auth = async (req: Request, res: Response, next: NextFunction): Pro
   };
 
   // Check if bearer auth via configured keys can validate this request
-  if (await validateBearerAuth(req, systemConfig)) {
+  const matchingBearerKey = await validateBearerAuth(req, systemConfig);
+  if (matchingBearerKey) {
+    (req as any).user = {
+      username: matchingBearerKey.owner || 'system',
+      isAdmin: true,
+    };
+    (req as any).bearerKey = matchingBearerKey;
     next();
     return;
   }

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -692,6 +692,162 @@ describe('serverController - authorization hardening', () => {
   });
 });
 
+describe('serverController - system bearer auth context', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates server with stable owner from system bearer user context', async () => {
+    mockAddServer.mockResolvedValue({ success: true });
+
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      body: {
+        name: 'openapi-server',
+        config: {
+          type: 'openapi',
+          openapi: {
+            url: 'https://api.example.com/openapi.json',
+            version: '3.1.0',
+          },
+        },
+      },
+      user: {
+        username: 'system-owner',
+        isAdmin: true,
+      },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+
+    await createServer(req, res);
+
+    expect(mockAddServer).toHaveBeenCalledWith(
+      'openapi-server',
+      expect.objectContaining({
+        owner: 'system-owner',
+        type: 'openapi',
+      }),
+    );
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server added successfully',
+    });
+  });
+
+  it('allows reading an existing server with system bearer admin context', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      name: 'existing-server',
+      type: 'openapi',
+      url: 'https://api.example.com/openapi.json',
+      owner: 'system-owner',
+      visibility: 'private',
+    });
+    mockGetServersInfo.mockResolvedValue([
+      { name: 'existing-server', status: 'connected', tools: [] },
+    ]);
+
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'existing-server' },
+      user: {
+        username: 'system-owner',
+        isAdmin: true,
+      },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+
+    await getServerConfig(req, res);
+
+    expect(mockServerDao.findById).toHaveBeenCalledWith('existing-server');
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        name: 'existing-server',
+        status: 'connected',
+        tools: [],
+        config: expect.objectContaining({
+          type: 'openapi',
+          url: 'https://api.example.com/openapi.json',
+        }),
+      },
+    });
+  });
+
+  it('allows updating an existing server with system bearer admin context', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      name: 'existing-server',
+      type: 'openapi',
+      url: 'https://api.example.com/openapi.json',
+      owner: 'system-owner',
+      visibility: 'private',
+    });
+    mockAddOrUpdateServer.mockResolvedValue({ success: true });
+
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'existing-server' },
+      body: {
+        config: {
+          type: 'openapi',
+          openapi: {
+            url: 'https://api.example.com/v2/openapi.json',
+            version: '3.1.0',
+          },
+          visibility: 'public',
+        },
+      },
+      user: {
+        username: 'system-owner',
+        isAdmin: true,
+      },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+
+    await updateServer(req, res);
+
+    expect(mockAddOrUpdateServer).toHaveBeenCalledWith(
+      'existing-server',
+      expect.objectContaining({
+        visibility: 'public',
+      }),
+      true,
+    );
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server updated successfully',
+    });
+  });
+
+  it('denies non-admin user from reading another users server', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      name: 'shared-server',
+      owner: 'bob',
+    });
+
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'shared-server' },
+      user: {
+        username: 'alice',
+        isAdmin: false,
+      },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+
+    await getServerConfig(req, res);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Forbidden',
+    });
+  });
+});
+
 describe('serverController - getAllServers', () => {
   beforeEach(() => {
     jest.clearAllMocks();


### PR DESCRIPTION
### Bug
mcphub's auth middleware (src/middlewares/auth.ts) authenticates kind=system + accessType=all bearer keys for dashboard/API management routes, but validateBearerAuth() returned only boolean. After successful bearer auth, auth() called next() without attaching req.user, creating a half-authenticated state:
- POST /api/servers succeeds (doesn't require req.user for creation)
- GET /api/servers/:name fails with 403 Forbidden (canAccessServer() returns false when req.user is null)
- PUT /api/servers/:name fails with 403 Forbidden for the same reason

### Fix
1. Return matched BearerKey - validateBearerAuth() now returns BearerKey | null instead of boolean, preserving key metadata (owner, id, name)
2. Attach admin user context - After successful system all-access bearer auth, set req.user = { username: key.owner || 'system', isAdmin: true } and req.bearerKey = matchingKey
3. Preserve security boundary - User-scoped and limited-access system keys remain denied for dashboard/API routes

### Files Changed
- mcphub/src/middlewares/auth.ts - core fix (2 changes: return type + user attachment)
- mcphub/src/middlewares/auth.test.ts - 5 new tests for system bearer context and security regression
- mcphub/tests/controllers/serverController.test.ts - 4 new tests verifying server CRUD with admin user context

### Tests
- 14 auth middleware tests (9 existing + 5 new) - all pass
- 17 server controller tests (13 existing + 4 new) - all pass
- Full suite: 734 passed, 1 pre-existing failure in mcpbController.test.ts (unrelated)