### PR TITLE
Add OpenRouter Fusion (multi-model deliberation) to the market

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -51,12 +51,12 @@
         "command": "npx",
         "args": [
           "-y",
-          "github:tboome33/openrouter-fusion-mcp"
+          "openrouter-fusion-mcp"
         ],
         "env": {
           "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
         },
-        "description": "Runs server.mjs straight from the public GitHub repo via npx (no npm publish required). Presets 'quality' and 'budget' work out-of-the-box; the custom presets (research, research-eco, maths, medecine, code) are added as extra OPENROUTER_FUSION_<NAME> env vars — paste-ready values are in the repo's fusion-env-vars.json."
+        "description": "Runs the published npm package via npx. Presets 'quality' and 'budget' work out-of-the-box; the custom presets (research, research-eco, maths, medecine, code) are added as extra OPENROUTER_FUSION_<NAME> env vars — paste-ready values are in the repo's fusion-env-vars.json."
       }
     },
     "arguments": {

--- a/servers.json
+++ b/servers.json
@@ -1,4 +1,170 @@
 {
+  "openrouter-fusion": {
+    "name": "openrouter-fusion",
+    "display_name": "OpenRouter Fusion",
+    "description": "Multi-model deliberation for high-stakes answers via OpenRouter Fusion: a panel of models answers in parallel (with web search/fetch), then a judge (Opus) synthesizes consensus, contradictions and blind spots into one best answer. Ships named presets (quality, budget, research, research-eco, maths, medecine, code) with per-config reasoning effort / temperature / web-loop cap, a live per-preset cost estimate from OpenRouter prices, and an async start/poll flow so long deliberations never hit a client timeout.",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/tboome33/openrouter-fusion-mcp"
+    },
+    "homepage": "https://github.com/tboome33/openrouter-fusion-mcp",
+    "author": {
+      "name": "tboome33"
+    },
+    "license": "MIT",
+    "categories": [
+      "AI Systems",
+      "MCP Tools"
+    ],
+    "tags": [
+      "openrouter",
+      "fusion",
+      "multi-model",
+      "llm",
+      "deliberation",
+      "ensemble",
+      "judge",
+      "research",
+      "async",
+      "cost-estimate"
+    ],
+    "examples": [
+      {
+        "title": "List the configs with their cost",
+        "description": "Show every Fusion preset (quality, budget, research, …) with its panel, judge, reasoning effort and estimated cost range, then pick one.",
+        "prompt": "List the available Fusion configs with their estimated cost."
+      },
+      {
+        "title": "Start a deep-research deliberation",
+        "description": "Run the diversified frontier panel (Opus + GPT + Gemini Pro + DeepSeek, judged by Opus) in the background and get a job id.",
+        "prompt": "Use Fusion (research) to assess whether 'CRSI' is a real, substantiated concept or an empty buzzword."
+      },
+      {
+        "title": "Fetch the result",
+        "description": "Long-poll the job id returned by fusion_start until the synthesized answer is ready.",
+        "prompt": "Get the Fusion result for job_id fj_xxx."
+      }
+    ],
+    "installations": {
+      "npm": {
+        "type": "npm",
+        "command": "npx",
+        "args": [
+          "-y",
+          "github:tboome33/openrouter-fusion-mcp"
+        ],
+        "env": {
+          "OPENROUTER_API_KEY": "${OPENROUTER_API_KEY}"
+        },
+        "description": "Runs server.mjs straight from the public GitHub repo via npx (no npm publish required). Presets 'quality' and 'budget' work out-of-the-box; the custom presets (research, research-eco, maths, medecine, code) are added as extra OPENROUTER_FUSION_<NAME> env vars — paste-ready values are in the repo's fusion-env-vars.json."
+      }
+    },
+    "arguments": {
+      "OPENROUTER_API_KEY": {
+        "description": "Your OpenRouter API key. MUST be an inference key with credit (a provisioning/management key returns 401 'User not found'). Get one at https://openrouter.ai/keys",
+        "required": true,
+        "example": "sk-or-v1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+      },
+      "OPENROUTER_FUSION_RESEARCH": {
+        "description": "Optional. A named custom config, as a JSON object. One env var per config: OPENROUTER_FUSION_<NAME> registers a config named <name>. Built-in configs 'quality' and 'budget' need no env var. Fields: analysis_models (panel), judge (orchestrator), reasoning_effort (xhigh|high|medium|low|minimal|none), temperature (null = model default), max_tool_calls (1-16, caps the web loop; default 8), optional system. More ready-made presets (research-eco, maths, medecine, code) are in the repo's fusion-env-vars.json.",
+        "required": false,
+        "example": "{\"name\":\"research\",\"analysis_models\":[\"~anthropic/claude-opus-latest\",\"openai/gpt-5.5\",\"~google/gemini-pro-latest\",\"deepseek/deepseek-v4-pro\"],\"judge\":\"~anthropic/claude-opus-latest\",\"reasoning_effort\":\"high\",\"temperature\":null,\"max_tool_calls\":8}"
+      },
+      "OPENROUTER_FUSION_DEFAULT_REASONING": {
+        "description": "Optional. Global default reasoning effort applied to any config that doesn't set its own. Defaults to 'high'.",
+        "required": false,
+        "example": "high"
+      }
+    },
+    "tools": [
+      {
+        "name": "fusion_list",
+        "description": "List the available Fusion configs — each with name, label, panel, judge, reasoning_effort, temperature, max_tool_calls, a relative cost_tier (€/€€/€€€) and a cost_estimate {low, high, usd_per_prompt_token} computed from live OpenRouter prices. Call this FIRST when the user wants Fusion but hasn't named a config: present them, recommend one, and let the user pick.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "fusion_start",
+        "description": "Start an OpenRouter Fusion deliberation in the background and return a job_id immediately (never times out). Pick a config with preset:'<name>' (default: quality). reasoning_effort, temperature and max_tool_calls default to the config's; override per call.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "prompt": {
+              "type": "string",
+              "description": "The question or task to deliberate on."
+            },
+            "preset": {
+              "type": "string",
+              "description": "Config name from fusion_list (quality, budget, or a custom one). Default: quality."
+            },
+            "system": {
+              "type": "string",
+              "description": "Optional system instruction (overrides the config's)."
+            },
+            "reasoning_effort": {
+              "type": "string",
+              "enum": [
+                "xhigh",
+                "high",
+                "medium",
+                "low",
+                "minimal",
+                "none"
+              ],
+              "description": "Override the config's reasoning effort."
+            },
+            "temperature": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 2,
+              "description": "Override the config's sampling temperature (omit = config/model default)."
+            },
+            "analysis_models": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1,
+              "maxItems": 8,
+              "description": "Override the config's panel (1-8 OpenRouter model slugs)."
+            },
+            "judge_model": {
+              "type": "string",
+              "description": "Override the config's judge/orchestrator model."
+            },
+            "max_tool_calls": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 16,
+              "description": "Cap the panel/judge web-search loop. Default 8; do not set very low (e.g. 1) or a hungry judge can end on a tool call with no final text."
+            }
+          },
+          "required": [
+            "prompt"
+          ]
+        }
+      },
+      {
+        "name": "fusion_result",
+        "description": "Fetch the result of a fusion_start job. Long-polls ~45s: returns the synthesized answer when ready, or {status:'running'} (call again with the same job_id).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "job_id": {
+              "type": "string",
+              "description": "The job_id returned by fusion_start."
+            }
+          },
+          "required": [
+            "job_id"
+          ]
+        }
+      }
+    ],
+    "is_official": false
+  },
   "firecrawl": {
     "name": "firecrawl",
     "display_name": "Firecrawl",


### PR DESCRIPTION
Adds **OpenRouter Fusion** to the market — an MCP server that exposes [OpenRouter Fusion](https://openrouter.ai/docs/guides/features/plugins/fusion) (multi-model deliberation).

**What it does:** turns a prompt into a small multi-model deliberation — a panel of models answers in parallel (with web search/fetch), then a judge (Opus) synthesizes consensus, contradictions and blind spots into one best answer.

- **Presets:** `quality`, `budget` (built-in) + `research`, `research-eco`, `maths`, `medecine`, `code` (added via `OPENROUTER_FUSION_<NAME>` env vars).
- **Per-config** reasoning effort / temperature / web-loop cap, plus a **live per-preset cost estimate** computed from OpenRouter prices.
- **Async** `fusion_start` → `fusion_result` long-poll, so long deliberations never hit a client timeout.

**Tools:** `fusion_list`, `fusion_start`, `fusion_result`.
**Install:** `npx -y github:tboome33/openrouter-fusion-mcp` (public repo, no npm publish required). Requires an `OPENROUTER_API_KEY` (an inference key with credit).
**Repo:** https://github.com/tboome33/openrouter-fusion-mcp · MIT.
**Categories:** AI Systems, MCP Tools.

A single keyed entry was added to `servers.json` (`is_official: false`); no other entry is modified.