### PR TITLE
[codex] Add Cargo to Docker image

### DIFF
--- a/.github/DOCKER_CLI_TEST.md
+++ b/.github/DOCKER_CLI_TEST.md
@@ -20,11 +20,14 @@ docker run --rm mcphub:base docker --version
 # Build with extended features
 docker build --build-arg INSTALL_EXT=true -t mcphub:extended .
 
-# Test Docker CLI is available
+# Test Docker CLI, Cargo, and Rust are available
 docker run --rm mcphub:extended docker --version
+docker run --rm --entrypoint sh mcphub:extended -c 'rustup --version && cargo --version && rustc --version'
 ```
 
-**Expected Result**: Docker version output (e.g., `Docker version 27.x.x, build xxxxx`)
+**Expected Result**:
+- Docker version output (e.g., `Docker version 27.x.x, build xxxxx`)
+- rustup, Cargo, and Rust compiler version output
 
 ## Test 3: Docker-in-Docker with Auto-start Daemon
 
@@ -96,7 +99,7 @@ docker images mcphub:*
 
 **Expected Result**: 
 - The `extended` image should be larger than the `base` image
-- The size difference should be reasonable (Docker Engine adds ~100-150MB)
+- The size difference should be expected for the full toolchain (Docker Engine plus rustup-managed Rust/Cargo)
 
 ## Test 6: Architecture Support
 
@@ -110,13 +113,14 @@ docker build --build-arg INSTALL_EXT=true --platform linux/arm64 -t mcphub:exten
 
 **Expected Result**: 
 - Both builds should succeed
-- AMD64 includes Chrome + Firefox for Playwright + Docker Engine
-- ARM64 includes Docker Engine only (browser installation is skipped)
+- AMD64 includes Chrome + Firefox for Playwright, Docker Engine, and rustup-managed Rust/Cargo
+- ARM64 includes Docker Engine and rustup-managed Rust/Cargo only (browser installation is skipped)
 
 ## Notes
 
 - The Docker Engine installation follows the official Docker documentation
 - Includes full Docker daemon (`dockerd`), CLI (`docker`), and containerd
+- Includes rustup-managed Rust/Cargo only in the opt-in `INSTALL_EXT=true` image, published as `-full`
 - The daemon auto-starts when running in privileged mode
 - The installation uses the Debian Bookworm repository
 - All temporary files are cleaned up to minimize image size

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ RUN apt-get update && apt-get install -y curl gnupg git build-essential \
 
 RUN corepack enable && corepack prepare pnpm@10.12.4 --activate
 
+ENV RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH
+
 ARG INSTALL_EXT=false
 RUN if [ "$INSTALL_EXT" = "true" ]; then \
   ARCH=$(uname -m); \
@@ -19,9 +23,11 @@ RUN if [ "$INSTALL_EXT" = "true" ]; then \
   else \
   echo "Skipping Chrome and Firefox installation on non-amd64 architecture: $ARCH"; \
   fi; \
-  # Install Docker Engine (includes CLI and daemon) \
+  # Install Rust toolchain and Docker Engine (includes CLI and daemon) \
   apt-get update && \
   apt-get install -y ca-certificates curl iptables && \
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal && \
+  cargo --version && rustc --version && \
   install -m 0755 -d /etc/apt/keyrings && \
   curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
   chmod a+r /etc/apt/keyrings/docker.asc && \

--- a/docs/configuration/docker-setup.mdx
+++ b/docs/configuration/docker-setup.mdx
@@ -11,6 +11,8 @@ This guide covers deploying MCPHub using Docker, including development and produ
 
 ### Using Pre-built Image
 
+The standard MCPHub image includes Node.js/pnpm, Python, uv/uvx, Git, and build tools. Use the `latest-full` image if you need Cargo and the stable Rust toolchain for Rust-based MCP servers.
+
 ```bash
 # Pull the latest image
 docker pull samanhappy/mcphub:latest
@@ -43,10 +45,10 @@ docker run -d \
 
 ### Building with Extended Features
 
