### PR TITLE
[codex] fix OpenAPI OAuth2 token refresh after 401

### DIFF
--- a/src/clients/__tests__/openapi-error-handling.test.ts
+++ b/src/clients/__tests__/openapi-error-handling.test.ts
@@ -57,4 +57,61 @@ describe('OpenAPIClient - error handling', () => {
       'API call failed: 400 Bad Request {"message":"upstream validation failed","code":"INVALID_INPUT"}',
     );
   });
+
+  test('redacts OAuth error fields from surfaced upstream response details', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        schema: {
+          openapi: '3.0.0',
+          info: { title: 'Test API', version: '1.0.0' },
+          paths: {},
+        },
+      },
+    };
+
+    const client = new OpenAPIClient(config) as OpenAPIClient & {
+      tools: Array<{
+        name: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        operationId: string;
+        method: string;
+        path: string;
+      }>;
+      httpClient: {
+        request: jest.Mock;
+      };
+    };
+
+    client.tools = [
+      {
+        name: 'get_users',
+        description: 'Get users',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'get_users',
+        method: 'get',
+        path: '/users',
+      },
+    ];
+
+    client.httpClient = {
+      request: jest.fn().mockRejectedValue({
+        isAxiosError: true,
+        response: {
+          status: 401,
+          statusText: 'Unauthorized',
+          data: {
+            error: 'invalid_token',
+            error_description: 'JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 leaked',
+          },
+        },
+      }),
+    };
+
+    await expect(client.callTool('get_users', {})).rejects.toThrow(
+      'API call failed: 401 Unauthorized {"error":"invalid_token","error_description":"[REDACTED]"}',
+    );
+    await expect(client.callTool('get_users', {})).rejects.not.toThrow('eyJhbGciOiJIUzI1NiI');
+  });
 });

--- a/src/clients/__tests__/openapi-oauth2.test.ts
+++ b/src/clients/__tests__/openapi-oauth2.test.ts
@@ -80,7 +80,9 @@ describe('OpenAPIClient - OAuth2 client credentials', () => {
         }),
       }),
     );
-    expect(client.httpClient.request.mock.calls[0][0].data).toContain('grant_type=client_credentials');
+    expect(client.httpClient.request.mock.calls[0][0].data).toContain(
+      'grant_type=client_credentials',
+    );
     expect(client.httpClient.request.mock.calls[0][0].data).toContain('client_id=test-client');
     expect(client.httpClient.request.mock.calls[0][0].data).toContain('client_secret=test-secret');
     expect(client.httpClient.defaults.headers.common.Authorization).toBe('Bearer ' + 'fresh-token');
@@ -101,5 +103,219 @@ describe('OpenAPIClient - OAuth2 client credentials', () => {
         url: '/users',
       }),
     );
