### PR TITLE
fix: remove pre-seeded admin credentials from shipped mcp_settings.json

### DIFF
--- a/mcp_settings.json
+++ b/mcp_settings.json
@@ -35,13 +35,7 @@
       }
     }
   },
-  "users": [
-    {
-      "username": "admin",
-      "password": "$2b$10$Vt7krIvjNgyN67LXqly0uOcTpN0LI55cYRbcKC71pUDAP0nJ7RPa.",
-      "isAdmin": true
-    }
-  ],
+  "users": [],
   "systemConfig": {
     "oauthServer": {
       "enabled": true,

--- a/tests/models/user-default-password.test.ts
+++ b/tests/models/user-default-password.test.ts
@@ -1,4 +1,6 @@
 import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
 
 // Mock the dao module before importing the module under test
 const mockCreateWithHashedPassword = jest.fn();
@@ -130,5 +132,15 @@ describe('initializeDefaultUser', () => {
 
     // Two random passwords should differ (probabilistically certain)
     expect(password1).not.toBe(password2);
+  });
+});
+
+describe('shipped mcp_settings.json', () => {
+  const settingsPath = path.resolve(__dirname, '../../mcp_settings.json');
+
+  it('does not ship a pre-seeded admin user (prevents default credentials in image)', () => {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(Array.isArray(settings.users)).toBe(true);
+    expect(settings.users.length).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- `mcp_settings.json` shipped an `admin` user with a bcrypt hash of `admin123`. `COPY . .` in the Dockerfile bakes it into the image at `/app/mcp_settings.json`, and since `.dockerignore` does not exclude it, every pulled `samanhappy/mcphub:latest` container starts with `admin/admin123` regardless of `ADMIN_PASSWORD`.
- Root cause: `initializeDefaultUser` ([src/models/User.ts](src/models/User.ts)) only seeds the admin user from `ADMIN_PASSWORD` when `users.length === 0`. The bundled row made that check fail, so the env var was silently ignored.
- Verified by running `bcrypt.compare('admin123', <shipped hash>)` → match.

## Fix

- Set `users: []` in `mcp_settings.json`. Default `mcpServers` / `systemConfig` / `bearerKeys` / `prompts` / `resources` are preserved — only the pre-seeded credentials are removed.
- Added a regression test asserting the shipped settings file contains no pre-seeded users.

## Test plan

- [x] `npx jest tests/models/user-default-password.test.ts` — 7/7 pass
- [ ] Rebuild image and confirm a fresh container honors `ADMIN_PASSWORD` (login fails with `admin123`, succeeds with the env-provided password)
- [ ] Confirm default MCP servers (amap/playwright/fetch/slack) still ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)