-The Docker image supports an `INSTALL_EXT` build argument to include additional tools:
+The Docker image supports an `INSTALL_EXT` build argument to include additional tools. Published `-full` images are built with this enabled:
 
 ```bash
-# Build with extended features (includes Docker Engine, Chrome + Firefox for Playwright)
+# Build with extended features (includes stable Rust/Cargo, Docker Engine, Chrome + Firefox for Playwright)
 docker build --build-arg INSTALL_EXT=true -t mcphub:extended .
 
 # Option 1: Run with automatic Docker-in-Docker (requires privileged mode)
@@ -72,6 +74,7 @@ docker exec mcphub docker ps
 
 <Note>
   **What's included with INSTALL_EXT=true:**
+  - **Stable Rust + Cargo**: Installed through rustup for Rust-based MCP servers.
   - **Docker Engine**: Full Docker daemon with CLI for container management. The daemon auto-starts when the container runs in privileged mode.
   - **Chrome + Firefox for Playwright** (amd64 only): For browser automation tasks
   

--- a/docs/zh/configuration/docker-setup.mdx
+++ b/docs/zh/configuration/docker-setup.mdx
@@ -11,6 +11,8 @@ description: '使用 Docker 和 Docker Compose 部署 MCPHub'
 
 ### 使用预构建镜像
 
+标准 MCPHub 镜像内置 Node.js/pnpm、Python、uv/uvx、Git 和构建工具。如果需要为 Rust MCP server 使用 Cargo 和稳定版 Rust 工具链，请使用 `latest-full` 镜像。
+
 ```bash
 # 拉取最新镜像
 docker pull samanhappy/mcphub:latest
@@ -43,10 +45,10 @@ docker run -d \
 
 ### 构建扩展功能版本
 
-Docker 镜像支持 `INSTALL_EXT` 构建参数以包含额外工具：
+Docker 镜像支持 `INSTALL_EXT` 构建参数以包含额外工具。发布的 `-full` 镜像会启用此参数：
 
 ```bash
-# 构建扩展功能版本（包含 Docker 引擎，以及供 Playwright 使用的 Chrome 和 Firefox）
+# 构建扩展功能版本（包含稳定版 Rust/Cargo、Docker 引擎，以及供 Playwright 使用的 Chrome 和 Firefox）
 docker build --build-arg INSTALL_EXT=true -t mcphub:extended .
 
 # 方式 1: 使用自动 Docker-in-Docker（需要特权模式）
@@ -72,6 +74,7 @@ docker exec mcphub docker ps
 
 <Note>
   **INSTALL_EXT=true 包含的功能：**
+  - **稳定版 Rust + Cargo**：通过 rustup 安装，用于基于 Rust 的 MCP server。
   - **Docker 引擎**：完整的 Docker 守护进程和 CLI，用于容器管理。在特权模式下运行时，守护进程会自动启动。
   - **Chrome + Firefox（供 Playwright 使用，仅 amd64）**：用于浏览器自动化任务
   


### PR DESCRIPTION
## Summary
- Add Cargo only to the opt-in `INSTALL_EXT=true` Docker variant, which is published as the `-full` image.
- Install the Rust toolchain through rustup minimal stable instead of Debian `apt cargo`, so Rust-based MCP servers are not stuck on Bookworm’s old compiler.
- Keep the standard image lean by leaving Rust/Cargo out of the default install layer.
- Update Docker setup docs and extended-image test notes to describe rustup-managed Rust/Cargo as full-image tooling.

## Review feedback
- Addressed the Gemini review thread about Debian `apt cargo` being too old by switching the full image to rustup-managed stable Rust/Cargo.

## Validation
- `git diff --check`
- `corepack pnpm lint`
- `corepack pnpm build`
- Earlier in this PR: `corepack pnpm test:ci`
- `docker build --build-arg INSTALL_EXT=true -t mcphub:full-rustup-verify .`
- `docker run --rm --entrypoint sh mcphub:full-rustup-verify -c 'rustup --version && cargo --version && rustc --version && docker --version'` -> `rustup 1.29.0`, `cargo 1.96.0`, `rustc 1.96.0`, `Docker 29.6.1`

Closes #954
