### PR TITLE
[codex] Fix remote keep-alive status updates

### DIFF
--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -102,7 +102,7 @@ const ServerForm = ({
     oauth: getInitialOAuthConfig(initialData),
     // KeepAlive configuration initialization
     keepAlive: {
-      enabled: initialData?.config?.enableKeepAlive || false,
+      enabled: initialData?.config?.enableKeepAlive === true,
       interval: initialData?.config?.keepAliveInterval || 60000,
     },
     // OpenAPI configuration initialization

--- a/frontend/src/utils/serverFormPayload.ts
+++ b/frontend/src/utils/serverFormPayload.ts
@@ -175,15 +175,15 @@ export const buildServerPayload = ({
     config.headers = headers;
     config.openapi = buildOpenApiConfig(formData);
   } else if (serverType === 'sse' || serverType === 'streamable-http') {
+    const keepAliveEnabled = formData.keepAlive?.enabled === true;
+
     config.url = formData.url.trim();
     config.env = env;
     config.headers = headers;
     config.passthroughHeaders = parseCommaSeparatedList(formData.passthroughHeaders);
     config.oauth = buildOAuthConfig(formData.oauth);
-    config.enableKeepAlive = formData.keepAlive?.enabled || false;
-    config.keepAliveInterval = formData.keepAlive?.enabled
-      ? formData.keepAlive.interval || 60000
-      : undefined;
+    config.enableKeepAlive = keepAliveEnabled;
+    config.keepAliveInterval = keepAliveEnabled ? formData.keepAlive?.interval || 60000 : undefined;
   } else {
     config.command = formData.command.trim();
     config.args = formData.args;

--- a/src/services/keepAliveService.ts
+++ b/src/services/keepAliveService.ts
@@ -40,23 +40,38 @@ export const setupClientKeepAlive = async (
 
   // Default interval: 60 seconds
   const interval = serverConfig.keepAliveInterval || 60000;
+  let isChecking = false;
+
+  const isHealthCheckCurrent = (activeClient: NonNullable<ServerInfo['client']>): boolean =>
+    serverInfo.client === activeClient &&
+    serverInfo.enabled !== false &&
+    serverInfo.status !== 'connecting' &&
+    serverInfo.status !== 'oauth_required';
 
   const checkRemoteHealth = async (): Promise<void> => {
+    const activeClient = serverInfo.client;
     if (
-      !serverInfo.client ||
+      !activeClient ||
       serverInfo.enabled === false ||
       serverInfo.status === 'connecting' ||
-      serverInfo.status === 'oauth_required'
+      serverInfo.status === 'oauth_required' ||
+      isChecking
     ) {
       return;
     }
 
+    isChecking = true;
+
     try {
       // Use client.ping() if available, otherwise fallback to listTools.
-      if (typeof (serverInfo.client as any).ping === 'function') {
-        await (serverInfo.client as any).ping({ ...(serverInfo.options || {}), timeout: 5000 });
+      if (typeof (activeClient as any).ping === 'function') {
+        await (activeClient as any).ping({ ...(serverInfo.options || {}), timeout: 5000 });
       } else {
-        await serverInfo.client.listTools({}, { ...(serverInfo.options || {}), timeout: 5000 });
+        await activeClient.listTools({}, { ...(serverInfo.options || {}), timeout: 5000 });
+      }
+
+      if (!isHealthCheckCurrent(activeClient)) {
+        return;
       }
 
       if (serverInfo.status !== 'connected') {
@@ -67,6 +82,10 @@ export const setupClientKeepAlive = async (
       serverInfo.status = 'connected';
       serverInfo.error = null;
     } catch (error) {
+      if (!isHealthCheckCurrent(activeClient)) {
+        return;
+      }
+
       const message = formatErrorForLogging(error);
       const nextError = `Keep-alive failed: ${message}`;
       if (serverInfo.status !== 'disconnected' || serverInfo.error !== nextError) {
@@ -74,6 +93,8 @@ export const setupClientKeepAlive = async (
       }
       serverInfo.status = 'disconnected';
       serverInfo.error = nextError;
+    } finally {
+      isChecking = false;
     }
   };
 

--- a/src/services/keepAliveService.ts
+++ b/src/services/keepAliveService.ts
@@ -41,8 +41,37 @@ export const setupClientKeepAlive = async (
   const interval = serverConfig.keepAliveInterval || 60000;
 
   const formatKeepAliveError = (error: unknown): string => {
+    const detailParts: string[] = [];
+    const appendDetail = (label: string, value: unknown): void => {
+      if (value === undefined || value === null || value === '') {
+        return;
+      }
+      const detail = `${label}: ${String(value)}`;
+      if (!detailParts.includes(detail)) {
+        detailParts.push(detail);
+      }
+    };
+
     if (error instanceof Error) {
-      return error.message;
+      const errorWithMetadata = error as Error & {
+        code?: unknown;
+        status?: unknown;
+        statusCode?: unknown;
+        response?: {
+          status?: unknown;
+          statusText?: unknown;
+        };
+      };
+
+      appendDetail('code', errorWithMetadata.code);
+      appendDetail('status', errorWithMetadata.status);
+      appendDetail('status', errorWithMetadata.statusCode);
+      appendDetail('status', errorWithMetadata.response?.status);
+      appendDetail('statusText', errorWithMetadata.response?.statusText);
+
+      return detailParts.length > 0
+        ? `${error.message} (${detailParts.join(', ')})`
+        : error.message;
     }
 
     return String(error);

--- a/src/services/keepAliveService.ts
+++ b/src/services/keepAliveService.ts
@@ -9,7 +9,7 @@ export interface KeepAliveOptions {
 
 /**
  * Set up keep-alive ping for MCP client connections (SSE or Streamable HTTP).
- * Keepalive is controlled per-server via `serverConfig.enableKeepAlive` (default off).
+ * Remote server health checks are opt-in because probes may count as upstream calls.
  */
 export const setupClientKeepAlive = async (
   serverInfo: ServerInfo,
@@ -40,22 +40,52 @@ export const setupClientKeepAlive = async (
   // Default interval: 60 seconds
   const interval = serverConfig.keepAliveInterval || 60000;
 
-  serverInfo.keepAliveIntervalId = setInterval(async () => {
-    try {
-      if (serverInfo.client && serverInfo.status === 'connected') {
-        // Use client.ping() if available, otherwise fallback to listTools
-        if (typeof (serverInfo.client as any).ping === 'function') {
-          await (serverInfo.client as any).ping();
-          console.log('Keep-alive ping successful', { serverName: serverInfo.name });
-        } else {
-          await serverInfo.client
-            .listTools({}, { ...(serverInfo.options || {}), timeout: 5000 })
-            .catch(() => void 0);
-        }
-      }
-    } catch (error) {
-      console.warn('Keep-alive ping failed', { serverName: serverInfo.name, error });
+  const formatKeepAliveError = (error: unknown): string => {
+    if (error instanceof Error) {
+      return error.message;
     }
+
+    return String(error);
+  };
+
+  const checkRemoteHealth = async (): Promise<void> => {
+    if (
+      !serverInfo.client ||
+      serverInfo.enabled === false ||
+      serverInfo.status === 'connecting' ||
+      serverInfo.status === 'oauth_required'
+    ) {
+      return;
+    }
+
+    try {
+      // Use client.ping() if available, otherwise fallback to listTools.
+      if (typeof (serverInfo.client as any).ping === 'function') {
+        await (serverInfo.client as any).ping({ ...(serverInfo.options || {}), timeout: 5000 });
+      } else {
+        await serverInfo.client.listTools({}, { ...(serverInfo.options || {}), timeout: 5000 });
+      }
+
+      if (serverInfo.status !== 'connected') {
+        console.log('Keep-alive ping restored server connection', {
+          serverName: serverInfo.name,
+        });
+      }
+      serverInfo.status = 'connected';
+      serverInfo.error = null;
+    } catch (error) {
+      const message = formatKeepAliveError(error);
+      const nextError = `Keep-alive failed: ${message}`;
+      if (serverInfo.status !== 'disconnected' || serverInfo.error !== nextError) {
+        console.warn('Keep-alive ping failed', { serverName: serverInfo.name, error });
+      }
+      serverInfo.status = 'disconnected';
+      serverInfo.error = nextError;
+    }
+  };
+
+  serverInfo.keepAliveIntervalId = setInterval(async () => {
+    await checkRemoteHealth();
   }, interval);
 
   console.log('Keep-alive enabled for server', {

--- a/src/services/keepAliveService.ts
+++ b/src/services/keepAliveService.ts
@@ -1,6 +1,7 @@
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { ServerInfo, ServerConfig } from '../types/index.js';
+import { formatErrorForLogging } from '../utils/serialization.js';
 
 export interface KeepAliveOptions {
   enabled?: boolean;
@@ -40,43 +41,6 @@ export const setupClientKeepAlive = async (
   // Default interval: 60 seconds
   const interval = serverConfig.keepAliveInterval || 60000;
 
-  const formatKeepAliveError = (error: unknown): string => {
-    const detailParts: string[] = [];
-    const appendDetail = (label: string, value: unknown): void => {
-      if (value === undefined || value === null || value === '') {
-        return;
-      }
-      const detail = `${label}: ${String(value)}`;
-      if (!detailParts.includes(detail)) {
-        detailParts.push(detail);
-      }
-    };
-
-    if (error instanceof Error) {
-      const errorWithMetadata = error as Error & {
-        code?: unknown;
-        status?: unknown;
-        statusCode?: unknown;
-        response?: {
-          status?: unknown;
-          statusText?: unknown;
-        };
-      };
-
-      appendDetail('code', errorWithMetadata.code);
-      appendDetail('status', errorWithMetadata.status);
-      appendDetail('status', errorWithMetadata.statusCode);
-      appendDetail('status', errorWithMetadata.response?.status);
-      appendDetail('statusText', errorWithMetadata.response?.statusText);
-
-      return detailParts.length > 0
-        ? `${error.message} (${detailParts.join(', ')})`
-        : error.message;
-    }
-
-    return String(error);
-  };
-
   const checkRemoteHealth = async (): Promise<void> => {
     if (
       !serverInfo.client ||
@@ -103,7 +67,7 @@ export const setupClientKeepAlive = async (
       serverInfo.status = 'connected';
       serverInfo.error = null;
     } catch (error) {
-      const message = formatKeepAliveError(error);
+      const message = formatErrorForLogging(error);
       const nextError = `Keep-alive failed: ${message}`;
       if (serverInfo.status !== 'disconnected' || serverInfo.error !== nextError) {
         console.warn('Keep-alive ping failed', { serverName: serverInfo.name, error });

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -146,11 +146,16 @@ const summarizeSerializedErrorForLogging = (
 ): Record<string, unknown> => {
   const summary: Record<string, unknown> = {};
 
-  ['name', 'message', 'stack', 'code', 'requestId'].forEach((key) => {
+  ['name', 'message', 'stack', 'requestId'].forEach((key) => {
     if (typeof serialized[key] === 'string') {
       summary[key] = sanitizeStringForLogging(serialized[key]);
     }
   });
+  if (typeof serialized.code === 'string') {
+    summary.code = sanitizeStringForLogging(serialized.code);
+  } else if (typeof serialized.code === 'number') {
+    summary.code = serialized.code;
+  }
   if (typeof serialized.status === 'number') {
     summary.status = serialized.status;
   }
@@ -182,6 +187,8 @@ export const summarizeErrorForLogging = (error: unknown): Record<string, unknown
     }
     if (typeof record.code === 'string') {
       summary.code = sanitizeStringForLogging(record.code);
+    } else if (typeof record.code === 'number') {
+      summary.code = record.code;
     }
     if (typeof record.status === 'number') {
       summary.status = record.status;
@@ -229,7 +236,7 @@ export const formatErrorForLogging = (error: unknown): string => {
   if (summary.status !== undefined) {
     parts.push(`status=${summary.status}`);
   }
-  if (typeof summary.code === 'string') {
+  if (typeof summary.code === 'string' || typeof summary.code === 'number') {
     parts.push(`code=${summary.code}`);
   }
   if (typeof summary.requestId === 'string') {

--- a/src/utils/serverConfigPersistence.ts
+++ b/src/utils/serverConfigPersistence.ts
@@ -194,6 +194,8 @@ export const normalizeServerConfigForPersistence = (config: ServerConfig): Serve
   }
 
   if (normalizedType === 'sse' || normalizedType === 'streamable-http') {
+    const keepAliveEnabled = config.enableKeepAlive === true;
+
     normalized.url = url;
     normalized.command = undefined;
     normalized.args = undefined;
@@ -201,9 +203,8 @@ export const normalizeServerConfigForPersistence = (config: ServerConfig): Serve
     normalized.headers = headers;
     normalized.passthroughHeaders = passthroughHeaders;
     normalized.oauth = oauth;
-    normalized.enableKeepAlive = config.enableKeepAlive === true;
-    normalized.keepAliveInterval =
-      config.enableKeepAlive === true ? config.keepAliveInterval || 60000 : undefined;
+    normalized.enableKeepAlive = keepAliveEnabled;
+    normalized.keepAliveInterval = keepAliveEnabled ? config.keepAliveInterval || 60000 : undefined;
     normalized.openapi = undefined;
     return normalized;
   }

--- a/tests/frontend/serverFormPayload.test.ts
+++ b/tests/frontend/serverFormPayload.test.ts
@@ -63,6 +63,42 @@ describe('buildServerPayload', () => {
     expect(payload.config).toHaveProperty('keepAliveInterval', undefined);
   });
 
+  it('keeps keep-alive disabled by default for remote server payloads', () => {
+    const payload = buildServerPayload({
+      formData: {
+        name: 'remote-server',
+        description: '',
+        url: 'https://example.com/mcp',
+        command: '',
+        arguments: '',
+        args: [],
+        env: [],
+        headers: [],
+        passthroughHeaders: '',
+        options: {},
+        oauth: {},
+        openapi: {
+          inputMode: 'url',
+          url: '',
+          schema: '',
+          version: '3.1.0',
+          securityType: 'none',
+          passthroughHeaders: '',
+        },
+      },
+      serverType: 'streamable-http',
+      envVars: [],
+      headerVars: [],
+    });
+
+    expect(payload.config).toMatchObject({
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: false,
+    });
+    expect(payload.config).toHaveProperty('keepAliveInterval', undefined);
+  });
+
   it('clears remote-only fields when switching to stdio', () => {
     const payload = buildServerPayload({
       formData: {

--- a/tests/services/keepAliveService.test.ts
+++ b/tests/services/keepAliveService.test.ts
@@ -52,6 +52,30 @@ describe('setupClientKeepAlive', () => {
     expect(serverInfo.error).toContain('connect ECONNREFUSED');
   });
 
+  it('includes HTTP error metadata in the displayed keep-alive error', async () => {
+    jest.useFakeTimers();
+    const error = Object.assign(
+      new Error('Streamable HTTP error: Error POSTing to endpoint: '),
+      { code: 502 },
+    );
+    const ping = jest.fn().mockRejectedValue(error);
+    const serverInfo = makeServerInfo(
+      new StreamableHTTPClientTransport(new URL('https://example.com/mcp')),
+      ping,
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+    });
+
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(serverInfo.error).toContain('Streamable HTTP error: Error POSTing to endpoint:');
+    expect(serverInfo.error).toContain('502');
+  });
+
   it('restores connected status when a later SSE health check succeeds', async () => {
     jest.useFakeTimers();
     const ping = jest.fn().mockResolvedValue({});

--- a/tests/services/keepAliveService.test.ts
+++ b/tests/services/keepAliveService.test.ts
@@ -1,0 +1,125 @@
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { setupClientKeepAlive } from '../../src/services/keepAliveService.js';
+import { ServerConfig, ServerInfo } from '../../src/types/index.js';
+
+const makeServerInfo = (
+  transport: ServerInfo['transport'],
+  ping: jest.Mock,
+  status: ServerInfo['status'] = 'connected',
+): ServerInfo =>
+  ({
+    name: 'remote-server',
+    status,
+    enabled: true,
+    error: null,
+    tools: [],
+    prompts: [],
+    resources: [],
+    createTime: Date.now(),
+    transport,
+    client: {
+      ping,
+    },
+    options: {},
+  }) as unknown as ServerInfo;
+
+describe('setupClientKeepAlive', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('marks failed streamable-http servers disconnected when keep-alive is enabled', async () => {
+    jest.useFakeTimers();
+    const ping = jest.fn().mockRejectedValue(new Error('connect ECONNREFUSED'));
+    const serverInfo = makeServerInfo(
+      new StreamableHTTPClientTransport(new URL('https://example.com/mcp')),
+      ping,
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+    });
+
+    expect(serverInfo.keepAliveIntervalId).toBeDefined();
+
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(serverInfo.status).toBe('disconnected');
+    expect(serverInfo.error).toContain('connect ECONNREFUSED');
+  });
+
+  it('restores connected status when a later SSE health check succeeds', async () => {
+    jest.useFakeTimers();
+    const ping = jest.fn().mockResolvedValue({});
+    const serverInfo = makeServerInfo(
+      new SSEClientTransport(new URL('https://example.com/sse')),
+      ping,
+      'disconnected',
+    );
+    serverInfo.error = 'Keep-alive failed: previous outage';
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      enableKeepAlive: true,
+    });
+
+    await jest.advanceTimersByTimeAsync(60000);
+
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(serverInfo.status).toBe('connected');
+    expect(serverInfo.error).toBeNull();
+  });
+
+  it('does not schedule checks when remote keep-alive is explicitly disabled', async () => {
+    jest.useFakeTimers();
+    const serverInfo = makeServerInfo(
+      new SSEClientTransport(new URL('https://example.com/sse')),
+      jest.fn(),
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      enableKeepAlive: false,
+    });
+
+    expect(serverInfo.keepAliveIntervalId).toBeUndefined();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('does not schedule checks for remote servers by default', async () => {
+    jest.useFakeTimers();
+    const serverInfo = makeServerInfo(
+      new StreamableHTTPClientTransport(new URL('https://example.com/mcp')),
+      jest.fn(),
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+    });
+
+    expect(serverInfo.keepAliveIntervalId).toBeUndefined();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it('does not schedule checks for stdio servers', async () => {
+    jest.useFakeTimers();
+    const serverInfo = makeServerInfo(undefined, jest.fn());
+    const serverConfig: ServerConfig = {
+      type: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+    };
+
+    await setupClientKeepAlive(serverInfo, serverConfig);
+
+    expect(serverInfo.keepAliveIntervalId).toBeUndefined();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/tests/services/keepAliveService.test.ts
+++ b/tests/services/keepAliveService.test.ts
@@ -24,6 +24,17 @@ const makeServerInfo = (
     options: {},
   }) as unknown as ServerInfo;
 
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
+
 describe('setupClientKeepAlive', () => {
   afterEach(() => {
     jest.useRealTimers();
@@ -74,6 +85,94 @@ describe('setupClientKeepAlive', () => {
 
     expect(serverInfo.error).toContain('Streamable HTTP error: Error POSTing to endpoint:');
     expect(serverInfo.error).toContain('502');
+  });
+
+  it('does not start a second remote health check while one is still running', async () => {
+    jest.useFakeTimers();
+    const deferred = createDeferred<unknown>();
+    const ping = jest.fn(() => deferred.promise);
+    const serverInfo = makeServerInfo(
+      new StreamableHTTPClientTransport(new URL('https://example.com/mcp')),
+      ping,
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+    });
+
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+
+    expect(ping).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({});
+    await jest.advanceTimersByTimeAsync(0);
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+
+    expect(ping).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores stale health check results after the client is cleared', async () => {
+    jest.useFakeTimers();
+    const deferred = createDeferred<unknown>();
+    const ping = jest.fn(() => deferred.promise);
+    const serverInfo = makeServerInfo(
+      new StreamableHTTPClientTransport(new URL('https://example.com/mcp')),
+      ping,
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+    });
+
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+
+    serverInfo.client = undefined;
+    serverInfo.status = 'disconnected';
+    serverInfo.error = 'Server disabled';
+
+    deferred.resolve({});
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(serverInfo.status).toBe('disconnected');
+    expect(serverInfo.error).toBe('Server disabled');
+  });
+
+  it('ignores stale health check failures after the client is cleared', async () => {
+    jest.useFakeTimers();
+    const deferred = createDeferred<unknown>();
+    const ping = jest.fn(() => deferred.promise);
+    const serverInfo = makeServerInfo(
+      new StreamableHTTPClientTransport(new URL('https://example.com/mcp')),
+      ping,
+    );
+
+    await setupClientKeepAlive(serverInfo, {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+    });
+
+    jest.advanceTimersByTime(60000);
+    await Promise.resolve();
+
+    serverInfo.client = undefined;
+    serverInfo.status = 'disconnected';
+    serverInfo.error = 'Server disabled';
+
+    deferred.reject(new Error('late keep-alive failure'));
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(serverInfo.status).toBe('disconnected');
+    expect(serverInfo.error).toBe('Server disabled');
   });
 
   it('restores connected status when a later SSE health check succeeds', async () => {

--- a/tests/utils/serialization.test.ts
+++ b/tests/utils/serialization.test.ts
@@ -109,6 +109,25 @@ describe('serialization utilities', () => {
     expect(formatted).not.toContain('top-secret');
   });
 
+  it('formatErrorForLogging includes numeric transport error codes', () => {
+    const error = Object.assign(
+      new Error('Streamable HTTP error: Error POSTing to endpoint: '),
+      { code: 502 },
+    );
+
+    const summary = summarizeErrorForLogging(error);
+    const formatted = formatErrorForLogging(error);
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        message: 'Streamable HTTP error: Error POSTing to endpoint: ',
+        code: 502,
+      }),
+    );
+    expect(formatted).toContain('Streamable HTTP error: Error POSTing to endpoint:');
+    expect(formatted).toContain('code=502');
+  });
+
   it('summarizeErrorForLogging redacts secrets from ordinary Error fields', () => {
     const error = Object.assign(new Error('oauth access_token=top-secret'), {
       code: 'E_OAUTH',

--- a/tests/utils/serverConfigPersistence.test.ts
+++ b/tests/utils/serverConfigPersistence.test.ts
@@ -1,6 +1,35 @@
 import { normalizeServerConfigForPersistence } from '../../src/utils/serverConfigPersistence.js';
 
 describe('normalizeServerConfigForPersistence', () => {
+  it('keeps remote keep-alive checks disabled by default', () => {
+    const normalized = normalizeServerConfigForPersistence({
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+    });
+
+    expect(normalized).toMatchObject({
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: false,
+    });
+    expect(normalized).toHaveProperty('keepAliveInterval', undefined);
+  });
+
+  it('preserves explicitly enabled remote keep-alive checks', () => {
+    const normalized = normalizeServerConfigForPersistence({
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+    });
+
+    expect(normalized).toMatchObject({
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      enableKeepAlive: true,
+      keepAliveInterval: 60000,
+    });
+  });
+
   it('clears empty remote collections while preserving explicit field presence for DB/JSON persistence', () => {
     const normalized = normalizeServerConfigForPersistence({
       type: 'sse',


### PR DESCRIPTION
## Summary

Fixes #392.

Remote SSE and Streamable HTTP servers now update their runtime status when an explicitly enabled keep-alive probe fails or later succeeds. Keep-alive probing remains opt-in: `enableKeepAlive` must be `true`, so upstream providers that bill by request are not pinged by default.

## Changes

- Mark remote servers `disconnected` and store a clear error when keep-alive ping/listTools health checks fail.
- Restore `connected` and clear the error after a later successful health check.
- Preserve add/import defaults as `enableKeepAlive: false`; only explicit true persists a keep-alive interval.
- Add regression coverage for keep-alive failure, recovery, default-off behavior, explicit opt-out, and payload/config normalization.

## Validation

- `corepack pnpm jest tests/services/keepAliveService.test.ts --runInBand`
- `corepack pnpm jest tests/utils/serverConfigPersistence.test.ts tests/frontend/serverFormPayload.test.ts tests/controllers/serverController.test.ts --runInBand`
- `corepack pnpm lint`
- `git diff --check`
- `corepack pnpm test:ci`
- `corepack pnpm build`