### PR TITLE
[codex] fix smart call_tool routing

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -2105,6 +2105,9 @@ const normalizeToolNameForServer = (serverName: string, toolName: string): strin
 };
 
 const getGroupLookupName = (group: string | undefined): string | undefined => {
+  if (group === '$smart') {
+    return undefined;
+  }
   if (group?.startsWith('$smart/')) {
     return group.substring(7) || undefined;
   }
@@ -2403,7 +2406,7 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
         targetServerInfo = appsRouteContext.serverInfo;
       } else if (extra && extra.server) {
         targetServerInfo = getServerByName(extra.server);
-      } else if (group) {
+      } else if (getGroupLookupName(group)) {
         const groupTool = await resolveToolInGroup(group, toolName, appsRouteContext.enabled);
         if (groupTool) {
           targetServerInfo = groupTool.serverInfo;
@@ -2585,13 +2588,15 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
     }
 
     // Regular tool handling
+    const lookupGroup = getGroupLookupName(group);
     const groupTool =
-      !appsRouteContext.enabled && group
-        ? await resolveToolInGroup(group, request.params.name, appsRouteContext.enabled)
+      !appsRouteContext.enabled && lookupGroup
+        ? await resolveToolInGroup(lookupGroup, request.params.name, appsRouteContext.enabled)
         : undefined;
     const serverInfo = appsRouteContext.enabled
       ? appsRouteContext.serverInfo
-      : (groupTool?.serverInfo ?? (group ? undefined : getServerByTool(request.params.name)));
+      : (groupTool?.serverInfo ??
+        (lookupGroup ? undefined : getServerByTool(request.params.name)));
     const routeToolName = groupTool?.toolName ?? request.params.name;
     const tool =
       groupTool?.tool ??
@@ -2810,10 +2815,11 @@ export const handleGetPromptRequest = async (request: any, extra: any) => {
 
     let server: ServerInfo | undefined;
     let promptNameForServer = name;
+    const lookupGroup = getGroupLookupName(group);
     if (extra && extra.server) {
       server = getServerByName(extra.server);
-    } else if (group) {
-      const groupPrompt = await resolvePromptInGroup(group, name);
+    } else if (lookupGroup) {
+      const groupPrompt = await resolvePromptInGroup(lookupGroup, name);
       if (groupPrompt) {
         server = groupPrompt.serverInfo;
         promptNameForServer = groupPrompt.promptName;
@@ -2872,6 +2878,7 @@ export const handleGetPromptRequest = async (request: any, extra: any) => {
 export const handleListPromptsRequest = async (_: any, extra: any) => {
   const sessionId = extra.sessionId || '';
   const group = getGroup(sessionId);
+  const lookupGroup = getGroupLookupName(group);
   console.log(`Handling ListPromptsRequest for group: ${group}`);
 
   // Start with built-in prompts (only enabled ones)
@@ -2885,7 +2892,8 @@ export const handleListPromptsRequest = async (_: any, extra: any) => {
     }),
   );
 
-  const { filteredServerInfos, serverConfigsByName } = await getFilteredServerInfosForGroup(group);
+  const { filteredServerInfos, serverConfigsByName } =
+    await getFilteredServerInfosForGroup(lookupGroup);
 
   for (const serverInfo of filteredServerInfos) {
     if (serverInfo.prompts && serverInfo.prompts.length > 0) {
@@ -2904,7 +2912,7 @@ export const handleListPromptsRequest = async (_: any, extra: any) => {
       }
 
       enabledPrompts = await filterPromptsByGroup(
-        group,
+        lookupGroup,
         serverInfo.name,
         enabledPrompts,
         groupServerConfig,
@@ -2932,6 +2940,7 @@ export const handleListPromptsRequest = async (_: any, extra: any) => {
 export const handleListResourcesRequest = async (_: any, extra: any) => {
   const sessionId = extra.sessionId || '';
   const group = getGroup(sessionId);
+  const lookupGroup = getGroupLookupName(group);
   console.log(`Handling ListResourcesRequest for group: ${group}`);
   const appsRouteContext = await getMcpAppsRouteContext(sessionId, group);
 
@@ -2946,7 +2955,8 @@ export const handleListResourcesRequest = async (_: any, extra: any) => {
     }),
   );
 
-  const { filteredServerInfos, serverConfigsByName } = await getFilteredServerInfosForGroup(group);
+  const { filteredServerInfos, serverConfigsByName } =
+    await getFilteredServerInfosForGroup(lookupGroup);
 
   for (const serverInfo of filteredServerInfos) {
     if (serverInfo.resources && serverInfo.resources.length > 0) {
@@ -2962,7 +2972,7 @@ export const handleListResourcesRequest = async (_: any, extra: any) => {
       }
 
       enabledResources = await filterResourcesByGroup(
-        group,
+        lookupGroup,
         serverInfo.name,
         enabledResources,
         serverConfigsByName.get(serverInfo.name),
@@ -2992,12 +3002,16 @@ export const handleListResourcesRequest = async (_: any, extra: any) => {
 export const handleListResourceTemplatesRequest = async (_: any, extra: any) => {
   const sessionId = extra.sessionId || '';
   const group = getGroup(sessionId);
+  const lookupGroup = getGroupLookupName(group);
   console.log(`Handling ListResourceTemplatesRequest for group: ${group}`);
   const appsRouteContext = await getMcpAppsRouteContext(sessionId, group);
 
-  const { filteredServerInfos, serverConfigsByName } = await getFilteredServerInfosForGroup(group, {
-    requireClient: true,
-  });
+  const { filteredServerInfos, serverConfigsByName } = await getFilteredServerInfosForGroup(
+    lookupGroup,
+    {
+      requireClient: true,
+    },
+  );
 
   const results = await Promise.allSettled(
     filteredServerInfos.map(async (serverInfo) => {
@@ -3007,7 +3021,7 @@ export const handleListResourceTemplatesRequest = async (_: any, extra: any) => 
 
       const templates = await serverInfo.client.listResourceTemplates({}, serverInfo.options || {});
       const filteredTemplates = await filterResourceTemplatesByGroup(
-        group,
+        lookupGroup,
         serverInfo.name,
         templates.resourceTemplates || [],
         serverConfigsByName.get(serverInfo.name),
@@ -3030,6 +3044,7 @@ export const handleReadResourceRequest = async (request: any, extra: any) => {
     const { uri } = request.params;
     const sessionId = extra.sessionId || '';
     const group = getGroup(sessionId);
+    const lookupGroup = getGroupLookupName(group);
     const appsRouteContext = await getMcpAppsRouteContext(sessionId, group);
 
     // Check built-in resources first
@@ -3047,7 +3062,7 @@ export const handleReadResourceRequest = async (request: any, extra: any) => {
     }
 
     const { filteredServerInfos, serverConfigsByName } =
-      await getFilteredServerInfosForGroup(group);
+      await getFilteredServerInfosForGroup(lookupGroup);
 
     let server: ServerInfo | undefined;
     for (const serverInfo of filteredServerInfos) {
@@ -3062,7 +3077,7 @@ export const handleReadResourceRequest = async (request: any, extra: any) => {
         );
       }
       enabledResources = await filterResourcesByGroup(
-        group,
+        lookupGroup,
         serverInfo.name,
         enabledResources,
         serverConfigsByName.get(serverInfo.name),

--- a/tests/services/mcpService-smart-routing-group.test.ts
+++ b/tests/services/mcpService-smart-routing-group.test.ts
@@ -34,9 +34,21 @@ jest.mock('../../src/services/sseService.js', () => ({
 }));
 
 jest.mock('../../src/dao/index.js', () => ({
+  getGroupDao: jest.fn(() => ({
+    findByName: jest.fn(() => Promise.resolve(null)),
+    findById: jest.fn(() => Promise.resolve(null)),
+  })),
   getServerDao: jest.fn(() => ({
     findById: jest.fn(),
     findAll: jest.fn(() => Promise.resolve([])),
+  })),
+  getBuiltinPromptDao: jest.fn(() => ({
+    findByName: jest.fn(() => Promise.resolve(null)),
+    findEnabled: jest.fn(() => Promise.resolve([])),
+  })),
+  getBuiltinResourceDao: jest.fn(() => ({
+    findByUri: jest.fn(() => Promise.resolve(null)),
+    findEnabled: jest.fn(() => Promise.resolve([])),
   })),
 }));
 
@@ -108,6 +120,7 @@ import { handleSearchToolsRequest } from '../../src/services/smartRoutingService
 describe('MCP Service - Smart Routing with Group Support', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mcpService.setServerInfosForTest([]);
     // Setup mock return for handleSearchToolsRequest
     mockHandleSearchToolsRequest.mockResolvedValue({
       content: [
@@ -246,6 +259,69 @@ describe('MCP Service - Smart Routing with Group Support', () => {
   });
 
   describe('handleCallToolRequest - call_tool', () => {
+    it('should route direct tool calls across all servers when using $smart', async () => {
+      const callTool = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+      const serverInfo = {
+        name: 'server1',
+        status: 'connected',
+        enabled: true,
+        tools: [{ name: 'server1::direct-tool', description: 'Direct', inputSchema: {} }],
+        client: { callTool },
+        options: {},
+      } as any;
+
+      mcpService.setServerInfosForTest([serverInfo]);
+
+      const result = await mcpService.handleCallToolRequest(
+        {
+          params: {
+            name: 'server1::direct-tool',
+            arguments: { input: 'value' },
+          },
+        },
+        { sessionId: 'session-smart' },
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(callTool).toHaveBeenCalledTimes(1);
+      expect(callTool.mock.calls[0][0]).toEqual({
+        name: 'direct-tool',
+        arguments: { input: 'value' },
+      });
+    });
+
+    it('should route call_tool across all servers when using $smart', async () => {
+      const callTool = jest.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+      const serverInfo = {
+        name: 'server1',
+        status: 'connected',
+        enabled: true,
+        tools: [{ name: 'server1::pal-version', description: 'Version', inputSchema: {} }],
+        client: { callTool },
+        options: {},
+      } as any;
+
+      mcpService.setServerInfosForTest([serverInfo]);
+
+      const request = {
+        params: {
+          name: 'call_tool',
+          arguments: {
+            toolName: 'server1::pal-version',
+            arguments: {},
+          },
+        },
+      };
+
+      const result = await mcpService.handleCallToolRequest(request, {
+        sessionId: 'session-smart',
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(callTool).toHaveBeenCalledTimes(1);
+      expect(callTool.mock.calls[0][0]).toEqual({ name: 'pal-version', arguments: {} });
+    });
+
     it('should not leak wrapper fields when tool arguments are empty', async () => {
       const callTool = jest.fn().mockResolvedValue({ content: [] });
       const serverInfo = {
@@ -282,6 +358,94 @@ describe('MCP Service - Smart Routing with Group Support', () => {
       expect(toolParams.arguments).not.toHaveProperty('toolName');
 
       getServerByNameSpy.mockRestore();
+    });
+  });
+
+  describe('prompt and resource handling for $smart', () => {
+    it('should get prompts across all servers when using $smart', async () => {
+      const getPrompt = jest.fn().mockResolvedValue({
+        messages: [{ role: 'user', content: { type: 'text', text: 'summary' } }],
+      });
+      const serverInfo = {
+        name: 'server1',
+        status: 'connected',
+        enabled: true,
+        prompts: [{ name: 'server1::summarize', description: 'Summarize', arguments: [] }],
+        client: { getPrompt },
+      } as any;
+
+      mcpService.setServerInfosForTest([serverInfo]);
+
+      const result = await mcpService.handleGetPromptRequest(
+        { params: { name: 'server1::summarize', arguments: { topic: 'docs' } } },
+        { sessionId: 'session-smart' },
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(result.messages[0].content.text).toBe('summary');
+      expect(getPrompt).toHaveBeenCalledWith({
+        name: 'summarize',
+        arguments: { topic: 'docs' },
+      });
+    });
+
+    it('should list prompts and resources across all servers when using $smart', async () => {
+      const listResourceTemplates = jest.fn().mockResolvedValue({
+        resourceTemplates: [{ uriTemplate: 'resource://docs/{slug}', name: 'Docs by slug' }],
+      });
+      const serverInfo = {
+        name: 'server1',
+        status: 'connected',
+        enabled: true,
+        prompts: [{ name: 'server1::summarize', description: 'Summarize', arguments: [] }],
+        resources: [{ uri: 'resource://docs/guide', name: 'Guide' }],
+        client: { listResourceTemplates },
+        options: {},
+      } as any;
+
+      mcpService.setServerInfosForTest([serverInfo]);
+
+      const prompts = await mcpService.handleListPromptsRequest({}, { sessionId: 'session-smart' });
+      const resources = await mcpService.handleListResourcesRequest(
+        {},
+        { sessionId: 'session-smart' },
+      );
+      const templates = await mcpService.handleListResourceTemplatesRequest(
+        {},
+        { sessionId: 'session-smart' },
+      );
+
+      expect(prompts.prompts.map((prompt: any) => prompt.name)).toEqual(['server1::summarize']);
+      expect(resources.resources.map((resource: any) => resource.uri)).toEqual([
+        'resource://docs/guide',
+      ]);
+      expect(templates.resourceTemplates).toEqual([
+        { uriTemplate: 'resource://docs/{slug}', name: 'Docs by slug' },
+      ]);
+    });
+
+    it('should read resources across all servers when using $smart', async () => {
+      const readResource = jest.fn().mockResolvedValue({
+        contents: [{ uri: 'resource://docs/guide', mimeType: 'text/plain', text: 'guide' }],
+      });
+      const serverInfo = {
+        name: 'server1',
+        status: 'connected',
+        enabled: true,
+        resources: [{ uri: 'resource://docs/guide', name: 'Guide' }],
+        client: { readResource },
+      } as any;
+
+      mcpService.setServerInfosForTest([serverInfo]);
+
+      const result = await mcpService.handleReadResourceRequest(
+        { params: { uri: 'resource://docs/guide' } },
+        { sessionId: 'session-smart' },
+      );
+
+      expect(result.isError).not.toBe(true);
+      expect(result.contents[0].text).toBe('guide');
+      expect(readResource).toHaveBeenCalledWith({ uri: 'resource://docs/guide' });
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix plain `/mcp/$smart` `call_tool` routing so it falls back to all connected servers instead of treating `$smart` as a literal group lookup.
- Keep `/mcp/$smart/<group>` scoped routing behavior intact.
- Add a regression test covering `$smart` wrapper `call_tool` execution against a connected server.

Fixes #946.

## Root Cause

`handleCallToolRequest` treated any non-empty group value as a scoped lookup. After session rebuild, `$smart` was therefore passed into group resolution, which could not find an actual server/group for the tool even though `search_tools` had discovered it.

## Validation

- `pnpm jest tests/services/mcpService-group-alias.test.ts tests/services/smartRoutingService-metatools.test.ts tests/services/mcpService-smart-routing-group.test.ts --runInBand`
- `pnpm lint`
- `pnpm test:ci`
- `pnpm build`
- `git diff --check`