+  });
+
+  test('refreshes the OAuth2 token and retries once when an upstream call returns 401', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        schema: {
+          openapi: '3.0.0',
+          info: { title: 'Test API', version: '1.0.0' },
+          paths: {},
+        },
+        security: {
+          type: 'oauth2',
+          oauth2: {
+            tokenUrl: 'https://auth.example.com/oauth/token',
+            clientId: 'test-client',
+            clientSecret: 'test-secret',
+            token: 'stale-token',
+            expiresAt: Date.now() + 3600_000,
+          },
+        },
+      },
+    };
+    const persistOAuth2Token = jest.fn();
+    const client = new OpenAPIClient(config, { persistOAuth2Token }) as OpenAPIClient & {
+      tools: Array<{
+        name: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        operationId: string;
+        method: string;
+        path: string;
+      }>;
+      httpClient: {
+        request: jest.Mock;
+        defaults: {
+          headers: {
+            common: Record<string, string>;
+          };
+        };
+      };
+    };
+    const observedAuthorizationHeaders: Array<string | undefined> = [];
+
+    client.tools = [
+      {
+        name: 'getUsers',
+        description: 'Get users',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'getUsers',
+        method: 'get',
+        path: '/users',
+      },
+    ];
+    client.httpClient = {
+      request: jest.fn((requestConfig: { url: string }) => {
+        observedAuthorizationHeaders.push(client.httpClient.defaults.headers.common.Authorization);
+
+        if (requestConfig.url === '/users' && observedAuthorizationHeaders.length === 1) {
+          return Promise.reject({
+            isAxiosError: true,
+            response: {
+              status: 401,
+              statusText: 'Unauthorized',
+              data: {
+                error: 'invalid_token',
+              },
+            },
+          });
+        }
+
+        if (requestConfig.url === 'https://auth.example.com/oauth/token') {
+          return Promise.resolve({
+            data: {
+              access_token: 'fresh-token',
+              expires_in: 3600,
+            },
+          });
+        }
+
+        return Promise.resolve({
+          data: {
+            users: [],
+          },
+        });
+      }),
+      defaults: {
+        headers: {
+          common: {},
+        },
+      },
+    };
+
+    await expect(client.callTool('getUsers', {})).resolves.toEqual({ users: [] });
+
+    expect(client.httpClient.request).toHaveBeenCalledTimes(3);
+    expect(client.httpClient.request).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ method: 'get', url: '/users' }),
+    );
+    expect(client.httpClient.request).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: 'post',
+        url: 'https://auth.example.com/oauth/token',
+      }),
+    );
+    expect(client.httpClient.request).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ method: 'get', url: '/users' }),
+    );
+    expect(observedAuthorizationHeaders).toEqual([
+      'Bearer stale-token',
+      undefined,
+      'Bearer fresh-token',
+    ]);
+    expect(config.openapi?.security?.oauth2?.token).toBe('fresh-token');
+    expect(persistOAuth2Token).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'fresh-token',
+        expiresAt: expect.any(Number),
+      }),
+    );
+  });
+
+  test('does not retry indefinitely when a refreshed OAuth2 token is still rejected', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        schema: {
+          openapi: '3.0.0',
+          info: { title: 'Test API', version: '1.0.0' },
+          paths: {},
+        },
+        security: {
+          type: 'oauth2',
+          oauth2: {
+            tokenUrl: 'https://auth.example.com/oauth/token',
+            clientId: 'test-client',
+            token: 'stale-token',
+            expiresAt: Date.now() + 3600_000,
+          },
+        },
+      },
+    };
+    const client = new OpenAPIClient(config) as OpenAPIClient & {
+      tools: Array<{
+        name: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        operationId: string;
+        method: string;
+        path: string;
+      }>;
+      httpClient: {
+        request: jest.Mock;
+        defaults: {
+          headers: {
+            common: Record<string, string>;
+          };
+        };
+      };
+    };
+
+    client.tools = [
+      {
+        name: 'getUsers',
+        description: 'Get users',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'getUsers',
+        method: 'get',
+        path: '/users',
+      },
+    ];
+    client.httpClient = {
+      request: jest
+        .fn()
+        .mockRejectedValueOnce({
+          isAxiosError: true,
+          response: {
+            status: 401,
+            statusText: 'Unauthorized',
+            data: {
+              error: 'invalid_token',
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            access_token: 'fresh-token',
+            expires_in: 3600,
+          },
+        })
+        .mockRejectedValueOnce({
+          isAxiosError: true,
+          response: {
+            status: 401,
+            statusText: 'Unauthorized',
+            data: {
+              error: 'invalid_token',
+            },
+          },
+        }),
+      defaults: {
+        headers: {
+          common: {},
+        },
+      },
+    };
+
+    await expect(client.callTool('getUsers', {})).rejects.toThrow(
+      'API call failed: 401 Unauthorized {"error":"invalid_token"}',
+    );
+    expect(client.httpClient.request).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/clients/__tests__/openapi-oauth2.test.ts
+++ b/src/clients/__tests__/openapi-oauth2.test.ts
@@ -126,7 +126,10 @@ describe('OpenAPIClient - OAuth2 client credentials', () => {
         },
       },
     };
