### PR TITLE
feat: release-notes skill + relaxed bilingual release notes validation

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -18,6 +18,7 @@ Every release body must follow this section order. Optional sections are omitted
 | `## Fixes` | optional | `## 修复` |
 | `## Breaking Changes` | optional | `## 破坏性变更` |
 | `## 摘要` | yes (non-empty) | pair of Summary |
+| `## New Contributors` | optional (English only, no Chinese pair) | — |
 | `## References` | yes (non-empty) | — |
 
 Rules enforced by `scripts/validate-release-notes.js` (CI runs it on publish/edit):
@@ -43,6 +44,7 @@ Rules enforced by `scripts/validate-release-notes.js` (CI runs it on publish/edi
 4. **Fetch merged PRs in the range.**
    - Use `gh pr list --state merged --limit 100 --json number,title,author,url,mergedAt` and filter to those merged after the previous tag (or up to `<tag>`'s publish date for the first-tag case).
    - Drop bot/maintenance PRs only if the user asks; otherwise include all.
+   - Identify new contributors: for each distinct human author of a merged PR in the range, check whether they had any merged PR before the previous tag (`gh pr list --state merged --author <user> --limit 1`, filter by merged date). Authors with none before the previous tag are new contributors. Exclude bot accounts (`dependabot[bot]`, `github-actions[bot]`, `Copilot`, and any `*[bot]` login).
 
 5. **Draft the body.** Generate each section from the PR set:
    - `## Summary` — one English paragraph on why this release matters.
@@ -51,6 +53,10 @@ Rules enforced by `scripts/validate-release-notes.js` (CI runs it on publish/edi
    - `## Breaking Changes` — only when present (omit if none).
    - `## 摘要` — Chinese translation of the Summary.
    - `## 功能` / `## 修复` / `## 破坏性变更` — Chinese pairs, present iff the English counterpart is present. Mirror the same bullets.
+   - `## New Contributors` — one bullet per new contributor (English only, no Chinese pair). Omit the whole section if there are none. Format:
+     ```
+     - @<login> made their first contribution in #<number>
+     ```
    - `## References` — one bullet per merged PR in the exact format, followed by the Full changelog line:
      ```
      - <PR title> by @<author login> in https://github.com/samanhappy/mcphub/pull/<number>

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: release-notes
+description: Edit an existing GitHub release's body into the project's bilingual (English + Chinese) template format with a References section built from merged PRs. Use when 修改 release、整理发布说明、release notes、编辑 release 内容、发版后整理、edit release body.
+---
+
+# Release Notes
+
+Rewrite an existing GitHub release's body into the project's bilingual template, then push it back. The repo's release pipeline auto-generates a raw body on tag push (`generate_release_notes: true`) that does not match the bilingual template — this skill cleans it up.
+
+## Required structure
+
+Every release body must follow this section order. Optional sections are omitted entirely when they have no content — never leave an empty section, never use `None`/`无` placeholders.
+
+| Section | Required | Chinese pair |
+|---|---|---|
+| `## Summary` | yes (non-empty) | — |
+| `## Features` | optional | `## 功能` |
+| `## Fixes` | optional | `## 修复` |
+| `## Breaking Changes` | optional | `## 破坏性变更` |
+| `## 摘要` | yes (non-empty) | pair of Summary |
+| `## References` | yes (non-empty) | — |
+
+Rules enforced by `scripts/validate-release-notes.js` (CI runs it on publish/edit):
+- `Summary`, `摘要`, `References` must be present and non-empty.
+- Each optional English section and its Chinese pair must appear together — having one without the other fails validation.
+- Optional sections with no real content are omitted, not stubbed.
+
+## Workflow
+
+1. **Resolve the target release.**
+   - If the user gave a tag (e.g. `v1.0.14`), use it.
+   - Otherwise use the latest: `gh release list --limit 1`.
+
+2. **Fetch the existing body.**
+   - `gh release view <tag> --json body -q .body`
+   - Read it to find an existing `Full changelog: ...compare/<prev>...<tag>` line to learn the previous tag. Also note any PR list already present, but do not trust it blindly — re-fetch authoritatively in step 4.
+
+3. **Resolve the previous tag (the compare range).**
+   - Preferred: parse `compare/vX...vY` from the existing body.
+   - Fallback: `git describe --tags --abbrev=0 <tag>^` to get the tag before `<tag>`.
+   - First-ever tag (no previous tag exists): fetch all merged PRs up to the tag date; if more than 50, take the 50 most recent and flag it for the user to review.
+
+4. **Fetch merged PRs in the range.**
+   - Use `gh pr list --state merged --limit 100 --json number,title,author,url,mergedAt` and filter to those merged after the previous tag (or up to `<tag>`'s publish date for the first-tag case).
+   - Drop bot/maintenance PRs only if the user asks; otherwise include all.
+
+5. **Draft the body.** Generate each section from the PR set:
+   - `## Summary` — one English paragraph on why this release matters.
+   - `## Features` — user-facing additions/improvements (omit if none).
+   - `## Fixes` — bug fixes, reliability, dependency bumps (omit if none).
+   - `## Breaking Changes` — only when present (omit if none).
+   - `## 摘要` — Chinese translation of the Summary.
+   - `## 功能` / `## 修复` / `## 破坏性变更` — Chinese pairs, present iff the English counterpart is present. Mirror the same bullets.
+   - `## References` — one bullet per merged PR in the exact format, followed by the Full changelog line:
+     ```
+     - <PR title> by @<author login> in https://github.com/samanhappy/mcphub/pull/<number>
+     - Full changelog: https://github.com/samanhappy/mcphub/compare/<prev>...<tag>
+     ```
+
+6. **Present the draft in the conversation.** Show the full markdown and ask the user to confirm or request edits. Iterate until the user says to push. Do not write the draft to a file in the working tree.
+
+7. **Validate locally before pushing.** Write the draft to a throwaway temp file (e.g. `/tmp/release-notes-<tag>.md`, never inside the repo), then:
+   ```
+   node scripts/validate-release-notes.js /tmp/release-notes-<tag>.md
+   ```
+   - On failure: report which section is missing/empty/asymmetric, fix the draft, re-validate.
+   - On success: proceed.
+
+8. **Push the edited body.**
+   ```
+   gh release edit <tag> --notes-file /tmp/release-notes-<tag>.md
+   ```
+
+9. **Clean up.** Delete the temp file.
+
+## Notes
+
+- Editing a release is externally visible and re-triggers the `release: edited` GitHub event (which runs the validator in CI). Always validate locally first.
+- The temp file is only for validation input — it is not a draft the user edits. Keep iteration in the conversation.
+- If the existing body already partially follows the template (e.g. a prior run already edited it), reuse the good parts rather than regenerating from scratch.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -42,7 +42,7 @@ Rules enforced by `scripts/validate-release-notes.js` (CI runs it on publish/edi
    - First-ever tag (no previous tag exists): fetch all merged PRs up to the tag date; if more than 50, take the 50 most recent and flag it for the user to review.
 
 4. **Fetch merged PRs in the range.**
-   - Use `gh pr list --state merged --limit 100 --json number,title,author,url,mergedAt` and filter to those merged after the previous tag (or up to `<tag>`'s publish date for the first-tag case).
+   - Use `gh pr list --state merged --limit 300 --json number,title,author,url,mergedAt` and filter to those merged after the previous tag (or up to `<tag>`'s publish date for the first-tag case). If the range exceeds 300 PRs, fetch in pages and warn the user.
    - Drop bot/maintenance PRs only if the user asks; otherwise include all.
    - Identify new contributors: for each distinct human author of a merged PR in the range, check whether they had any merged PR before the previous tag (`gh pr list --state merged --author <user> --limit 1`, filter by merged date). Authors with none before the previous tag are new contributors. Exclude bot accounts (`dependabot[bot]`, `github-actions[bot]`, `Copilot`, and any `*[bot]` login).
 

--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -30,6 +30,10 @@ One paragraph in English describing why this release matters.
 
 - 无
 
+## New Contributors
+
+- @username made their first contribution in #123
+
 ## References
 
 - Pull requests, issues, or compare links.

--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -2,7 +2,7 @@
 
 One paragraph in English describing why this release matters.
 
-## Highlights
+## Features
 
 - User-facing feature or improvement.
 
@@ -14,19 +14,15 @@ One paragraph in English describing why this release matters.
 
 - None
 
-## Upgrade Notes
-
-- None
-
-## 中文摘要
+## 摘要
 
 用中文概括这个版本为什么值得升级。
 
-## 中文亮点
+## 功能
 
 - 面向用户的功能或体验改进。
 
-## 中文修复
+## 修复
 
 - 缺陷修复、稳定性改进或依赖更新。
 
@@ -34,11 +30,7 @@ One paragraph in English describing why this release matters.
 
 - 无
 
-## 升级说明
-
-- 无
-
 ## References
 
 - Pull requests, issues, or compare links.
-
+- Full changelog: https://github.com/samanhappy/mcphub/compare/vX.Y.Z...vX.Y.W

--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -28,7 +28,7 @@ One paragraph in English describing why this release matters.
 
 ## 破坏性变更
 
-- 无
+- 描述破坏性变更及迁移路径（无则省略本区块）。
 
 ## New Contributors
 

--- a/scripts/validate-release-notes.js
+++ b/scripts/validate-release-notes.js
@@ -47,7 +47,7 @@ function normalizeHeading(value) {
 
 function collectSections(markdown) {
   const sections = new Map();
-  const lines = markdown.replace(/^﻿/, '').replace(/\r\n?/g, '\n').split('\n');
+  const lines = markdown.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n').split('\n');
   let current = null;
   let currentLines = [];
 

--- a/scripts/validate-release-notes.js
+++ b/scripts/validate-release-notes.js
@@ -1,16 +1,11 @@
 import fs from 'fs';
 
-const REQUIRED_HEADINGS = [
-  'Summary',
-  'Highlights',
-  'Fixes',
-  'Breaking Changes',
-  'Upgrade Notes',
-  '中文摘要',
-  '中文亮点',
-  '中文修复',
-  '破坏性变更',
-  '升级说明',
+const REQUIRED_HEADINGS = ['Summary', '摘要', 'References'];
+
+const PAIRED_HEADINGS = [
+  ['Features', '功能'],
+  ['Fixes', '修复'],
+  ['Breaking Changes', '破坏性变更'],
 ];
 
 function usage() {
@@ -50,7 +45,7 @@ function normalizeHeading(value) {
 
 function collectSections(markdown) {
   const sections = new Map();
-  const lines = markdown.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n').split('\n');
+  const lines = markdown.replace(/^﻿/, '').replace(/\r\n?/g, '\n').split('\n');
   let current = null;
   let currentLines = [];
 
@@ -76,22 +71,40 @@ function collectSections(markdown) {
 
 const markdown = readInput();
 const sections = collectSections(markdown);
+
 const missing = REQUIRED_HEADINGS.filter((heading) => !sections.has(normalizeHeading(heading)));
-const empty = REQUIRED_HEADINGS.filter((heading) => {
+const emptyRequired = REQUIRED_HEADINGS.filter((heading) => {
   const value = sections.get(normalizeHeading(heading));
   return value !== undefined && value.trim() === '';
 });
 
-if (missing.length > 0 || empty.length > 0) {
-  if (missing.length > 0) {
-    console.error(`Missing release note sections: ${missing.join(', ')}`);
+const emptyOptional = [];
+const asymmetries = [];
+for (const [en, zh] of PAIRED_HEADINGS) {
+  const enValue = sections.get(normalizeHeading(en));
+  const zhValue = sections.get(normalizeHeading(zh));
+  if (enValue !== undefined && enValue.trim() === '') emptyOptional.push(en);
+  if (zhValue !== undefined && zhValue.trim() === '') emptyOptional.push(zh);
+  if ((enValue !== undefined) !== (zhValue !== undefined)) {
+    asymmetries.push(`${en} / ${zh}`);
   }
-  if (empty.length > 0) {
-    console.error(`Empty release note sections: ${empty.join(', ')}`);
+}
+
+if (missing.length > 0 || emptyRequired.length > 0 || emptyOptional.length > 0 || asymmetries.length > 0) {
+  if (missing.length > 0) {
+    console.error(`Missing required release note sections: ${missing.join(', ')}`);
+  }
+  if (emptyRequired.length > 0) {
+    console.error(`Empty required release note sections: ${emptyRequired.join(', ')}`);
+  }
+  if (emptyOptional.length > 0) {
+    console.error(`Empty optional release note sections: ${emptyOptional.join(', ')} (omit the section instead of leaving it empty)`);
+  }
+  if (asymmetries.length > 0) {
+    console.error(`Asymmetric bilingual sections (both English and Chinese must be present together): ${asymmetries.join(', ')}`);
   }
   console.error('Use .github/release-notes-template.md as the required structure.');
   process.exit(1);
 }
 
 console.log('Release notes structure is valid.');
-

--- a/scripts/validate-release-notes.js
+++ b/scripts/validate-release-notes.js
@@ -8,6 +8,8 @@ const PAIRED_HEADINGS = [
   ['Breaking Changes', '破坏性变更'],
 ];
 
+const OPTIONAL_UNPAIRED_HEADINGS = ['New Contributors'];
+
 function usage() {
   console.error('Usage: node scripts/validate-release-notes.js <file>');
   console.error('   or: node scripts/validate-release-notes.js --env RELEASE_BODY');
@@ -88,6 +90,11 @@ for (const [en, zh] of PAIRED_HEADINGS) {
   if ((enValue !== undefined) !== (zhValue !== undefined)) {
     asymmetries.push(`${en} / ${zh}`);
   }
+}
+
+for (const heading of OPTIONAL_UNPAIRED_HEADINGS) {
+  const value = sections.get(normalizeHeading(heading));
+  if (value !== undefined && value.trim() === '') emptyOptional.push(heading);
 }
 
 if (missing.length > 0 || emptyRequired.length > 0 || emptyOptional.length > 0 || asymmetries.length > 0) {


### PR DESCRIPTION
## Summary

- Adds a `release-notes` skill that rewrites an existing GitHub release's auto-generated body into the project's bilingual (English + Chinese) template, with a `References` section built from merged PRs in the compare range.
- Relaxes `scripts/validate-release-notes.js` so optional sections can be omitted instead of stubbed, renames `Highlights` → `Features`, drops `Upgrade Notes`, and enforces English/Chinese section pairs to appear together. Updates the template to match.

## Why

The release pipeline auto-generates a raw body (`generate_release_notes: true`) that doesn't match the bilingual template, so each release's body needs manual cleanup. The old validator forced every section present and non-empty, which produced noisy `None`/`无` placeholders for empty sections. This makes sections optional (omit when empty) while keeping the bilingual structure symmetric.

## Changes

- `scripts/validate-release-notes.js` — `Summary`/`摘要`/`References` required; `Features`/`Fixes`/`Breaking Changes` (+ Chinese pairs) optional, omitted when empty; English and Chinese pairs must appear together (asymmetry fails validation).
- `.github/release-notes-template.md` — `Highlights` → `Features`, removed `Upgrade Notes`, dropped the `中文` prefix from Chinese section names.
- `.claude/skills/release-notes/SKILL.md` — new skill: resolves target release (tag arg or latest), parses the compare range from the body (falls back to `git describe`, then all-merged-PRs for the first tag), fetches merged PRs, drafts the bilingual body, iterates in-conversation, validates locally against the script in a temp file, then `gh release edit` to push.

## Reviewer notes

- Editing a release is externally visible and re-triggers the `release: edited` event (which runs this validator in CI); the skill validates locally before pushing.
- The validator change is backward-incompatible for any future release body: existing auto-generated bodies use the old section names. The skill rewrites them to the new structure, so this is fine for releases edited via the skill going forward.

## Test plan

- [x] Validator passes a well-formed bilingual body with all optional sections.
- [x] Validator passes a minimal body (only `Summary`/`摘要`/`References`).
- [x] Validator rejects an asymmetric body (English section without its Chinese pair).
- [x] `settings.local.json` (gitignored) was not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)