### PR TITLE
fix: filter servers across all pages, not just the current page

### DIFF
--- a/frontend/src/pages/ServersPage.tsx
+++ b/frontend/src/pages/ServersPage.tsx
@@ -11,7 +11,7 @@ import JSONImportForm from '@/components/JSONImportForm';
 import Pagination from '@/components/ui/Pagination';
 import { useServerData } from '@/hooks/useServerData';
 import { useCostData } from '@/hooks/useCostData';
-import { filterServers, getServerFilterCounts, type ServerFilter } from '@/utils/serverFilters';
+import { selectServerPage, getServerFilterCounts, type ServerFilter } from '@/utils/serverFilters';
 
 const ServersPage: React.FC = () => {
   const { t } = useTranslation();
@@ -22,7 +22,6 @@ const ServersPage: React.FC = () => {
     error,
     setError,
     isLoading,
-    pagination,
     currentPage,
     serversPerPage,
     setCurrentPage,
@@ -53,7 +52,12 @@ const ServersPage: React.FC = () => {
 
   const counts = useMemo(() => getServerFilterCounts(allServers), [allServers]);
 
-  const filteredServers = useMemo(() => filterServers(servers, filter, search), [servers, filter, search]);
+  // Filter against the full list and paginate the filtered result client-side,
+  // so status filters reach servers that live on other pagination pages.
+  const { servers: visibleServers, pagination: clientPagination } = useMemo(
+    () => selectServerPage(allServers, filter, search, currentPage, serversPerPage),
+    [allServers, filter, search, currentPage, serversPerPage],
+  );
 
   const handleEditClick = async (server: Server) => {
     const fullServerData = await handleServerEdit(server);
@@ -184,7 +188,7 @@ const ServersPage: React.FC = () => {
         </div>
 
         <div className="ml-auto hub-mono text-[12px]" style={{ color: 'var(--hub-ink-3)' }}>
-          {filteredServers.length}/{servers.length}
+          {clientPagination.total}/{allServers.length}
         </div>
       </div>
 
@@ -196,14 +200,14 @@ const ServersPage: React.FC = () => {
             <p style={{ color: 'var(--hub-ink-3)' }}>{t('app.loading')}</p>
           </div>
         </div>
-      ) : filteredServers.length === 0 ? (
+      ) : visibleServers.length === 0 ? (
         <div className="hub-card p-10 text-center" style={{ color: 'var(--hub-ink-3)' }}>
           <p>{servers.length === 0 ? t('app.noServers') : t('market.noServers')}</p>
         </div>
       ) : (
         <>
           <div className="flex flex-col">
-            {filteredServers.map((server) => (
+            {visibleServers.map((server) => (
               <ServerCard
                 key={server.name}
                 server={server}
@@ -221,19 +225,17 @@ const ServersPage: React.FC = () => {
 
           <div className="flex items-center mt-4 text-[12px]" style={{ color: 'var(--hub-ink-3)' }}>
             <div className="flex-[2]">
-              {pagination
-                ? t('common.showing', {
-                    start: (pagination.page - 1) * pagination.limit + 1,
-                    end: Math.min(pagination.page * pagination.limit, pagination.total),
-                    total: pagination.total,
-                  })
-                : t('common.showing', { start: 1, end: servers.length, total: servers.length })}
+              {t('common.showing', {
+                start: (clientPagination.page - 1) * clientPagination.limit + 1,
+                end: Math.min(clientPagination.page * clientPagination.limit, clientPagination.total),
+                total: clientPagination.total,
+              })}
             </div>
             <div className="flex-[4] flex justify-center">
-              {pagination && pagination.totalPages > 1 && (
+              {clientPagination.totalPages > 1 && (
                 <Pagination
-                  currentPage={currentPage}
-                  totalPages={pagination.totalPages}
+                  currentPage={clientPagination.page}
+                  totalPages={clientPagination.totalPages}
                   onPageChange={setCurrentPage}
                   disabled={isLoading}
                 />

--- a/frontend/src/pages/ServersPage.tsx
+++ b/frontend/src/pages/ServersPage.tsx
@@ -59,6 +59,13 @@ const ServersPage: React.FC = () => {
     [allServers, filter, search, currentPage, serversPerPage],
   );
 
+  // Sync currentPage when client-side pagination clamps it (filter/search narrows results).
+  useEffect(() => {
+    if (clientPagination.page !== currentPage) {
+      setCurrentPage(clientPagination.page);
+    }
+  }, [clientPagination.page, currentPage, setCurrentPage]);
+
   const handleEditClick = async (server: Server) => {
     const fullServerData = await handleServerEdit(server);
     if (fullServerData) setEditingServer(fullServerData);

--- a/frontend/src/utils/serverFilters.ts
+++ b/frontend/src/utils/serverFilters.ts
@@ -2,6 +2,15 @@ import { Server } from '@/types';
 
 export type ServerFilter = 'all' | 'online' | 'issues' | 'disabled';
 
+export interface ServerPageInfo {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+}
+
 export const getServerFilterCounts = (servers: Server[]) => ({
   all: servers.length,
   online: servers.filter((server) => server.status === 'connected').length,
@@ -32,4 +41,33 @@ export const filterServers = (
 
     return haystack.includes(query);
   });
+};
+
+// Filters the full server list then paginates the filtered result client-side.
+// Filtering must run against the complete list, not a single pagination page, so
+// that servers on other pages remain reachable when a status filter is active.
+export const selectServerPage = (
+  allServers: Server[],
+  filter: ServerFilter,
+  search: string,
+  page: number,
+  limit: number,
+): { servers: Server[]; pagination: ServerPageInfo } => {
+  const filtered = filterServers(allServers, filter, search);
+  const total = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const safePage = Math.min(Math.max(1, page), totalPages);
+  const start = (safePage - 1) * limit;
+
+  return {
+    servers: filtered.slice(start, start + limit),
+    pagination: {
+      page: safePage,
+      limit,
+      total,
+      totalPages,
+      hasNextPage: safePage < totalPages,
+      hasPrevPage: safePage > 1,
+    },
+  };
 };

--- a/tests/frontend/serverFilters.test.ts
+++ b/tests/frontend/serverFilters.test.ts
@@ -1,4 +1,4 @@
-import { filterServers, getServerFilterCounts } from '../../frontend/src/utils/serverFilters';
+import { filterServers, getServerFilterCounts, selectServerPage } from '../../frontend/src/utils/serverFilters';
 
 describe('serverFilters', () => {
   const servers = [
@@ -52,5 +52,70 @@ describe('serverFilters', () => {
     expect(filterServers(servers, 'disabled', 'archive').map((server) => server.name)).toEqual([
       'disabled-offline-server',
     ]);
+  });
+});
+
+describe('selectServerPage', () => {
+  // Build a list where disabled servers do NOT land on page 1 (limit 5).
+  const online = (name: string) => ({ name, status: 'connected' as const, enabled: true, tools: [] });
+  const disabled = (name: string) => ({ name, status: 'disconnected' as const, enabled: false, tools: [] });
+
+  const allServers = [
+    online('online-1'),
+    online('online-2'),
+    online('online-3'),
+    online('online-4'),
+    online('online-5'), // page 1 (limit 5) is entirely online
+    disabled('disabled-6'), // lives on page 2 — never visible to a page-1-only filter
+    disabled('disabled-7'),
+  ];
+
+  it('filters against the full list, not just the current page', () => {
+    // Regression for #939: the Disabled filter used to narrow only the current
+    // pagination page, so disabled servers on other pages were hidden even
+    // though the badge counted them.
+    const { servers, pagination } = selectServerPage(allServers, 'disabled', '', 1, 5);
+    expect(servers.map((server) => server.name)).toEqual(['disabled-6', 'disabled-7']);
+    expect(pagination.total).toBe(2);
+    expect(pagination.totalPages).toBe(1);
+    expect(pagination.page).toBe(1);
+  });
+
+  it('paginates the filtered result client-side', () => {
+    const page1 = selectServerPage(allServers, 'all', '', 1, 5);
+    expect(page1.servers.map((server) => server.name)).toEqual([
+      'online-1',
+      'online-2',
+      'online-3',
+      'online-4',
+      'online-5',
+    ]);
+    expect(page1.pagination).toEqual({
+      page: 1,
+      limit: 5,
+      total: 7,
+      totalPages: 2,
+      hasNextPage: true,
+      hasPrevPage: false,
+    });
+
+    const page2 = selectServerPage(allServers, 'all', '', 2, 5);
+    expect(page2.servers.map((server) => server.name)).toEqual(['disabled-6', 'disabled-7']);
+    expect(page2.pagination.hasNextPage).toBe(false);
+    expect(page2.pagination.hasPrevPage).toBe(true);
+  });
+
+  it('clamps the page when the filter reduces the result below the current page', () => {
+    // Sitting on page 2 of 'all' (7 servers), switch to 'disabled' (2 results, 1 page).
+    const { servers, pagination } = selectServerPage(allServers, 'disabled', '', 2, 5);
+    expect(pagination.page).toBe(1);
+    expect(servers.map((server) => server.name)).toEqual(['disabled-6', 'disabled-7']);
+  });
+
+  it('returns an empty page when no servers match the filter', () => {
+    const { servers, pagination } = selectServerPage(allServers, 'disabled', 'nonexistent', 1, 5);
+    expect(servers).toEqual([]);
+    expect(pagination.total).toBe(0);
+    expect(pagination.totalPages).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #939
- The Disabled / Online / Issues filter buttons on the Servers page narrowed only the **current pagination page**, while the count badges were computed from the **full list**. Servers that lived on other pages were unreachable when a status filter was active, even though the badge reported them.
- Added a pure helper `selectServerPage(allServers, filter, search, page, limit)` that filters the full list and then paginates the filtered result client-side (with page clamping). `ServersPage` now renders and paginates against this output instead of the single backend page, so filtering and pagination stay consistent. Backend `getAllServers` already returns the full list as `allServers`, so no backend change was needed.

## Behavior change

- `visibleServers` (the rendered cards) is now the filtered+paginated slice of `allServers`, not the filtered slice of the current `servers` page.
- The footer "showing x/y" and `Pagination` control are driven by the client-computed pagination (`clientPagination`), not the backend `pagination` object.
- Switching to a filter whose result fits fewer pages clamps `currentPage` back to the last valid page.

## Test plan

- [x] Added 4 regression tests in `tests/frontend/serverFilters.test.ts` covering: filters-against-full-list (the #939 regression), client-side pagination of the filtered result, page clamping when the filter shrinks the result below the current page, and empty-match page.
- [x] Red → Green: new tests fail without `selectServerPage`, pass with it.
- [x] `npx jest tests/frontend/serverFilters.test.ts` — 8/8 pass; `npx jest tests/frontend/` — 35/35 pass.
- [x] `pnpm test:ci` — 811/811 pass.
- [x] `pnpm lint` clean; `pnpm build` (backend tsc + frontend vite) succeeds.
- [x] Smoke-checked the bundled `selectServerPage` in the dev server: a disabled server on page 2 is now returned by the Disabled filter, page clamping works, no console errors on `/servers`.
- Note: a live multi-page UI repro needs >5 configured servers (default config has 4, which would mutate user state), so the regression is covered at the unit level against the exact real-list shape rather than via a seeded live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)