### PR TITLE
fix: only flag true cycles, not diamond/shared refs, in safe serialization

### DIFF
--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -246,32 +246,45 @@ const CIRCULAR_REFERENCE = '[Circular Reference]';
 const createAncestorTracker = () => {
   const stack: unknown[] = [];
 
-  return (holder: unknown, value: unknown): boolean => {
-    // Unwind to the current holder: siblings share a holder, so anything still
-    // on the stack below it belongs to an already-finished branch.
-    while (stack.length > 0 && stack[stack.length - 1] !== holder) {
-      stack.pop();
-    }
+  return {
+    isCircular(holder: unknown, value: unknown): boolean {
+      // Unwind to the current holder: siblings share a holder, so anything still
+      // on the stack below it belongs to an already-finished branch.
+      while (stack.length > 0 && stack[stack.length - 1] !== holder) {
+        stack.pop();
+      }
 
-    if (stack.includes(value)) {
-      return true;
-    }
+      if (stack.includes(value)) {
+        return true;
+      }
 
-    stack.push(value);
-    return false;
+      stack.push(value);
+      return false;
+    },
+    // When a value is replaced mid-traversal (an Error becomes a plain object),
+    // swap it on the stack too. JSON.stringify walks the *replacement's*
+    // properties next, passing it as the holder, so the stack must reference the
+    // replacement or the unwind above would empty the stack and miss cycles that
+    // close through the error.
+    replace(oldValue: unknown, newValue: unknown): void {
+      const index = stack.indexOf(oldValue);
+      if (index !== -1) {
+        stack[index] = newValue;
+      }
+    },
   };
 };
 
 const createSafeJsonReplacer = () => {
-  const isCircular = createAncestorTracker();
-  // Errors are replaced by serializeError() mid-traversal, which detaches the
-  // original from the ancestor stack; this guard keeps a cyclic Error.cause
-  // chain from recursing forever.
+  const tracker = createAncestorTracker();
+  // serializeError() returns a fresh object on each call, so a cyclic
+  // Error.cause chain would keep producing new objects forever; this guard
+  // breaks it independently of the ancestor stack.
   const seenErrors = new WeakSet<Error>();
 
   return function (this: unknown, _key: string, value: unknown): unknown {
     if (typeof value === 'object' && value !== null) {
-      if (isCircular(this, value)) {
+      if (tracker.isCircular(this, value)) {
         return CIRCULAR_REFERENCE;
       }
 
@@ -280,7 +293,9 @@ const createSafeJsonReplacer = () => {
           return CIRCULAR_REFERENCE;
         }
         seenErrors.add(value);
-        return serializeError(value);
+        const serialized = serializeError(value);
+        tracker.replace(value, serialized);
+        return serialized;
       }
     }
 
@@ -289,7 +304,7 @@ const createSafeJsonReplacer = () => {
 };
 
 const createSafeLogReplacer = () => {
-  const isCircular = createAncestorTracker();
+  const tracker = createAncestorTracker();
   const seenErrors = new WeakSet<Error>();
 
   return function (this: unknown, key: string, value: unknown): unknown {
@@ -302,7 +317,7 @@ const createSafeLogReplacer = () => {
     }
 
     if (typeof value === 'object' && value !== null) {
-      if (isCircular(this, value)) {
+      if (tracker.isCircular(this, value)) {
         return CIRCULAR_REFERENCE;
       }
 
@@ -311,7 +326,9 @@ const createSafeLogReplacer = () => {
           return CIRCULAR_REFERENCE;
         }
         seenErrors.add(value);
-        return serializeError(value);
+        const serialized = serializeError(value);
+        tracker.replace(value, serialized);
+        return serialized;
       }
     }
 

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -229,18 +229,57 @@ export const formatErrorForLogging = (error: unknown): string => {
   return parts.join(' | ') || 'Unknown error';
 };
 
-const createSafeJsonReplacer = () => {
-  const seen = new WeakSet<object>();
+const CIRCULAR_REFERENCE = '[Circular Reference]';
 
-  return (_key: string, value: unknown): unknown => {
+/**
+ * Tracks the chain of ancestors during a single JSON.stringify traversal so
+ * that only true circular references (an object that contains itself, directly
+ * or transitively) are flagged — not diamond/shared references where the same
+ * object is reachable from two sibling keys.
+ *
+ * A naive `WeakSet` of every visited object cannot tell the two apart: it marks
+ * a shared-but-acyclic object as circular the second time it is seen, silently
+ * dropping data. JSON.stringify traverses depth-first and invokes the replacer
+ * with `this` bound to the object that holds the current value, so we keep an
+ * ancestor stack and unwind it back to the current holder before each check.
+ */
+const createAncestorTracker = () => {
+  const stack: unknown[] = [];
+
+  return (holder: unknown, value: unknown): boolean => {
+    // Unwind to the current holder: siblings share a holder, so anything still
+    // on the stack below it belongs to an already-finished branch.
+    while (stack.length > 0 && stack[stack.length - 1] !== holder) {
+      stack.pop();
+    }
+
+    if (stack.includes(value)) {
+      return true;
+    }
+
+    stack.push(value);
+    return false;
+  };
+};
+
+const createSafeJsonReplacer = () => {
+  const isCircular = createAncestorTracker();
+  // Errors are replaced by serializeError() mid-traversal, which detaches the
+  // original from the ancestor stack; this guard keeps a cyclic Error.cause
+  // chain from recursing forever.
+  const seenErrors = new WeakSet<Error>();
+
+  return function (this: unknown, _key: string, value: unknown): unknown {
     if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) {
-        return '[Circular Reference]';
+      if (isCircular(this, value)) {
+        return CIRCULAR_REFERENCE;
       }
 
-      seen.add(value);
-
       if (value instanceof Error) {
+        if (seenErrors.has(value)) {
+          return CIRCULAR_REFERENCE;
+        }
+        seenErrors.add(value);
         return serializeError(value);
       }
     }
@@ -250,9 +289,10 @@ const createSafeJsonReplacer = () => {
 };
 
 const createSafeLogReplacer = () => {
-  const seen = new WeakSet<object>();
+  const isCircular = createAncestorTracker();
+  const seenErrors = new WeakSet<Error>();
 
-  return (key: string, value: unknown): unknown => {
+  return function (this: unknown, key: string, value: unknown): unknown {
     if (isSensitiveLogKey(key)) {
       return REDACTED_VALUE;
     }
@@ -262,13 +302,15 @@ const createSafeLogReplacer = () => {
     }
 
     if (typeof value === 'object' && value !== null) {
-      if (seen.has(value)) {
-        return '[Circular Reference]';
+      if (isCircular(this, value)) {
+        return CIRCULAR_REFERENCE;
       }
 
-      seen.add(value);
-
       if (value instanceof Error) {
+        if (seenErrors.has(value)) {
+          return CIRCULAR_REFERENCE;
+        }
+        seenErrors.add(value);
         return serializeError(value);
       }
     }

--- a/tests/utils/serialization.test.ts
+++ b/tests/utils/serialization.test.ts
@@ -179,4 +179,38 @@ describe('serialization utilities', () => {
 
     expect(result).toContain('2026-01-02T03:04:05.000Z');
   });
+
+  it('createSafeJSON breaks cycles that close through a serialized Error', () => {
+    const parent: Record<string, unknown> = { tag: 'PARENT' };
+    const error = new Error('boom') as Error & { ctx?: unknown };
+    error.ctx = parent; // error points back to its own ancestor
+    parent.error = error;
+
+    // Must not throw "Converting circular structure to JSON".
+    const result = createSafeJSON(parent) as {
+      tag: string;
+      error: { message: string; ctx: string };
+    };
+
+    expect(result.tag).toBe('PARENT');
+    expect(result.error.message).toBe('boom');
+    expect(result.error.ctx).toBe('[Circular Reference]');
+    // The ancestor must not be duplicated by a premature stack unwind.
+    expect(JSON.stringify(result).match(/PARENT/g)).toHaveLength(1);
+  });
+
+  it('safeStringify terminates on a cyclic Error.cause chain', () => {
+    const first = new Error('first') as Error & { cause?: unknown };
+    const second = new Error('second') as Error & { cause?: unknown };
+    first.cause = second;
+    second.cause = first;
+
+    // Must not blow the stack.
+    const result = safeStringify({ first });
+    const parsed = JSON.parse(result);
+
+    expect(parsed.first.message).toBe('first');
+    expect(parsed.first.cause.message).toBe('second');
+    expect(parsed.first.cause.cause).toBe('[Circular Reference]');
+  });
 });

--- a/tests/utils/serialization.test.ts
+++ b/tests/utils/serialization.test.ts
@@ -128,4 +128,55 @@ describe('serialization utilities', () => {
     expect(JSON.stringify(summary)).not.toContain('also-secret');
     expect(formatted).not.toContain('top-secret');
   });
+
+  it('createSafeJSON keeps shared (diamond) references instead of dropping them as circular', () => {
+    const shared = { id: 1, label: 'shared' };
+    const result = createSafeJSON({ a: shared, b: shared, list: [shared, shared] }) as {
+      a: typeof shared;
+      b: typeof shared;
+      list: Array<typeof shared>;
+    };
+
+    // None of these are true cycles, so every occurrence must survive verbatim.
+    expect(result.a).toEqual(shared);
+    expect(result.b).toEqual(shared);
+    expect(result.list[0]).toEqual(shared);
+    expect(result.list[1]).toEqual(shared);
+    expect(JSON.stringify(result)).not.toContain('[Circular Reference]');
+  });
+
+  it('safeStringify keeps shared references but still breaks true cycles', () => {
+    const shared = { id: 7 };
+    const cyclic: Record<string, unknown> = { shared, sibling: shared };
+    cyclic.self = cyclic;
+
+    const result = safeStringify(cyclic);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.shared).toEqual({ id: 7 });
+    expect(parsed.sibling).toEqual({ id: 7 });
+    expect(parsed.self).toBe('[Circular Reference]');
+    // Only the genuine self-reference should be flagged, not the shared sibling.
+    expect(result.match(/\[Circular Reference\]/g)).toHaveLength(1);
+  });
+
+  it('createSafeJSON breaks deep transitive cycles', () => {
+    const a: Record<string, unknown> = { name: 'a' };
+    const b: Record<string, unknown> = { name: 'b' };
+    a.child = b;
+    b.parent = a; // a -> b -> a
+
+    const result = createSafeJSON(a) as { name: string; child: { name: string; parent: string } };
+
+    expect(result.name).toBe('a');
+    expect(result.child.name).toBe('b');
+    expect(result.child.parent).toBe('[Circular Reference]');
+  });
+
+  it('safeStringify still honors toJSON (e.g. Date) after the replacer change', () => {
+    const when = new Date('2026-01-02T03:04:05.000Z');
+    const result = safeStringify({ when });
+
+    expect(result).toContain('2026-01-02T03:04:05.000Z');
+  });
 });


### PR DESCRIPTION
## The bug

`createSafeJsonReplacer` / `createSafeLogReplacer` tracked **every** visited object in a `WeakSet` and returned `"[Circular Reference]"` the second time any object was seen. A `WeakSet` of all-visited objects cannot tell apart:

- a **true cycle** — an object that contains itself, directly or transitively, and
- a **diamond / shared reference** — the same object reached from two sibling keys (not a cycle).

So `JSON.stringify` silently dropped shared data:

```js
const shared = { id: 1 };
safeStringify({ a: shared, b: shared });
// => {"a":{"id":1},"b":"[Circular Reference]"}   // b is NOT a cycle
```

`createSafeJSON` has the wider blast radius: it feeds **real business data** (e.g. the `GET /servers` response in `serverController`), so the frontend could receive the literal string `"[Circular Reference]"` in place of an actual object whenever two fields shared a reference.

## The fix

Track the **ancestor stack** for the current traversal instead of an all-visited set. `JSON.stringify` walks depth-first and binds `this` to the holder of the current value, so we unwind the stack back to the current holder before each check — a shared sibling's earlier branch has already been popped, while a genuine self/transitive cycle is still on the stack and gets flagged.

`Error` values are replaced by `serializeError()` mid-traversal (which detaches the original from the stack), so a separate `WeakSet<Error>` guards against a cyclic `Error.cause` chain recursing forever.

## Tests

- diamond/shared refs in both objects and arrays survive verbatim (no `[Circular Reference]`)
- true self-reference and deep transitive (`a → b → a`) cycles are still broken
- exactly one occurrence is flagged when a shared ref and a real cycle coexist
- `Date.toJSON` still honored after switching the replacers to `function` for `this` binding

Existing redaction tests unchanged and green; `tsc --noEmit` and eslint clean.

## 中文摘要

安全序列化的两个 replacer 之前用 `WeakSet` 记录**所有**访问过的对象，任何对象第二次出现就判为 `[Circular Reference]`。但「全部访问过」无法区分**真环**（对象包含自身）和**菱形/共享引用**（同一对象被多个兄弟键引用），导致 `JSON.stringify` 静默丢掉共享数据。`createSafeJSON` 影响更大——它喂的是返回给前端的真实业务数据（如 `GET /servers`），前端可能拿到 `[Circular Reference]` 字符串而非真实对象。

修复改为按**祖先栈**判环：检查前先回退到当前 holder，兄弟分支已出栈、只有真正在通往根路径上的对象才会被标记。`Error` 在遍历中会被 `serializeError()` 替换、脱离栈，故另用 `WeakSet<Error>` 防止 `Error.cause` 成环导致无限递归。

## Note

Discovered while reviewing the serialization utils alongside #944 (configurable tool payload storage). This PR is independent and branches from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)