### PR TITLE
fix: record system-key user in activity logs and reserve usernames (#886)

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -8,6 +8,7 @@ import {
   deleteUser,
   getUserCount,
   getAdminCount,
+  checkReservedUsername,
 } from '../services/userService.js';
 import { validatePasswordStrength } from '../utils/passwordValidation.js';
 
@@ -102,6 +103,16 @@ export const createUser = async (req: Request, res: Response): Promise<void> => 
         success: false,
         message: 'Password does not meet security requirements',
         errors: validationResult.errors,
+      });
+      return;
+    }
+
+    // Check username against reserved names (e.g. "system", "admin")
+    const reservedError = checkReservedUsername(username);
+    if (reservedError) {
+      res.status(400).json({
+        success: false,
+        message: reservedError,
       });
       return;
     }

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -2308,7 +2308,11 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
   // Fallback to extra for backward compatibility (e.g., direct API calls)
   const group =
     requestContextService.getGroupContext() || extra?.group || getGroup(sessionId) || undefined;
-  const username = requestContextService.getUsernameContext() || extra?.username || undefined;
+  const username =
+    requestContextService.getUsernameContext() ||
+    extra?.username ||
+    (requestContextService.getKeyKindContext() === 'system' ? 'system' : undefined) ||
+    undefined;
   let appsRouteContext: McpAppsRouteContext = { enabled: false };
   const keyId = bearerKeyContext.keyId || extra?.keyId || undefined;
   const keyName = bearerKeyContext.keyName || extra?.keyName || undefined;

--- a/src/services/requestContextService.ts
+++ b/src/services/requestContextService.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { Request } from 'express';
 import ipaddr from 'ipaddr.js';
