### PR TITLE
feat(activity): surface OAuth auth method in activity log API key field

### DIFF
--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -43,6 +43,14 @@ export const transports: {
 const SESSION_NOT_FOUND_CODE = -32001;
 const SESSION_NOT_FOUND_MESSAGE = 'Session not found. Please reinitialize the session.';
 
+/**
+ * Label recorded in the activity log's API key field when a request was
+ * authenticated via an OAuth bearer token (no static API key was presented).
+ * OAuth requests have no keyId/keyName of their own, so this surfaces the
+ * authentication method instead of leaving the field blank.
+ */
+const OAUTH_AUTH_METHOD_LABEL = 'OAuth';
+
 type RehydratableWebStandardTransport = {
   sessionId?: string;
   _initialized?: boolean;
@@ -374,7 +382,7 @@ const validateBearerAuth = async (req: Request): Promise<BearerAuthResult> => {
     const oauthUser = await resolveOAuthUserFromToken(token);
     if (oauthUser) {
       console.log('Recognized OAuth bearer token (auth disabled)');
-      return { valid: true, user: oauthUser };
+      return { valid: true, user: oauthUser, keyName: OAUTH_AUTH_METHOD_LABEL };
     }
 
     return { valid: true };
@@ -393,7 +401,7 @@ const validateBearerAuth = async (req: Request): Promise<BearerAuthResult> => {
     const oauthUser = await resolveOAuthUserFromToken(token);
     if (oauthUser) {
       console.log('Authenticated request using OAuth bearer token without configured keys');
-      return { valid: true, user: oauthUser };
+      return { valid: true, user: oauthUser, keyName: OAUTH_AUTH_METHOD_LABEL };
     }
 
     console.warn(
@@ -425,7 +433,7 @@ const validateBearerAuth = async (req: Request): Promise<BearerAuthResult> => {
   const oauthUser = await resolveOAuthUserFromToken(token);
   if (oauthUser) {
     console.log('Authenticated request using OAuth bearer token (no matching static key)');
-    return { valid: true, user: oauthUser };
+    return { valid: true, user: oauthUser, keyName: OAUTH_AUTH_METHOD_LABEL };
   }
 
   console.warn('Bearer authentication failed: token did not match any key or OAuth user');

--- a/tests/services/keepalive.test.ts
+++ b/tests/services/keepalive.test.ts
@@ -47,6 +47,7 @@ jest.mock('../../src/config/index.js', () => ({
 
 import { Request, Response } from 'express';
 import { handleSseConnection, transports } from '../../src/services/sseService.js';
+import { resolveOAuthUserFromToken } from '../../src/utils/oauthBearer.js';
 import * as mcpService from '../../src/services/mcpService.js';
 import * as configModule from '../../src/config/index.js';
 import * as daoIndex from '../../src/dao/index.js';
@@ -269,6 +270,43 @@ describe('Keepalive Functionality', () => {
       // This test verifies the pattern is set up correctly
       const intervalCount = intervals.length;
       expect(intervalCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('OAuth authentication activity logging', () => {
+    it('records OAuth as the API key name when authenticated via an OAuth bearer token', async () => {
+      // Enable bearer auth and present an OAuth bearer token with no static keys configured
+      const mockSystemConfigDao = {
+        get: jest.fn().mockResolvedValue({
+          routing: {
+            enableGlobalRoute: true,
+            enableGroupNameRoute: true,
+            enableBearerAuth: true,
+            bearerAuthKey: '',
+            skipAuth: false,
+          },
+        }),
+      };
+      (daoIndex.getSystemConfigDao as unknown as jest.Mock).mockReturnValue(mockSystemConfigDao);
+
+      const mockBearerKeyDao = {
+        findEnabled: jest.fn().mockResolvedValue([]),
+      };
+      (daoIndex.getBearerKeyDao as unknown as jest.Mock).mockReturnValue(mockBearerKeyDao);
+
+      (resolveOAuthUserFromToken as jest.Mock).mockResolvedValue({
+        username: 'oauth-user',
+        password: '',
+        isAdmin: false,
+      });
+
+      mockReq.headers = { authorization: 'Bearer a-valid-oauth-token' };
+
+      await handleSseConnection(mockReq as Request, mockRes as Response);
+
+      // The OAuth auth method should be surfaced in the API key field rather than blank
+      expect(transports['test-session-id'].keyName).toBe('OAuth');
+      expect(transports['test-session-id'].keyId).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## What & Why

Closes #885.

For OAuth-authenticated requests, the activity log's **API Key** column showed `—` even though the request was clearly authenticated. The issue asks that the OAuth auth method be surfaced there instead.

### Root cause

When a request is authenticated via an OAuth bearer token (`resolveOAuthUserFromToken` in `src/utils/oauthBearer.ts`), `validateBearerAuth` in `src/services/sseService.ts` returned `{ valid: true, user: oauthUser }` with **no** `keyId`/`keyName`. That flowed through `setBearerKeyContext` → `handleCallToolRequest` → `logToolCall` into an empty `key_name` column, which the frontend renders as `—`.

## Changes

- Added an `OAUTH_AUTH_METHOD_LABEL = 'OAuth'` constant in `sseService.ts` and returned it as `keyName` for all three OAuth resolution paths in `validateBearerAuth` (auth-disabled fallback, no configured keys, no matching static key).
- The label propagates through the existing pipeline with no schema/frontend/i18n changes: session context (`transports[sessionId].keyName`) → `setBearerKeyContext` → `logToolCall({ keyName })` → `key_name` column → activity table cell, detail modal, and the `keyNames` filter dropdown.
- Consistent with the existing `'system'` username fallback (`mcpService.ts:2350`), which also stores a non-key sentinel string in a key-related field.

## Tests

- Added a regression test in `tests/services/keepalive.test.ts` that drives `handleSseConnection` with an OAuth bearer token and asserts `transports[sessionId].keyName === 'OAuth'` (and `keyId` undefined).
- `tsc --noEmit` — clean
- `eslint` (changed files) — clean
- `jest` (services + middlewares + activityController) — 283 passing

## Notes for reviewer

- No DB migration is needed — `key_name` is an existing nullable `varchar` column (`src/db/entities/Activity.ts`).
- The REST API middleware's `validateBearerAuth` (`src/middlewares/auth.ts`) only runs for non-MCP routes and does not produce activity logs, so it is intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)