### PR TITLE
fix: scope server toggle to target instead of re-initializing the fleet

### DIFF
--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -1011,7 +1011,12 @@ export const toggleServer = async (req: Request, res: Response): Promise<void> =
 
     const result = await toggleServerStatus(existingServer.name, enabled);
     if (result.success) {
-      notifyToolChanged();
+      // toggleServerStatus already scopes its work to this server (disabling
+      // closes it; enabling runs a targeted reconnect). Only broadcast the
+      // tool-list change here — calling the unscoped notifyToolChanged() would
+      // re-initialize every non-connected server in the fleet, spiking CPU and
+      // orphaning stdio child processes. See #938 (and the #921/#926 guarantee).
+      broadcastToolListChanged();
       res.json({
         success: true,
         message: result.message || `Server ${enabled ? 'enabled' : 'disabled'} successfully`,

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -94,6 +94,7 @@ import {
   resetPromptDescription,
   resetResourceDescription,
   resetToolDescription,
+  toggleServer,
   updateServer,
   updateSystemConfig,
 } from '../../src/controllers/serverController.js';
@@ -956,6 +957,60 @@ describe('serverController - getAllServers', () => {
           totalPages: 2,
         }),
       }),
+    );
+  });
+});
+
+describe('serverController - toggleServer (issue #938)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServerDao.findById.mockResolvedValue({
+      name: 'target',
+      owner: 'admin',
+    });
+    mockToggleServerStatus.mockResolvedValue({ success: true });
+  });
+
+  const makeReqRes = (enabled: boolean) => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'target' },
+      body: { enabled },
+      user: { username: 'admin', isAdmin: true },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+    return { req, res, json, status };
+  };
+
+  // toggleServerStatus already scopes work to the target server (disable closes
+  // it; enable runs a targeted initializeClientsFromSettings(false, name)). The
+  // controller must NOT additionally call the unscoped notifyToolChanged(),
+  // which would re-initialize every non-connected server in the fleet and spike
+  // CPU. It should only broadcast the tool-list change.
+  it('enabling a server broadcasts only and does not trigger a fleet-wide re-init', async () => {
+    const { req, res, json } = makeReqRes(true);
+
+    await toggleServer(req, res);
+
+    expect(mockToggleServerStatus).toHaveBeenCalledWith('target', true);
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+    expect(mockBroadcastToolListChanged).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true }),
+    );
+  });
+
+  it('disabling a server broadcasts only and does not trigger a fleet-wide re-init', async () => {
+    const { req, res, json } = makeReqRes(false);
+
+    await toggleServer(req, res);
+
+    expect(mockToggleServerStatus).toHaveBeenCalledWith('target', false);
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+    expect(mockBroadcastToolListChanged).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true }),
     );
   });
 });


### PR DESCRIPTION
## Summary

Toggling a single server via `POST /servers/:name/toggle` re-initialized the **entire** server fleet, spiking CPU and orphaning stdio child processes. This fix scopes the toggle to the target server only.

- `toggleServer` called the unscoped `notifyToolChanged()` → `registerAllTools(false, undefined)` → `initializeClientsFromSettings(false, undefined)`, which iterates over **all** servers.
- The reuse guard (`src/services/mcpService.ts:1261`) only preserves a server already in the `connected` state, so every non-connected server (`disconnected`/`failed`/`oauth_required`) was re-spawned on each toggle — pegging CPU with stdio (`npx`/`uvx`) child processes.
- On **enable**, the target was still `connecting` (async `listTools`) when the unscoped call ran, so it failed the reuse guard and got spawned a second time, orphaning the first child.

`toggleServerStatus` already scopes its work to the target (disable closes it + updates `serverInfos`; enable runs a targeted `initializeClientsFromSettings(false, name)`), so the controller only needs to broadcast the tool-list change. Replaced the unscoped `notifyToolChanged()` with `broadcastToolListChanged()`.

Restores the "reload one server affects only that server" guarantee from #921/#926.

Fixes #938

## Test plan

- [x] Added regression tests (`serverController - toggleServer (issue #938)`): both enable and disable assert `broadcastToolListChanged()` is called once and the unscoped `notifyToolChanged()` is never called (red before fix, green after).
- [x] Related suites pass: controller + `mcpService-toggle` + `mcpService-targeted-reload` (27/27).
- [x] `tsc --noEmit` clean.
- [x] Full suite: 125 suites / 809 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)