+import type { BearerKeyKind } from '../types/index.js';
 import type { HostedAuthContext } from './hostedAuthService.js';
 
 /**
@@ -15,6 +16,7 @@ export interface RequestContext {
   username?: string;
   keyId?: string;
   keyName?: string;
+  keyKind?: BearerKeyKind;
   hostedAuth?: HostedAuthContext;
 }
 
@@ -201,6 +203,16 @@ export class RequestContextService {
   }
 
   /**
+   * Set key kind context for activity logging
+   */
+  public setKeyKindContext(keyKind?: BearerKeyKind): void {
+    const requestContext = this.getRequestContext();
+    if (requestContext) {
+      requestContext.keyKind = keyKind;
+    }
+  }
+
+  /**
    * Get bearer key context
    */
   public getBearerKeyContext(): { keyId?: string; keyName?: string } {
@@ -223,6 +235,13 @@ export class RequestContextService {
    */
   public getUsernameContext(): string | undefined {
     return this.getRequestContext()?.username;
+  }
+
+  /**
+   * Get key kind context
+   */
+  public getKeyKindContext(): BearerKeyKind | undefined {
+    return this.getRequestContext()?.keyKind;
   }
 
   public getHostedAuthContext(): HostedAuthContext | undefined {

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -15,7 +15,7 @@ import {
 } from '../dao/index.js';
 import { UserContextService } from './userContextService.js';
 import { RequestContextService } from './requestContextService.js';
-import { IUser, BearerKey } from '../types/index.js';
+import { IUser, BearerKey, BearerKeyKind } from '../types/index.js';
 import { resolveOAuthUserFromToken } from '../utils/oauthBearer.js';
 import { safeCompare } from '../utils/safeCompare.js';
 import { getBearerAuthHeaderValue, getBearerTokenFromHeaders } from '../utils/bearerAuth.js';
@@ -117,6 +117,7 @@ type BearerAuthResult =
       user?: IUser;
       keyId?: string;
       keyName?: string;
+      kind?: BearerKeyKind;
       hostedAuth?: HostedAuthContext;
     }
   | {
@@ -266,7 +267,7 @@ const resolveUserLevelKeyUser = async (
   key: BearerKey,
 ): Promise<BearerAuthResult> => {
   if (key.kind !== 'user') {
-    return { valid: true, keyId: key.id, keyName: key.name };
+    return { valid: true, keyId: key.id, keyName: key.name, kind: key.kind || 'system' };
   }
 
   if (!key.owner) {
@@ -283,7 +284,7 @@ const resolveUserLevelKeyUser = async (
     return { valid: false, reason: 'forbidden' };
   }
 
-  return { valid: true, user, keyId: key.id, keyName: key.name };
+  return { valid: true, user, keyId: key.id, keyName: key.name, kind: 'user' };
 };
 
 const validateBearerAuth = async (req: Request): Promise<BearerAuthResult> => {
@@ -329,6 +330,7 @@ const validateBearerAuth = async (req: Request): Promise<BearerAuthResult> => {
         user: { username: hostedAuth.userId, password: '', isAdmin: true },
         keyId: hostedAuth.apiKeyId,
         keyName: hostedAuth.apiKeyPrefix,
+        kind: 'system',
         hostedAuth,
       };
     } catch (error) {
@@ -684,6 +686,7 @@ export const handleSseMessage = async (req: Request, res: Response): Promise<voi
     requestContextService.setGroupContext(group);
     requestContextService.setUsernameContext(username);
     requestContextService.setHostedAuthContext(currentHostedAuth);
+    requestContextService.setKeyKindContext(bearerAuthResult.kind);
 
     await (transport as SSEServerTransport).handlePostMessage(req, res);
   });
@@ -934,6 +937,7 @@ export const handleMcpPostRequest = async (req: Request, res: Response): Promise
     requestContextService.setBearerKeyContext(bearerAuthResult.keyId, bearerAuthResult.keyName);
     requestContextService.setGroupContext(group);
     requestContextService.setUsernameContext(username);
+    requestContextService.setKeyKindContext(bearerAuthResult.kind);
     requestContextService.setHostedAuthContext(
       bearerAuthResult.hostedAuth || transportInfo?.hostedAuth,
     );

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -14,6 +14,21 @@ export const getUserByUsername = async (username: string): Promise<IUser | undef
   return user || undefined;
 };
 
+/** Usernames reserved for system use (case-insensitive). */
+const RESERVED_USERNAMES = ['system', 'admin', 'guest', 'root'];
+
+/**
+ * Check if a username is reserved for system use.
+ * Returns the reason string if reserved, or null if allowed.
+ */
+export const checkReservedUsername = (username: string): string | null => {
+  const lower = username.toLowerCase();
+  if (RESERVED_USERNAMES.includes(lower)) {
+    return `Username "${username}" is reserved and cannot be used`;
+  }
+  return null;
+};
+
 // Create a new user
 export const createNewUser = async (
   username: string,
@@ -22,6 +37,12 @@ export const createNewUser = async (
   email?: string,
 ): Promise<IUser | null> => {
   try {
+    const reservedError = checkReservedUsername(username);
+    if (reservedError) {
+      console.warn(`User creation blocked: ${reservedError}`);
+      return null;
+    }
+
     const userDao = getUserDao();
     const existingUser = await userDao.findByUsername(username);
     if (existingUser) {

--- a/tests/controllers/userController.test.ts
+++ b/tests/controllers/userController.test.ts
@@ -8,6 +8,7 @@ const mockUpdateUser = jest.fn();
 const mockDeleteUser = jest.fn();
 const mockGetUserCount = jest.fn();
 const mockGetAdminCount = jest.fn();
+const mockCheckReservedUsername = jest.fn(() => null);
 
 jest.mock('../../src/services/userService.js', () => ({
   getAllUsers: mockGetAllUsers,
@@ -17,6 +18,7 @@ jest.mock('../../src/services/userService.js', () => ({
   deleteUser: mockDeleteUser,
   getUserCount: mockGetUserCount,
   getAdminCount: mockGetAdminCount,
+  checkReservedUsername: mockCheckReservedUsername,
 }));
 
 jest.mock('../../src/utils/passwordValidation.js', () => ({


### PR DESCRIPTION
## Problem

When a system-level bearer key triggers a tool call via MCP/SSE, the activity record's `username` field is always `NULL`. This makes it impossible to filter or audit system-key-initiated tool calls.

Additionally, there is no protection against users registering reserved usernames like "system", "admin", etc.

## Root Cause

`resolveUserLevelKeyUser` in `sseService.ts` returns **no `user` field** for system keys (`key.kind !== "user"`). This causes `attachUserContextFromBearer` to bail out early, leaving `username` undefined throughout the entire pipeline — and `NULL` in the `activities` table.

The Dashboard API middleware (`auth.ts`) handled this correctly (`username: matchingBearerKey.owner || "system"`), but that path never generates activity records (tool calls flow through MCP/SSE routes).

## Fix

**Plan B — push `keyKind` through request context**, fixing the issue at the precise point where it matters (activity logging in `mcpService.ts`) without altering auth behavior or routing:

| File | Change |
|------|--------|
| `src/services/requestContextService.ts` | Add `keyKind?: BearerKeyKind` to `RequestContext` + setter/getter |
| `src/services/sseService.ts` | Add `kind` to `BearerAuthResult`; return `kind` in `resolveUserLevelKeyUser` and hosted auth; set via `setKeyKindContext()` in both SSE handlers |
| `src/services/mcpService.ts` | When `username` is undefined and `keyKind === "system"`, default to `"system"` |
| `src/services/userService.ts` | Export `checkReservedUsername()`; validate in `createNewUser()` |
| `src/controllers/userController.ts` | Call `checkReservedUsername()` before user creation with user-facing 400 |
| `tests/controllers/userController.test.ts` | Wire `checkReservedUsername` mock |

### Key design decisions

- **No routing change**: Unlike fixing `resolveUserLevelKeyUser` to return a synthetic user (which would switch system keys to `/system/messages` paths), this approach only affects activity logging
- **KeyKind in context is forward-looking**: Other consumers (`setKeyKindContext`) can use `keyKind` for audit, rate-limiting, or authorization decisions
- **Defense in depth for reserved usernames**: Validation in both the controller (user-facing error) and service layer (programmatic guard)

## Verification

```bash
# All affected test suites pass
npx jest tests/controllers/userController.test.ts   # 7 passed
npx jest tests/services/userService.test.ts          # 9 passed
npx jest tests/controllers/activityController.test.ts # 5 passed
npx jest tests/services/activityLoggingService.test.ts # 2 passed
npx jest tests/services/requestContextService.test.ts # 3 passed
npx jest src/middlewares/auth.test.ts                 # 15 passed
npx jest tests/services/sseService.test.ts           # 12 passed
```

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)