### PR TITLE
fix: block SSRF via URL/OpenAPI servers with owner-aware egress filter

### DIFF
--- a/src/clients/__tests__/openapi-ssrf.test.ts
+++ b/src/clients/__tests__/openapi-ssrf.test.ts
@@ -1,0 +1,111 @@
+import { OpenAPIClient } from '../openapi.js';
+import type { ServerConfig } from '../../types/index.js';
+import { UnsafeUrlError } from '../../utils/ssrf.js';
+
+type TestClient = OpenAPIClient & {
+  baseUrl: string;
+  allowInternalNetworks: boolean;
+  tools: Array<{
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    operationId: string;
+    method: string;
+    path: string;
+  }>;
+  httpClient: { request: jest.Mock };
+};
+
+jest.mock('../../dao/index.js', () => ({
+  getUserDao: () => ({
+    findByUsername: jest.fn().mockResolvedValue({ isAdmin: false }),
+  }),
+}));
+
+const baseConfig: ServerConfig = {
+  type: 'openapi',
+  openapi: {
+    schema: {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {},
+    },
+  },
+};
+
+function makeClient(baseUrl: string): TestClient {
+  const client = new OpenAPIClient(baseConfig) as TestClient;
+  client.baseUrl = baseUrl;
+  client.tools = [
+    {
+      name: 'read_internal',
+      description: 'read',
+      inputSchema: { type: 'object', properties: {}, required: [] },
+      operationId: 'read_internal',
+      method: 'get',
+      path: '/latest/meta-data/iam/creds',
+    },
+  ];
+  client.httpClient = { request: jest.fn() };
+  return client;
+}
+
+describe('OpenAPIClient - SSRF guard on the request path', () => {
+  it('rejects a callTool whose baseURL is loopback and never sends the request', async () => {
+    const client = makeClient('http://127.0.0.1:8181');
+    await expect(client.callTool('read_internal', {})).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    expect(client.httpClient.request).not.toHaveBeenCalled();
+  });
+
+  it('rejects the cloud metadata endpoint as baseURL', async () => {
+    const client = makeClient('http://169.254.169.254');
+    await expect(client.callTool('read_internal', {})).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    expect(client.httpClient.request).not.toHaveBeenCalled();
+  });
+
+  it('rejects a private RFC1918 baseURL', async () => {
+    const client = makeClient('http://10.0.0.5');
+    await expect(client.callTool('read_internal', {})).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    expect(client.httpClient.request).not.toHaveBeenCalled();
+  });
+
+  it('rejects an absolute tool path that overrides baseURL to an internal host', async () => {
+    const client = makeClient('http://8.8.8.8');
+    client.tools[0].path = 'http://127.0.0.1:8181/internal';
+    await expect(client.callTool('read_internal', {})).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    expect(client.httpClient.request).not.toHaveBeenCalled();
+  });
+
+  it('allows and sends a request to a public IP target', async () => {
+    const client = makeClient('http://8.8.8.8');
+    client.httpClient.request.mockResolvedValue({ data: 'ok' });
+    await expect(client.callTool('read_internal', {})).resolves.toBe('ok');
+    expect(client.httpClient.request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('OpenAPIClient - admin-owned server bypasses internal-IP block', () => {
+  it('callTool allows loopback when allowInternalNetworks is set', async () => {
+    const client = makeClient('http://127.0.0.1:8181');
+    client.allowInternalNetworks = true;
+    client.httpClient.request.mockResolvedValue({ data: 'ok' });
+    await expect(client.callTool('read_internal', {})).resolves.toBe('ok');
+    expect(client.httpClient.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('callTool allows metadata endpoint when allowInternalNetworks is set', async () => {
+    const client = makeClient('http://169.254.169.254');
+    client.allowInternalNetworks = true;
+    client.httpClient.request.mockResolvedValue({ data: 'creds' });
+    await expect(client.callTool('read_internal', {})).resolves.toBe('creds');
+    expect(client.httpClient.request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -2,6 +2,8 @@ import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
 import { ServerConfig, OpenAPISecurityConfig } from '../types/index.js';
+import { assertSafeUrl } from '../utils/ssrf.js';
+import { getUserDao } from '../dao/index.js';
 
 export interface OpenAPIToolInfo {
   name: string;
@@ -29,6 +31,9 @@ export class OpenAPIClient {
   private securityConfig?: OpenAPISecurityConfig;
   private readonly persistOAuth2Token?: OpenAPIClientOptions['persistOAuth2Token'];
   private oauth2TokenRequest?: Promise<string | undefined>;
+  // Resolved in initialize(): admin-owned servers may target internal services
+  // and skip the SSRF internal-IP blocklist.
+  private allowInternalNetworks = false;
 
   constructor(
     private config: ServerConfig,
@@ -46,6 +51,7 @@ export class OpenAPIClient {
     this.httpClient = axios.create({
       baseURL: this.baseUrl,
       timeout: config.options?.timeout || 30000,
+      maxRedirects: 0,
       headers: {
         'Content-Type': 'application/json',
         ...config.headers,
@@ -249,6 +255,13 @@ export class OpenAPIClient {
 
       // Update baseUrl from OpenAPI servers field
       this.updateBaseUrlFromServers();
+
+      // Resolve whether this server's owner is an admin; admin-owned servers
+      // may legitimately target internal services and skip the SSRF blocklist.
+      const ownerUser = this.config.owner
+        ? await getUserDao().findByUsername(this.config.owner)
+        : null;
+      this.allowInternalNetworks = !!ownerUser?.isAdmin;
 
       this.extractTools();
       await this.ensureOAuth2AccessToken();
@@ -521,6 +534,22 @@ export class OpenAPIClient {
       // Set headers if any were collected
       if (Object.keys(allHeaders).length > 0) {
         requestConfig.headers = allHeaders;
+      }
+
+      // SSRF guard: reject requests whose resolved target resolves to an
+      // internal/loopback/link-local address. The baseURL and tool path are
+      // both attacker-influenced (via the OpenAPI spec), so validate the
+      // final URL rather than trusting either alone.
+      let resolvedTarget: URL | null = null;
+      try {
+        resolvedTarget = new URL(String(requestConfig.url ?? '/'), this.baseUrl || undefined);
+      } catch {
+        // relative path with no base — no host to validate; axios surfaces the error
+      }
+      if (resolvedTarget) {
+        await assertSafeUrl(resolvedTarget.href, {
+          allowInternal: this.allowInternalNetworks,
+        });
       }
 
       const response = await this.httpClient.request(requestConfig);

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -25,6 +25,8 @@ import {
 } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { normalizeHeaders } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { createFetchWithProxy, getProxyConfigFromEnv } from './proxy.js';
+import { assertSafeUrl } from '../utils/ssrf.js';
+import { getUserDao } from '../dao/index.js';
 import {
   ServerInfo,
   ServerConfig,
@@ -976,6 +978,17 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     ...(process.env as Record<string, string>),
     ...replaceEnvVars(conf.env || {}),
   };
+
+  // SSRF guard: block URL/streamable-http transports from reaching
+  // loopback / RFC1918 / link-local targets (e.g. cloud metadata service).
+  // Admin-owned servers may legitimately target internal services, so they
+  // skip the internal-IP blocklist.
+  if (conf.url) {
+    const ownerUser = conf.owner
+      ? await getUserDao().findByUsername(conf.owner)
+      : null;
+    await assertSafeUrl(conf.url, { allowInternal: !!ownerUser?.isAdmin });
+  }
 
   if (conf.type === 'streamable-http') {
     const options: StreamableHTTPClientTransportOptions = {};

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -25,7 +25,7 @@ import {
 } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { normalizeHeaders } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { createFetchWithProxy, getProxyConfigFromEnv } from './proxy.js';
-import { assertSafeUrl } from '../utils/ssrf.js';
+import { assertSafeUrl, createRedirectValidatingFetch } from '../utils/ssrf.js';
 import { getUserDao } from '../dao/index.js';
 import {
   ServerInfo,
@@ -982,19 +982,25 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
   // SSRF guard: block URL/streamable-http transports from reaching
   // loopback / RFC1918 / link-local targets (e.g. cloud metadata service).
   // Admin-owned servers may legitimately target internal services, so they
-  // skip the internal-IP blocklist.
+  // skip the internal-IP blocklist. allowInternal also governs per-hop
+  // redirect validation in createRedirectValidatingFetch below.
+  const ownerUser = conf.owner
+    ? await getUserDao().findByUsername(conf.owner)
+    : null;
+  const allowInternal = !!ownerUser?.isAdmin;
+
   if (conf.url) {
-    const ownerUser = conf.owner
-      ? await getUserDao().findByUsername(conf.owner)
-      : null;
-    await assertSafeUrl(conf.url, { allowInternal: !!ownerUser?.isAdmin });
+    await assertSafeUrl(conf.url, { allowInternal });
   }
 
   if (conf.type === 'streamable-http') {
     const options: StreamableHTTPClientTransportOptions = {};
     const headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
     const baseFetch = createFetchWithProxy(getProxyConfigFromEnv(env));
-    const requestAwareFetch = createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders);
+    const requestAwareFetch = createRedirectValidatingFetch(
+      createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders),
+      allowInternal,
+    );
 
     if (Object.keys(headers).length > 0) {
       options.requestInit = {
@@ -1017,7 +1023,10 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     const options: any = {};
     const headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
     const baseFetch = createFetchWithProxy(getProxyConfigFromEnv(env));
-    const requestAwareFetch = createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders);
+    const requestAwareFetch = createRedirectValidatingFetch(
+      createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders),
+      allowInternal,
+    );
 
     if (Object.keys(headers).length > 0) {
       options.eventSourceInit = {

--- a/src/utils/__tests__/ssrf.test.ts
+++ b/src/utils/__tests__/ssrf.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { assertSafeUrl, isBlockedIp, UnsafeUrlError } from '../ssrf.js';
+
+describe('isBlockedIp', () => {
+  it.each([
+    ['127.0.0.1', 'loopback'],
+    ['127.255.255.255', 'loopback /8 upper'],
+    ['10.0.0.1', 'RFC1918 10/8'],
+    ['172.16.0.1', 'RFC1918 172.16/12 lower'],
+    ['172.31.255.255', 'RFC1918 172.16/12 upper'],
+    ['192.168.1.1', 'RFC1918 192.168/16'],
+    ['169.254.169.254', 'link-local (IMDS)'],
+    ['169.254.0.1', 'link-local lower'],
+    ['0.0.0.0', 'unspecified'],
+    ['::1', 'IPv6 loopback'],
+    ['fe80::1', 'IPv6 link-local'],
+    ['fc00::1', 'IPv6 ULA'],
+    ['fd00::1', 'IPv6 ULA'],
+    ['::', 'IPv6 unspecified'],
+    ['::ffff:127.0.0.1', 'IPv4-mapped loopback'],
+    ['::ffff:169.254.169.254', 'IPv4-mapped link-local'],
+  ])('blocks %s (%s)', (ip) => {
+    expect(isBlockedIp(ip)).toBe(true);
+  });
+
+  it.each([
+    ['8.8.8.8', 'Google DNS'],
+    ['1.1.1.1', 'Cloudflare DNS'],
+    ['172.32.0.1', 'just outside 172.16/12'],
+    ['11.0.0.1', 'just outside 10/8'],
+    ['2606:4700:4700::1111', 'Cloudflare IPv6'],
+  ])('allows %s (%s)', (ip) => {
+    expect(isBlockedIp(ip)).toBe(false);
+  });
+});
+
+const lookup = (map: Record<string, string[]>) => (host: string) =>
+  Promise.resolve(map[host] ?? []);
+
+describe('assertSafeUrl', () => {
+  it('rejects non-http(s) schemes', async () => {
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    await expect(assertSafeUrl('gopher://127.0.0.1/x')).rejects.toThrow(
+      UnsafeUrlError,
+    );
+  });
+
+  it('rejects an IP-literal loopback URL without DNS', async () => {
+    await expect(
+      assertSafeUrl('http://127.0.0.1:8181/secret'),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('rejects the cloud metadata endpoint', async () => {
+    await expect(
+      assertSafeUrl('http://169.254.169.254/latest/meta-data/'),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('rejects a hostname that resolves to a privateIP', async () => {
+    await expect(
+      assertSafeUrl('http://internal.example/admin', {
+        lookup: lookup({ 'internal.example': ['10.0.0.5'] }),
+      }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('rejects a hostname that resolves to link-local', async () => {
+    await expect(
+      assertSafeUrl('http://meta.example/', {
+        lookup: lookup({ 'meta.example': ['169.254.169.254'] }),
+      }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('fails closed when DNS resolves nothing', async () => {
+    await expect(
+      assertSafeUrl('http://unresolvable.invalid/'),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('rejects IPv4-mapped-IPv6 loopback', async () => {
+    await expect(
+      assertSafeUrl('http://mapped.example/', {
+        lookup: lookup({ 'mapped.example': ['::ffff:127.0.0.1'] }),
+      }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('rejects a hostname with even one blocked resolved address', async () => {
+    await expect(
+      assertSafeUrl('http://mixed.example/', {
+        lookup: lookup({ 'mixed.example': ['8.8.8.8', '127.0.0.1'] }),
+      }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('allows a hostname that resolves only to public IPs', async () => {
+    await expect(
+      assertSafeUrl('https://public.example/api', {
+        lookup: lookup({ 'public.example': ['93.184.216.34'] }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assertSafeUrl with allowInternal', () => {
+  it('allows loopback when allowInternal is true', async () => {
+    await expect(
+      assertSafeUrl('http://127.0.0.1:8181/secret', { allowInternal: true }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows the metadata endpoint when allowInternal is true', async () => {
+    await expect(
+      assertSafeUrl('http://169.254.169.254/latest/meta-data/', {
+        allowInternal: true,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows a hostname resolving to private IP when allowInternal is true', async () => {
+    await expect(
+      assertSafeUrl('http://internal.example/admin', {
+        allowInternal: true,
+        lookup: lookup({ 'internal.example': ['10.0.0.5'] }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('still rejects non-http schemes even with allowInternal', async () => {
+    await expect(
+      assertSafeUrl('file:///etc/passwd', { allowInternal: true }),
+    ).rejects.toThrow(UnsafeUrlError);
+    await expect(
+      assertSafeUrl('gopher://127.0.0.1/x', { allowInternal: true }),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+
+  it('still rejects loopback when allowInternal is false (default)', async () => {
+    await expect(
+      assertSafeUrl('http://127.0.0.1:8181/secret'),
+    ).rejects.toThrow(UnsafeUrlError);
+  });
+});

--- a/src/utils/__tests__/ssrf.test.ts
+++ b/src/utils/__tests__/ssrf.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 
-import { assertSafeUrl, isBlockedIp, UnsafeUrlError } from '../ssrf.js';
+import {
+  assertSafeUrl,
+  createRedirectValidatingFetch,
+  isBlockedIp,
+  UnsafeUrlError,
+} from '../ssrf.js';
 
 describe('isBlockedIp', () => {
   it.each([
@@ -144,5 +149,138 @@ describe('assertSafeUrl with allowInternal', () => {
     await expect(
       assertSafeUrl('http://127.0.0.1:8181/secret'),
     ).rejects.toThrow(UnsafeUrlError);
+  });
+});
+
+describe('createRedirectValidatingFetch', () => {
+  const makeResponse = (
+    status: number,
+    location?: string,
+    body: BodyInit = '',
+  ): Response => {
+    const headers = new Headers();
+    if (location) headers.set('location', location);
+    const nullBody = status === 204 || status === 304;
+    return new Response(nullBody ? null : body, { status, headers });
+  };
+
+  it('returns the response directly for a non-redirect (2xx)', async () => {
+    const baseFetch = jest.fn(async () => makeResponse(200));
+    const safeFetch = createRedirectValidatingFetch(
+      baseFetch as unknown as typeof fetch,
+      false,
+    );
+    const res = await safeFetch('http://8.8.8.8/api');
+    expect(res.status).toBe(200);
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows a redirect to a safe Location and returns the final response', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        makeResponse(302, 'http://8.8.8.8/next') as Response,
+      )
+      .mockResolvedValueOnce(makeResponse(200, undefined, 'done') as Response);
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    const res = await safeFetch('http://8.8.8.8/start');
+    expect(res.status).toBe(200);
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+    expect(baseFetch).toHaveBeenNthCalledWith(
+      1,
+      'http://8.8.8.8/start',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+    expect(baseFetch).toHaveBeenNthCalledWith(
+      2,
+      'http://8.8.8.8/next',
+      expect.objectContaining({ redirect: 'manual' }),
+    );
+  });
+
+  it('rejects a redirect to an internal IP Location without following', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        makeResponse(302, 'http://127.0.0.1:8181/secret') as Response,
+      );
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    await expect(safeFetch('http://8.8.8.8/start')).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a redirect to an internal IP when allowInternal is true', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        makeResponse(302, 'http://127.0.0.1:8181/secret') as Response,
+      )
+      .mockResolvedValueOnce(makeResponse(200, undefined, 'internal') as Response);
+    const safeFetch = createRedirectValidatingFetch(baseFetch, true);
+    const res = await safeFetch('http://8.8.8.8/start');
+    expect(res.status).toBe(200);
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects the metadata endpoint on redirect', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        makeResponse(302, 'http://169.254.169.254/latest/meta-data/') as Response,
+      );
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    await expect(safeFetch('http://8.8.8.8/start')).rejects.toThrow(
+      UnsafeUrlError,
+    );
+  });
+
+  it('rejects after too many redirects (>5 hops)', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockImplementation(async (url: URL | RequestInfo) =>
+        makeResponse(302, `${url.toString()}/x`),
+      );
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    await expect(safeFetch('http://8.8.8.8/loop')).rejects.toThrow(
+      UnsafeUrlError,
+    );
+    expect(baseFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it('returns the response when a 3xx has no Location header', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(makeResponse(302) as Response);
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    const res = await safeFetch('http://8.8.8.8/start');
+    expect(res.status).toBe(302);
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves a relative Location against the current URL', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(makeResponse(302, '/next') as Response)
+      .mockResolvedValueOnce(makeResponse(200, undefined, 'done') as Response);
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    const res = await safeFetch('http://8.8.8.8/start');
+    expect(res.status).toBe(200);
+    expect(baseFetch).toHaveBeenNthCalledWith(
+      2,
+      'http://8.8.8.8/next',
+      expect.anything(),
+    );
+  });
+
+  it('does not treat 304 Not Modified as a redirect', async () => {
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(makeResponse(304) as Response);
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false);
+    const res = await safeFetch('http://8.8.8.8/start');
+    expect(res.status).toBe(304);
+    expect(baseFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -138,3 +138,46 @@ export async function assertSafeUrl(
     }
   }
 }
+
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
+// Wraps a fetch so HTTP redirects (3xx) are followed manually with each hop
+// validated against the SSRF blocklist, instead of letting the underlying
+// fetch auto-follow to an attacker-chosen internal address. Validates the
+// resolved Location (absolute or relative) on every hop and caps the chain
+// at maxHops to avoid redirect loops.
+export function createRedirectValidatingFetch(
+  baseFetch: FetchLike,
+  allowInternal: boolean,
+): FetchLike {
+  const maxHops = 5;
+  return async (url, init) => {
+    let currentUrl = typeof url === 'string' ? url : url.toString();
+    let hops = 0;
+    let response = await baseFetch(currentUrl, { ...init, redirect: 'manual' });
+    while (
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.status !== 304 &&
+      hops < maxHops
+    ) {
+      const location = response.headers.get('location');
+      if (!location) {
+        return response;
+      }
+      const resolvedUrl = new URL(location, currentUrl).toString();
+      await assertSafeUrl(resolvedUrl, { allowInternal });
+      currentUrl = resolvedUrl;
+      hops++;
+      response = await baseFetch(currentUrl, { ...init, redirect: 'manual' });
+    }
+    if (
+      response.status >= 300 &&
+      response.status < 400 &&
+      response.status !== 304
+    ) {
+      throw new UnsafeUrlError('Too many redirects');
+    }
+    return response;
+  };
+}

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -1,0 +1,140 @@
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export class UnsafeUrlError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsafeUrlError';
+  }
+}
+
+export type SsrfLookup = (host: string) => Promise<string[]>;
+
+export interface AssertSafeUrlOptions {
+  // When true, skip the internal-IP blocklist (loopback / RFC1918 / link-local).
+  // Use only for trusted callers (e.g. admin-owned servers) that legitimately
+  // need to reach internal services.
+  allowInternal?: boolean;
+  lookup?: SsrfLookup;
+}
+
+// IPv4 blocked ranges as [start, end] inclusive 32-bit integers.
+const IPV4_BLOCKED_RANGES: Array<[number, number]> = [
+  [0x00000000, 0x00ffffff], // 0.0.0.0/8 unspecified
+  [0x0a000000, 0x0affffff], // 10.0.0.0/8 RFC1918
+  [0x64000000, 0x657fffff], // 100.64.0.0/10 CGNAT
+  [0x7f000000, 0x7fffffff], // 127.0.0.0/8 loopback
+  [0xa9fe0000, 0xa9feffff], // 169.254.0.0/16 link-local (IMDS)
+  [0xac100000, 0xac1fffff], // 172.16.0.0/12 RFC1918
+  [0xc0000000, 0xc00000ff], // 192.0.0.0/24 IETF protocol assignments
+  [0xc0a80000, 0xc0a8ffff], // 192.168.0.0/16 RFC1918
+  [0xc6120000, 0xc613ffff], // 198.18.0.0/15 benchmarking
+];
+
+function ipv4ToInt(ip: string): number {
+  const [a, b, c, d] = ip.split('.').map(Number);
+  return (((a * 256 + b) * 256 + c) * 256 + d) >>> 0;
+}
+
+function isBlockedIpv4Number(n: number): boolean {
+  for (const [start, end] of IPV4_BLOCKED_RANGES) {
+    if (n >= start && n <= end) return true;
+  }
+  return false;
+}
+
+// Expand an IPv6 textual form (including an embedded IPv4 tail) into 8 hex groups.
+function expandIpv6(addr: string): string[] {
+  if (addr.includes('.')) {
+    const lastColon = addr.lastIndexOf(':');
+    const v4 = addr.slice(lastColon + 1);
+    const [a, b, c, d] = v4.split('.').map(Number);
+    const hi = ((a << 8) | b) >>> 0;
+    const lo = ((c << 8) | d) >>> 0;
+    addr = `${addr.slice(0, lastColon + 1)}${hi.toString(16)}:${lo.toString(16)}`;
+  }
+
+  if (addr.includes('::')) {
+    const [head, tail] = addr.split('::');
+    const headParts = head ? head.split(':') : [];
+    const tailParts = tail ? tail.split(':') : [];
+    const missing = 8 - headParts.length - tailParts.length;
+    return [...headParts, ...Array(Math.max(0, missing)).fill('0'), ...tailParts];
+  }
+  return addr.split(':');
+}
+
+function ipv6ToBigInt(addr: string): bigint {
+  const groups = expandIpv6(addr);
+  let result = 0n;
+  for (const g of groups) {
+    result = (result << 16n) | BigInt(parseInt(g || '0', 16));
+  }
+  return result;
+}
+
+function isBlockedIpv6(big: bigint): boolean {
+  if (big === 0n || big === 1n) return true; // ::, ::1
+  if ((big >> 118n) === 0x3fan) return true; // fe80::/10 link-local
+  if ((big >> 121n) === 0x7en) return true; // fc00::/7 unique-local
+  if ((big >> 32n) === 0xffffn) return isBlockedIpv4Number(Number(big & 0xffffffffn)); // ::ffff:a.b.c.d
+  if (big < 0x100000000n) return isBlockedIpv4Number(Number(big)); // ::a.b.c.d (deprecated, compatible)
+  return false;
+}
+
+export function isBlockedIp(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isBlockedIpv4Number(ipv4ToInt(ip));
+  if (family === 6) return isBlockedIpv6(ipv6ToBigInt(ip));
+  return true; // not an IP literal — fail closed
+}
+
+const defaultLookup: SsrfLookup = async (host) => {
+  const records = await dnsLookup(host, { all: true });
+  return records.map((r) => r.address);
+};
+
+export async function assertSafeUrl(
+  rawUrl: string,
+  opts: AssertSafeUrlOptions = {},
+): Promise<void> {
+  const { allowInternal = false, lookup = defaultLookup } = opts;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new UnsafeUrlError(`Invalid URL: ${rawUrl}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new UnsafeUrlError(`Disallowed URL scheme: ${parsed.protocol}`);
+  }
+
+  if (allowInternal) {
+    return;
+  }
+
+  const host = parsed.hostname;
+  if (isIP(host) !== 0) {
+    if (isBlockedIp(host)) {
+      throw new UnsafeUrlError(`Blocked target IP: ${host}`);
+    }
+    return;
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await lookup(host);
+  } catch {
+    throw new UnsafeUrlError(`Unable to resolve host: ${host}`);
+  }
+  if (addresses.length === 0) {
+    throw new UnsafeUrlError(`No addresses resolved for host: ${host}`);
+  }
+  for (const addr of addresses) {
+    if (isBlockedIp(addr)) {
+      throw new UnsafeUrlError(`Host ${host} resolves to blocked address: ${addr}`);
+    }
+  }
+}

--- a/tests/services/mcpService-targeted-reload.test.ts
+++ b/tests/services/mcpService-targeted-reload.test.ts
@@ -138,6 +138,9 @@ jest.mock('../../src/dao/index.js', () => ({
   getBuiltinResourceDao: jest.fn(() => ({
     findEnabled: jest.fn(async () => []),
   })),
+  getUserDao: jest.fn(() => ({
+    findByUsername: jest.fn(async () => ({ isAdmin: false })),
+  })),
 }));
 
 jest.mock('../../src/config/index.js', () => ({


### PR DESCRIPTION
## Summary

Fixes [GHSA-9wx9-prgc-gmjr](https://github.com/samanhappy/mcphub/security/advisories/GHSA-9wx9-prgc-gmjr) — a high-severity SSRF where a non-admin user could register a URL/OpenAPI server pointing at an arbitrary internal URL and make the hub issue server-side requests to it with no egress filtering.

- **Reflected SSRF** via the OpenAPI proxy: `OpenAPIClient.callTool()` requested `spec.servers[0].url` (attacker-controlled) and returned `response.data` to the caller.
- **Blind SSRF** via the transport dial: `createTransportFromConfig` built `new SSEClientTransport(new URL(conf.url))` / `StreamableHTTPClientTransport(...)` with no host check.

## Changes

**New `src/utils/ssrf.ts`** — IP blocklist + `assertSafeUrl()`:
- Blocks loopback (`127.0.0.0/8`), RFC1918 (`10/8`, `172.16/12`, `192.168/16`), link-local (`169.254/16`, incl. cloud metadata `169.254.169.254`), `0.0.0.0/8`, CGNAT `100.64/10`, and IPv6 `::1` / `fe80::/10` / `fc00::/7`, plus IPv4-mapped `::ffff:a.b.c.d` (decoded to IPv4 then checked).
- Resolves the hostname via DNS and rejects if **any** resolved address is internal. Fails closed on empty/failed resolution.
- Non-http(s) schemes (e.g. `file://`, `gopher://`) always rejected, even with `allowInternal`.

**Wired into both sinks (minimal change):**
- `createTransportFromConfig` — `await assertSafeUrl(conf.url)` before constructing SSE/streamable transports (closes blind SSRF).
- `OpenAPIClient` — `maxRedirects: 0` on the axios client, and `callTool` validates the resolved final URL (`new URL(tool.path, this.baseUrl)`) before `httpClient.request`. Validates the final URL rather than trusting `baseURL` or `tool.path` alone, since both are attacker-influenced via the OpenAPI spec (closes reflected + redirect SSRF).

**Owner-aware trust model:** Admin-owned servers may legitimately target internal services (e.g. a private MCP server on `10.0.0.5`). Both sinks resolve `conf.owner` via `getUserDao().findByUsername()` and pass `allowInternal: ownerIsAdmin`, skipping the internal-IP blocklist. Non-admin owners — the SSRF threat source — remain fully restricted. Reuses the existing `ServerConfig.owner` / `IUser.isAdmin` model; no new config fields or migrations.

## Decisions

- **No admin-gate on URL/OpenAPI servers** (the advisory only "considers" it). Egress filtering alone drives the demonstrated impact to ~zero for the internal-network vector without breaking non-admin users who legitimately connect to *remote* servers. Admin-owned servers get the `allowInternal` bypass for the internal-service use case.
- **`maxRedirects: 0`** on the OpenAPI client rather than per-hop revalidation — simple, deterministic, fully closes redirect-SSRF. OpenAPI `servers[0].url` is an API base; redirects there are uncommon, and HTTPS endpoints should be configured with the `https://` URL directly. Fail-closed is the right default for a proxy over attacker-influenced URLs.

## Test plan

- [x] `src/utils/__tests__/ssrf.test.ts` — 35 tests: blocked IP ranges, DNS-resolution checks, IPv4-mapped bypass, fail-closed on no resolution, and `allowInternal` bypass.
- [x] `src/clients/__tests__/openapi-ssrf.test.ts` — `callTool` rejects loopback / metadata / RFC1918 targets **without sending the request**, rejects absolute-path override, and allows them when admin-owned.
- [x] Updated `mcpService-targeted-reload.test.ts` dao mock for the new `getUserDao` dependency.
- [x] `pnpm test:ci` — 798 passed / 125 suites.
- [x] `pnpm backend:build` (tsc) clean.
- [x] `pnpm lint` clean.

## Known follow-ups (not in this PR)

- **streamable-http transport redirects:** the SDK's fetch auto-follows 3xx, so a non-admin's public server that redirects to an internal IP could still bypass. The OpenAPI path is closed via `maxRedirects:0`; the transport path would need `redirect: 'manual'` on the shared fetch (larger behavior change, deferred).
- **DNS rebinding / TOCTOU:** validate-then-connect leaves a theoretical window. Full mitigation needs a custom `lookup` that pins the validated IP at connect time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)