-    const persistOAuth2Token = jest.fn();
+    const persistedOAuth2States: Array<Record<string, unknown>> = [];
+    const persistOAuth2Token = jest.fn((oauth2) => {
+      persistedOAuth2States.push({ ...oauth2 });
+    });
     const client = new OpenAPIClient(config, { persistOAuth2Token }) as OpenAPIClient & {
       tools: Array<{
         name: string;
@@ -220,7 +223,164 @@ describe('OpenAPIClient - OAuth2 client credentials', () => {
       'Bearer fresh-token',
     ]);
     expect(config.openapi?.security?.oauth2?.token).toBe('fresh-token');
-    expect(persistOAuth2Token).toHaveBeenCalledWith(
+    expect(persistOAuth2Token).toHaveBeenCalledTimes(2);
+    expect(persistedOAuth2States[0]).toEqual(
+      expect.objectContaining({
+        tokenUrl: 'https://auth.example.com/oauth/token',
+        clientId: 'test-client',
+        clientSecret: 'test-secret',
+      }),
+    );
+    expect(persistedOAuth2States[0]).not.toHaveProperty('token');
+    expect(persistedOAuth2States[0]).not.toHaveProperty('expiresAt');
+    expect(persistedOAuth2States[1]).toEqual(
+      expect.objectContaining({
+        token: 'fresh-token',
+        expiresAt: expect.any(Number),
+      }),
+    );
+  });
+
+  test('does not invalidate a token refreshed by another in-flight 401 retry', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        schema: {
+          openapi: '3.0.0',
+          info: { title: 'Test API', version: '1.0.0' },
+          paths: {},
+        },
+        security: {
+          type: 'oauth2',
+          oauth2: {
+            tokenUrl: 'https://auth.example.com/oauth/token',
+            clientId: 'test-client',
+            token: 'stale-token',
+            expiresAt: Date.now() + 3600_000,
+          },
+        },
+      },
+    };
+    const persistedOAuth2States: Array<Record<string, unknown>> = [];
+    const client = new OpenAPIClient(config, {
+      persistOAuth2Token: (oauth2) => {
+        persistedOAuth2States.push({ ...oauth2 });
+      },
+    }) as OpenAPIClient & {
+      tools: Array<{
+        name: string;
+        description: string;
+        inputSchema: Record<string, unknown>;
+        operationId: string;
+        method: string;
+        path: string;
+      }>;
+      httpClient: {
+        request: jest.Mock;
+        defaults: {
+          headers: {
+            common: Record<string, string>;
+          };
+        };
+      };
+    };
+    const rejectInitialUserRequests: Array<(error: unknown) => void> = [];
+    const observedAuthorizationHeaders: Array<string | undefined> = [];
+    let userRequestCount = 0;
+    let tokenRequestCount = 0;
+
+    client.tools = [
+      {
+        name: 'getUsers',
+        description: 'Get users',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'getUsers',
+        method: 'get',
+        path: '/users',
+      },
+    ];
+    client.httpClient = {
+      request: jest.fn((requestConfig: { url: string }) => {
+        observedAuthorizationHeaders.push(client.httpClient.defaults.headers.common.Authorization);
+
+        if (requestConfig.url === 'https://auth.example.com/oauth/token') {
+          tokenRequestCount += 1;
+          return Promise.resolve({
+            data: {
+              access_token: 'fresh-token',
+              expires_in: 3600,
+            },
+          });
+        }
+
+        if (requestConfig.url === '/users') {
+          userRequestCount += 1;
+
+          if (userRequestCount <= 2) {
+            return new Promise((_, reject) => {
+              rejectInitialUserRequests.push(reject);
+            });
+          }
+
+          return Promise.resolve({
+            data: {
+              users: [],
+            },
+          });
+        }
+
+        return Promise.reject(new Error(`Unexpected request URL: ${requestConfig.url}`));
+      }),
+      defaults: {
+        headers: {
+          common: {},
+        },
+      },
+    };
+
+    const firstCall = client.callTool('getUsers', {});
+    const secondCall = client.callTool('getUsers', {});
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(rejectInitialUserRequests).toHaveLength(2);
+    rejectInitialUserRequests[0]({
+      isAxiosError: true,
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: {
+          error: 'invalid_token',
+        },
+      },
+    });
+    await expect(firstCall).resolves.toEqual({ users: [] });
+
+    expect(client.httpClient.defaults.headers.common.Authorization).toBe('Bearer fresh-token');
+    rejectInitialUserRequests[1]({
+      isAxiosError: true,
+      response: {
+        status: 401,
+        statusText: 'Unauthorized',
+        data: {
+          error: 'invalid_token',
+        },
+      },
+    });
+    await expect(secondCall).resolves.toEqual({ users: [] });
+
+    expect(tokenRequestCount).toBe(1);
+    expect(userRequestCount).toBe(4);
+    expect(observedAuthorizationHeaders).toEqual([
+      'Bearer stale-token',
+      'Bearer stale-token',
+      undefined,
+      'Bearer fresh-token',
+      'Bearer fresh-token',
+    ]);
+    expect(persistedOAuth2States).toHaveLength(2);
+    expect(persistedOAuth2States[0]).not.toHaveProperty('token');
+    expect(persistedOAuth2States[1]).toEqual(
       expect.objectContaining({
         token: 'fresh-token',
         expiresAt: expect.any(Number),

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -131,7 +131,12 @@ export class OpenAPIClient {
     return this.securityConfig?.type === 'oauth2' ? this.securityConfig.oauth2 : undefined;
   }
 
-  private invalidateRefreshableOAuth2Token(): boolean {
+  private getDefaultAuthorizationHeader(): string | undefined {
+    const authorization = this.httpClient.defaults?.headers?.common?.['Authorization'];
+    return typeof authorization === 'string' ? authorization : undefined;
+  }
+
+  private async invalidateRefreshableOAuth2Token(): Promise<boolean> {
     const oauth2 = this.getOAuth2Config();
     if (!oauth2?.tokenUrl || !oauth2.clientId) {
       return false;
@@ -145,6 +150,7 @@ export class OpenAPIClient {
     }
 
     this.setAuthorizationHeader(undefined);
+    await this.persistOAuth2Token?.({ ...oauth2 });
     return true;
   }
 
@@ -493,6 +499,7 @@ export class OpenAPIClient {
     }
 
     let attemptedUpstreamRequest = false;
+    let authorizationUsedForRequest: string | undefined;
 
     try {
       await this.ensureOAuth2AccessToken();
@@ -573,6 +580,7 @@ export class OpenAPIClient {
         });
       }
 
+      authorizationUsedForRequest = this.getDefaultAuthorizationHeader();
       attemptedUpstreamRequest = true;
       const response = await this.httpClient.request(requestConfig);
       return response.data;
@@ -582,7 +590,17 @@ export class OpenAPIClient {
           attemptedUpstreamRequest &&
           error.response?.status === 401 &&
           !hasRetriedAfterUnauthorized &&
-          this.invalidateRefreshableOAuth2Token()
+          authorizationUsedForRequest &&
+          authorizationUsedForRequest !== this.getDefaultAuthorizationHeader()
+        ) {
+          return this.callTool(toolName, args, passthroughHeaders, true);
+        }
+
+        if (
+          attemptedUpstreamRequest &&
+          error.response?.status === 401 &&
+          !hasRetriedAfterUnauthorized &&
+          (await this.invalidateRefreshableOAuth2Token())
         ) {
           return this.callTool(toolName, args, passthroughHeaders, true);
         }

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -4,6 +4,7 @@ import { OpenAPIV3 } from 'openapi-types';
 import { ServerConfig, OpenAPISecurityConfig } from '../types/index.js';
 import { assertSafeUrl } from '../utils/ssrf.js';
 import { getUserDao } from '../dao/index.js';
+import { sanitizeStringForLogging } from '../utils/serialization.js';
 
 export interface OpenAPIToolInfo {
   name: string;
@@ -128,6 +129,23 @@ export class OpenAPIClient {
 
   private getOAuth2Config(): OpenAPIOAuth2Config | undefined {
     return this.securityConfig?.type === 'oauth2' ? this.securityConfig.oauth2 : undefined;
+  }
+
+  private invalidateRefreshableOAuth2Token(): boolean {
+    const oauth2 = this.getOAuth2Config();
+    if (!oauth2?.tokenUrl || !oauth2.clientId) {
+      return false;
+    }
+
+    delete oauth2.token;
+    delete oauth2.expiresAt;
+
+    if (this.config.openapi?.security?.oauth2) {
+      this.config.openapi.security.oauth2 = oauth2;
+    }
+
+    this.setAuthorizationHeader(undefined);
+    return true;
   }
 
   private hasValidOAuth2Token(oauth2: OpenAPIOAuth2Config): boolean {
@@ -467,11 +485,14 @@ export class OpenAPIClient {
     toolName: string,
     args: Record<string, unknown>,
     passthroughHeaders?: Record<string, string>,
+    hasRetriedAfterUnauthorized = false,
   ): Promise<unknown> {
     const tool = this.tools.find((t) => t.name === toolName);
     if (!tool) {
       throw new Error(`Tool '${toolName}' not found`);
     }
+
+    let attemptedUpstreamRequest = false;
 
     try {
       await this.ensureOAuth2AccessToken();
@@ -552,10 +573,20 @@ export class OpenAPIClient {
         });
       }
 
+      attemptedUpstreamRequest = true;
       const response = await this.httpClient.request(requestConfig);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
+        if (
+          attemptedUpstreamRequest &&
+          error.response?.status === 401 &&
+          !hasRetriedAfterUnauthorized &&
+          this.invalidateRefreshableOAuth2Token()
+        ) {
+          return this.callTool(toolName, args, passthroughHeaders, true);
+        }
+
         const status = error.response?.status ?? 'unknown';
         const statusText = error.response?.statusText ?? 'Unknown Error';
         const responseData = error.response?.data;
@@ -573,6 +604,7 @@ export class OpenAPIClient {
           }
         }
 
+        responseDetails = sanitizeStringForLogging(responseDetails);
         throw new Error(
           `API call failed: ${status} ${statusText}${responseDetails ? ` ${responseDetails}` : ''}`,
         );

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -32,6 +32,26 @@ const SENSITIVE_LOG_KEY_NAMES = new Set([
 const SENSITIVE_INLINE_KEY_PATTERN =
   'access_token|refresh_token|id_token|client_secret|api_key|token|password|authorization|secret|error_description|error_uri|error_code';
 
+const AUTHORIZATION_CREDENTIAL_RE =
+  /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic)\s+)[^\s",;]+/gi;
+const BEARER_BASIC_CREDENTIAL_RE = /\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*/gi;
+const SENSITIVE_QUERY_PARAM_RE = new RegExp(
+  `([?&](?:${SENSITIVE_INLINE_KEY_PATTERN})=)[^&#\\s",;]+`,
+  'gi',
+);
+const SENSITIVE_EQUALS_RE = new RegExp(
+  `(\\b(?:${SENSITIVE_INLINE_KEY_PATTERN})\\s*[:=]\\s*)[^\\s",;]+`,
+  'gi',
+);
+const SENSITIVE_JSON_DOUBLE_QUOTE_RE = new RegExp(
+  `("(?:${SENSITIVE_INLINE_KEY_PATTERN})"\\s*:\\s*")([^"]*)(")`,
+  'gi',
+);
+const SENSITIVE_JSON_SINGLE_QUOTE_RE = new RegExp(
+  `('(?:${SENSITIVE_INLINE_KEY_PATTERN})'\\s*:\\s*')([^']*)(')`,
+  'gi',
+);
+
 const normalizeKey = (key: string): string => key.replace(/[^a-z0-9]/gi, '').toLowerCase();
 
 const isSensitiveLogKey = (key: string): boolean => {
@@ -53,30 +73,12 @@ const isSensitiveLogKey = (key: string): boolean => {
 export const sanitizeStringForLogging = (value: string): string => {
   let sanitized = value;
 
-  sanitized = sanitized.replace(
-    /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic)\s+)[^\s",;]+/gi,
-    `$1${REDACTED_VALUE}`,
-  );
-  sanitized = sanitized.replace(
-    /\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*/gi,
-    `$1 ${REDACTED_VALUE}`,
-  );
-  sanitized = sanitized.replace(
-    new RegExp(`([?&](?:${SENSITIVE_INLINE_KEY_PATTERN})=)[^&#\\s",;]+`, 'gi'),
-    `$1${REDACTED_VALUE}`,
-  );
-  sanitized = sanitized.replace(
-    new RegExp(`(\\b(?:${SENSITIVE_INLINE_KEY_PATTERN})\\s*[:=]\\s*)[^\\s",;]+`, 'gi'),
-    `$1${REDACTED_VALUE}`,
-  );
-  sanitized = sanitized.replace(
-    new RegExp(`("(?:${SENSITIVE_INLINE_KEY_PATTERN})"\\s*:\\s*")([^"]*)(")`, 'gi'),
-    `$1${REDACTED_VALUE}$3`,
-  );
-  sanitized = sanitized.replace(
-    new RegExp(`('(?:${SENSITIVE_INLINE_KEY_PATTERN})'\\s*:\\s*')([^']*)(')`, 'gi'),
-    `$1${REDACTED_VALUE}$3`,
-  );
+  sanitized = sanitized.replace(AUTHORIZATION_CREDENTIAL_RE, `$1${REDACTED_VALUE}`);
+  sanitized = sanitized.replace(BEARER_BASIC_CREDENTIAL_RE, `$1 ${REDACTED_VALUE}`);
+  sanitized = sanitized.replace(SENSITIVE_QUERY_PARAM_RE, `$1${REDACTED_VALUE}`);
+  sanitized = sanitized.replace(SENSITIVE_EQUALS_RE, `$1${REDACTED_VALUE}`);
+  sanitized = sanitized.replace(SENSITIVE_JSON_DOUBLE_QUOTE_RE, `$1${REDACTED_VALUE}$3`);
+  sanitized = sanitized.replace(SENSITIVE_JSON_SINGLE_QUOTE_RE, `$1${REDACTED_VALUE}$3`);
 
   return sanitized;
 };

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -24,7 +24,13 @@ const SENSITIVE_LOG_KEY_NAMES = new Set([
   'registrationaccesstoken',
   'privatekey',
   'assertion',
+  'errordescription',
+  'erroruri',
+  'errorcode',
 ]);
+
+const SENSITIVE_INLINE_KEY_PATTERN =
+  'access_token|refresh_token|id_token|client_secret|api_key|token|password|authorization|secret|error_description|error_uri|error_code';
 
 const normalizeKey = (key: string): string => key.replace(/[^a-z0-9]/gi, '').toLowerCase();
 
@@ -51,21 +57,24 @@ export const sanitizeStringForLogging = (value: string): string => {
     /((?:authorization|proxy-authorization)\s*[:=]\s*(?:bearer|basic)\s+)[^\s",;]+/gi,
     `$1${REDACTED_VALUE}`,
   );
-  sanitized = sanitized.replace(/\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*/gi, `$1 ${REDACTED_VALUE}`);
   sanitized = sanitized.replace(
-    /([?&](?:access_token|refresh_token|id_token|client_secret|api_key|token|password|authorization)=)[^&#\s"]+/gi,
+    /\b(Bearer|Basic)\s+[A-Za-z0-9\-._~+/]+=*/gi,
+    `$1 ${REDACTED_VALUE}`,
+  );
+  sanitized = sanitized.replace(
+    new RegExp(`([?&](?:${SENSITIVE_INLINE_KEY_PATTERN})=)[^&#\\s",;]+`, 'gi'),
     `$1${REDACTED_VALUE}`,
   );
   sanitized = sanitized.replace(
-    /(\b(?:access_token|refresh_token|id_token|client_secret|api_key|token|password|authorization|secret)\s*[:=]\s*)[^\s",;]+/gi,
+    new RegExp(`(\\b(?:${SENSITIVE_INLINE_KEY_PATTERN})\\s*[:=]\\s*)[^\\s",;]+`, 'gi'),
     `$1${REDACTED_VALUE}`,
   );
   sanitized = sanitized.replace(
-    /("(?:access_token|refresh_token|id_token|client_secret|api_key|authorization|token|password|secret)"\s*:\s*")([^"]*)(")/gi,
+    new RegExp(`("(?:${SENSITIVE_INLINE_KEY_PATTERN})"\\s*:\\s*")([^"]*)(")`, 'gi'),
     `$1${REDACTED_VALUE}$3`,
   );
   sanitized = sanitized.replace(
-    /('(?:access_token|refresh_token|id_token|client_secret|api_key|authorization|token|password|secret)'\s*:\s*')([^']*)(')/gi,
+    new RegExp(`('(?:${SENSITIVE_INLINE_KEY_PATTERN})'\\s*:\\s*')([^']*)(')`, 'gi'),
     `$1${REDACTED_VALUE}$3`,
   );
 
@@ -108,8 +117,7 @@ const serializeRemoteError = (error: Error): Record<string, unknown> => {
     name: error.name,
     message: REMOTE_ERROR_REDACTED_MESSAGE,
     code: candidate.code,
-    status:
-      typeof candidate.status === 'number' ? candidate.status : candidate.response?.status,
+    status: typeof candidate.status === 'number' ? candidate.status : candidate.response?.status,
     requestId: typeof requestId === 'string' ? requestId : undefined,
     hasResponseBody: candidate.response?.data !== undefined,
   };

--- a/tests/utils/serialization.test.ts
+++ b/tests/utils/serialization.test.ts
@@ -2,6 +2,7 @@ import {
   createSafeJSON,
   formatErrorForLogging,
   safeStringify,
+  sanitizeStringForLogging,
   summarizeErrorForLogging,
 } from '../../src/utils/serialization.js';
 
@@ -127,6 +128,22 @@ describe('serialization utilities', () => {
     expect(JSON.stringify(summary)).not.toContain('top-secret');
     expect(JSON.stringify(summary)).not.toContain('also-secret');
     expect(formatted).not.toContain('top-secret');
+  });
+
+  it('redacts OAuth error response fields that may carry tokens', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+    const rawJson = `{"error":"invalid_token","error_description":"expired ${jwt}","error_uri":"https://auth.example.com/debug?token=${jwt}","error_code":"${jwt}"}`;
+    const rawText = `error_description=expired-${jwt}; error_uri=https://auth.example.com/debug?token=${jwt}; error_code=${jwt}`;
+
+    expect(sanitizeStringForLogging(rawJson)).toBe(
+      '{"error":"invalid_token","error_description":"[REDACTED]","error_uri":"[REDACTED]","error_code":"[REDACTED]"}',
+    );
+    expect(sanitizeStringForLogging(rawText)).toBe(
+      'error_description=[REDACTED]; error_uri=[REDACTED]; error_code=[REDACTED]',
+    );
+    expect(safeStringify({ error_description: `expired ${jwt}` })).toBe(
+      '{"error_description":"[REDACTED]"}',
+    );
   });
 
   it('createSafeJSON keeps shared (diamond) references instead of dropping them as circular', () => {


### PR DESCRIPTION
## Summary

Fixes #955.

OpenAPI tools using OAuth2 client credentials now treat an upstream `401` as a stale cached token signal. MCPHub clears the in-memory OAuth2 token state, removes the stale Authorization header, fetches a fresh client-credentials token, and retries the original tool request once.

The OpenAPI error path also sanitizes upstream response details before surfacing them, and the shared serialization helper now redacts OAuth error fields such as `error_description`, `error_uri`, and `error_code` because those fields may contain bearer tokens or token-bearing debug URLs.

## Root cause

`OpenAPIClient.callTool` trusted the local `expiresAt` cache and did not react when the authorization server invalidated a token before that local timestamp. The same error path included raw upstream response bodies in the thrown error message, which could expose token material returned by OAuth servers.

## Validation

- `pnpm jest src/clients/__tests__/openapi-oauth2.test.ts src/clients/__tests__/openapi-error-handling.test.ts tests/utils/serialization.test.ts --runInBand`
- `pnpm lint && pnpm test:ci && pnpm build`

Note: this local environment required `pnpm approve-builds --all` for dependency build-script approval before running the broad gate; generated pnpm lock/workspace churn was reverted and is not part of this PR.