### PR TITLE
fix: broadcast list changes after upstream data is loaded, not before

### DIFF
--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -18,6 +18,8 @@ import {
   getServerByName,
   notifyToolChanged,
   broadcastToolListChanged,
+  broadcastPromptListChanged,
+  broadcastResourceListChanged,
   syncToolEmbedding,
   toggleServerStatus,
   reconnectServer,
@@ -1011,12 +1013,17 @@ export const toggleServer = async (req: Request, res: Response): Promise<void> =
 
     const result = await toggleServerStatus(existingServer.name, enabled);
     if (result.success) {
-      // toggleServerStatus already scopes its work to this server (disabling
-      // closes it; enabling runs a targeted reconnect). Only broadcast the
-      // tool-list change here — calling the unscoped notifyToolChanged() would
-      // re-initialize every non-connected server in the fleet, spiking CPU and
-      // orphaning stdio child processes. See #938 (and the #921/#926 guarantee).
-      broadcastToolListChanged();
+      // On disable, toggleServerStatus synchronously closes the server and
+      // updates serverInfos, so we broadcast the now-removed tools/prompts/
+      // resources here. On enable, the connection completes asynchronously
+      // inside initializeClientsFromSettings, which broadcasts itself once the
+      // tools/prompts/resources are actually loaded — broadcasting here would
+      // race ahead of that and push a stale (empty) list. See #938 / #942.
+      if (!enabled) {
+        broadcastToolListChanged();
+        broadcastPromptListChanged();
+        broadcastResourceListChanged();
+      }
       res.json({
         success: true,
         message: result.message || `Server ${enabled ? 'enabled' : 'disabled'} successfully`,

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1355,6 +1355,10 @@ export const initializeClientsFromSettings = async (
             `Successfully initialized OpenAPI server: ${name} with ${mcpTools.length} tools`,
           );
 
+          // Broadcast now that tools are loaded. OpenAPI servers expose tools
+          // only (no prompts/resources). See the standard-path note above.
+          broadcastToolListChanged();
+
           // Save tools as vector embeddings for search
           syncToolsAsVectorEmbeddings(name, mcpTools, {
             reportProgress: options?.reportEmbeddingProgress === true && serverName === name,
@@ -1451,6 +1455,11 @@ export const initializeClientsFromSettings = async (
                   reportEmbeddingProgress:
                     options?.reportEmbeddingProgress === true && serverName === name,
                 });
+                // Broadcast only after tools are actually loaded into the cache.
+                // The connection completes asynchronously, so callers (e.g. enabling
+                // a server) cannot broadcast a correct tool list themselves — doing so
+                // would race ahead of this point and push a stale (empty) list.
+                broadcastToolListChanged();
               })
               .catch((error) => {
                 console.error('Failed to list tools for server', {
@@ -1469,6 +1478,7 @@ export const initializeClientsFromSettings = async (
                   `Successfully listed ${prompts.prompts.length} prompts for server: ${name}`,
                 );
                 updateServerPromptsCache(serverInfo, prompts.prompts);
+                broadcastPromptListChanged();
               })
               .catch((error) => {
                 console.error('Failed to list prompts for server', {
@@ -1487,6 +1497,7 @@ export const initializeClientsFromSettings = async (
                   `Successfully listed ${resources.resources.length} resources for server: ${name}`,
                 );
                 updateServerResourcesCache(serverInfo, resources.resources);
+                broadcastResourceListChanged();
               })
               .catch((error) => {
                 console.error('Failed to list resources for server', {

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -42,6 +42,8 @@ const mockBearerKeyDao = {
 
 const mockNotifyToolChanged = jest.fn();
 const mockBroadcastToolListChanged = jest.fn();
+const mockBroadcastPromptListChanged = jest.fn();
+const mockBroadcastResourceListChanged = jest.fn();
 const mockSyncToolEmbedding = jest.fn();
 const mockGetServerByName = jest.fn();
 const mockAddServer = jest.fn();
@@ -72,6 +74,8 @@ jest.mock('../../src/services/mcpService.js', () => ({
   getServerByName: jest.fn(() => mockGetServerByName()),
   notifyToolChanged: jest.fn(() => mockNotifyToolChanged()),
   broadcastToolListChanged: jest.fn(() => mockBroadcastToolListChanged()),
+  broadcastPromptListChanged: jest.fn(() => mockBroadcastPromptListChanged()),
+  broadcastResourceListChanged: jest.fn(() => mockBroadcastResourceListChanged()),
   syncToolEmbedding: jest.fn((...args: unknown[]) => mockSyncToolEmbedding(...args)),
   toggleServerStatus: mockToggleServerStatus,
   reconnectServer: mockReconnectServer,
@@ -985,23 +989,29 @@ describe('serverController - toggleServer (issue #938)', () => {
 
   // toggleServerStatus already scopes work to the target server (disable closes
   // it; enable runs a targeted initializeClientsFromSettings(false, name)). The
-  // controller must NOT additionally call the unscoped notifyToolChanged(),
-  // which would re-initialize every non-connected server in the fleet and spike
-  // CPU. It should only broadcast the tool-list change.
-  it('enabling a server broadcasts only and does not trigger a fleet-wide re-init', async () => {
+  // controller must NOT call the unscoped notifyToolChanged(), which would
+  // re-initialize every non-connected server in the fleet and spike CPU.
+  //
+  // On enable, the connection completes asynchronously and mcpService broadcasts
+  // itself once tools/prompts/resources are loaded — so the controller must NOT
+  // broadcast here (it would race ahead and push a stale, empty list). On
+  // disable, work is synchronous, so the controller broadcasts all three lists.
+  it('enabling a server does not broadcast from the controller (mcpService broadcasts after load)', async () => {
     const { req, res, json } = makeReqRes(true);
 
     await toggleServer(req, res);
 
     expect(mockToggleServerStatus).toHaveBeenCalledWith('target', true);
     expect(mockNotifyToolChanged).not.toHaveBeenCalled();
-    expect(mockBroadcastToolListChanged).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastToolListChanged).not.toHaveBeenCalled();
+    expect(mockBroadcastPromptListChanged).not.toHaveBeenCalled();
+    expect(mockBroadcastResourceListChanged).not.toHaveBeenCalled();
     expect(json).toHaveBeenCalledWith(
       expect.objectContaining({ success: true }),
     );
   });
 
-  it('disabling a server broadcasts only and does not trigger a fleet-wide re-init', async () => {
+  it('disabling a server broadcasts tools/prompts/resources and does not trigger a fleet-wide re-init', async () => {
     const { req, res, json } = makeReqRes(false);
 
     await toggleServer(req, res);
@@ -1009,6 +1019,8 @@ describe('serverController - toggleServer (issue #938)', () => {
     expect(mockToggleServerStatus).toHaveBeenCalledWith('target', false);
     expect(mockNotifyToolChanged).not.toHaveBeenCalled();
     expect(mockBroadcastToolListChanged).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastPromptListChanged).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastResourceListChanged).toHaveBeenCalledTimes(1);
     expect(json).toHaveBeenCalledWith(
       expect.objectContaining({ success: true }),
     );


### PR DESCRIPTION
## Summary

Follow-up to #942, addressing the two issues raised by Gemini Code Assist on that PR. Both predate #942 — they are corrected here.

**1. Async connection race (enable path).** Enabling a server calls `toggleServerStatus(name, true)` → `initializeClientsFromSettings(false, name)`, but the internal `client.connect(...).then(...)` chain is fire-and-forget — the function returns while the server is still `connecting` and before `listTools`/`listPrompts`/`listResources` have populated `serverInfo`. The `toggleServer` controller then called `broadcastToolListChanged()` immediately, so downstream clients fetched a **stale (empty)** tool list and never received a follow-up notification once the tools actually loaded.

**2. Missing prompt/resource broadcasts.** Toggling a server affects its tools, prompts, *and* resources, but the whole path only ever broadcast tools.

## Fix

Move the broadcasts into `mcpService.ts`, firing each one **right after its list is written to the cache**:

- Standard connect path (`stdio`/`sse`/`streamable`): broadcast inside each `.then()` after `updateServerToolsCache` / `updateServerPromptsCache` / `updateServerResourcesCache` — mirroring the existing upstream `onChanged` precedent.
- OpenAPI path: broadcast tools after `serverInfo.tools` is set (OpenAPI exposes tools only).

The controller now broadcasts **only on disable**, where `toggleServerStatus` works synchronously (`closeServer` + `serverInfos` update). On enable, `mcpService` broadcasts itself once data is loaded, so broadcasting in the controller would just race ahead with a stale list.

`reloadServer` / `reconnectServer` share the same connect path and get the corrected behavior for free.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Updated `serverController` toggle tests: enable no longer broadcasts from the controller; disable broadcasts tools/prompts/resources once each.
- [x] Affected suites pass (controller + mcpService-toggle + targeted-reload + stdio-cleanup): 36/36.
- [x] Full suite: 125 suites / 813 tests pass.

Relates to #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)