### PR TITLE
fix: i18n OAuth callback page and per-request language resolution

### DIFF
--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -38,53 +38,82 @@ const escapeHtml = (value: string): string =>
     .replace(/'/g, '&#39;');
 
 /**
- * Generate HTML response page with i18n support
+ * Generate HTML response page with i18n support.
+ *
+ * Styling mirrors the OAuth authorize consent page (oauthServerController) so the
+ * flow feels continuous for end users, and adapts to light/dark color schemes.
  */
 const generateHtmlResponse = (
+  t: (key: string) => string,
   type: 'error' | 'success',
   title: string,
   message: string,
   details?: { label: string; value: string }[],
   autoClose: boolean = false,
 ): string => {
-  const backgroundColor = type === 'error' ? '#fee' : '#efe';
-  const borderColor = type === 'error' ? '#fcc' : '#cfc';
-  const titleColor = type === 'error' ? '#c33' : '#3c3';
-  const buttonColor = type === 'error' ? '#c33' : '#3c3';
+  const isSuccess = type === 'success';
+  const accentColor = isSuccess ? '#16a34a' : '#dc2626';
+  const accentBgLight = isSuccess ? '#dcfce7' : '#fee2e2';
+  const accentBgDark = isSuccess ? '#14532d' : '#7f1d1d';
+  const icon = isSuccess ? '✓' : '⚠';
 
   const safeTitle = escapeHtml(title);
-  const safeMessage = escapeHtml(message);
+  // Render multi-line messages (joined with \n by callers) as line breaks.
+  const safeMessage = escapeHtml(message).replace(/\n/g, '<br />');
+  const closeButtonLabel = escapeHtml(
+    t(autoClose ? 'oauthCallback.closeNow' : 'oauthCallback.closeWindow'),
+  );
+  const autoCloseNotice = escapeHtml(t('oauthCallback.autoCloseMessage'));
 
   return `
     <!DOCTYPE html>
     <html>
       <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>${safeTitle}</title>
         <style>
-          body { font-family: Arial, sans-serif; max-width: 600px; margin: 50px auto; padding: 20px; }
-          .container { background-color: ${backgroundColor}; border: 1px solid ${borderColor}; padding: 20px; border-radius: 8px; }
-          h1 { color: ${titleColor}; margin-top: 0; }
-          .detail { margin-top: 10px; padding: 10px; background: #f9f9f9; border-radius: 4px; ${type === 'error' ? 'font-family: monospace; font-size: 12px; white-space: pre-wrap;' : ''} }
-          .close-btn { margin-top: 20px; padding: 10px 20px; background: ${buttonColor}; color: white; border: none; border-radius: 4px; cursor: pointer; }
+          :root { color-scheme: light dark; }
+          body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 560px; margin: 60px auto; padding: 24px; background: #f3f4f6; color: #111827; }
+          .container { background-color: #ffffff; border: 1px solid #e5e7eb; padding: 28px; border-radius: 12px; box-shadow: 0 10px 25px rgba(15, 23, 42, 0.12); }
+          h1 { margin-top: 0; font-size: 22px; display: flex; align-items: center; gap: 10px; color: #111827; }
+          h1 .icon { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; border-radius: 999px; background: ${accentBgLight}; color: ${accentColor}; font-size: 18px; font-weight: 700; }
+          p.message { color: #4b5563; font-size: 14px; line-height: 1.6; margin: 12px 0 0; }
+          .detail { margin-top: 12px; padding: 12px 14px; background: #f9fafb; border: 1px solid #f3f4f6; border-radius: 8px; font-size: 13px; color: #374151; }
+          .detail strong { color: #111827; }
+          .detail.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+          .autoclose { margin-top: 12px; color: #6b7280; font-size: 13px; }
+          .close-btn { margin-top: 24px; padding: 10px 20px; background: #2563eb; color: #ffffff; border: none; border-radius: 999px; cursor: pointer; font-size: 14px; font-weight: 500; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.35); transition: background-color 120ms ease, transform 60ms ease; }
+          .close-btn:hover { background: #1d4ed8; transform: translateY(-1px); }
+          @media (prefers-color-scheme: dark) {
+            body { background: #0f172a; color: #e5e7eb; }
+            .container { background-color: #1e293b; border-color: #334155; box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4); }
+            h1 { color: #f1f5f9; }
+            h1 .icon { background: ${accentBgDark}; }
+            p.message { color: #cbd5e1; }
+            .detail { background: #0f172a; border-color: #334155; color: #cbd5e1; }
+            .detail strong { color: #f1f5f9; }
+            .autoclose { color: #94a3b8; }
+          }
         </style>
         ${autoClose ? '<script>setTimeout(() => { window.close(); }, 3000);</script>' : ''}
       </head>
       <body>
         <div class="container">
-          <h1>${type === 'success' ? '✓ ' : ''}${safeTitle}</h1>
+          <h1><span class="icon">${icon}</span>${safeTitle}</h1>
           ${
             details
               ? details
                   .map(
                     (d) =>
-                      `<div class="detail"><strong>${escapeHtml(d.label)}:</strong> ${escapeHtml(d.value)}</div>`,
+                      `<div class="detail${type === 'error' ? ' mono' : ''}">${d.label ? `<strong>${escapeHtml(d.label)}:</strong> ` : ''}${escapeHtml(d.value)}</div>`,
                   )
                   .join('')
               : ''
           }
-          <p>${safeMessage}</p>
-          ${autoClose ? '<p>This window will close automatically in 3 seconds...</p>' : ''}
-          <button class="close-btn" onclick="window.close()">${autoClose ? 'Close Now' : 'Close Window'}</button>
+          ${message ? `<p class="message">${safeMessage}</p>` : ''}
+          ${autoClose ? `<p class="autoclose">${autoCloseNotice}</p>` : ''}
+          <button class="close-btn" onclick="window.close()">${closeButtonLabel}</button>
         </div>
       </body>
     </html>
@@ -155,7 +184,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         errorDescription: error_description || '',
       });
       return res.status(400).send(
-        generateHtmlResponse('error', t('oauthCallback.authorizationFailed'), '', [
+        generateHtmlResponse(t, 'error', t('oauthCallback.authorizationFailed'), '', [
           { label: t('oauthCallback.authorizationFailedError'), value: String(error) },
           ...(error_description
             ? [
@@ -176,6 +205,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         .status(400)
         .send(
           generateHtmlResponse(
+            t,
             'error',
             t('oauthCallback.invalidRequest'),
             t('oauthCallback.missingStateParameter'),
@@ -189,6 +219,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         .status(400)
         .send(
           generateHtmlResponse(
+            t,
             'error',
             t('oauthCallback.invalidRequest'),
             t('oauthCallback.missingCodeParameter'),
@@ -223,6 +254,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         .status(400)
         .send(
           generateHtmlResponse(
+            t,
             'error',
             t('oauthCallback.serverNotFound'),
             `${t('oauthCallback.serverNotFoundMessage')}\n${t('oauthCallback.sessionExpiredMessage')}`,
@@ -383,9 +415,10 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         // Return success page
         return res.status(200).send(
           generateHtmlResponse(
+            t,
             'success',
             t('oauthCallback.authorizationSuccessful'),
-            `${t('oauthCallback.successMessage')}\n${t('oauthCallback.autoCloseMessage')}`,
+            t('oauthCallback.successMessage'),
             [
               { label: t('oauthCallback.server'), value: serverInfo.name },
               { label: t('oauthCallback.status'), value: t('oauthCallback.connected') },
@@ -410,6 +443,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
           .status(500)
           .send(
             generateHtmlResponse(
+              t,
               'error',
               t('oauthCallback.connectionError'),
               `${t('oauthCallback.connectionErrorMessage')}\n${t('oauthCallback.reconnectMessage')}`,
@@ -424,6 +458,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         .status(500)
         .send(
           generateHtmlResponse(
+            t,
             'error',
             t('oauthCallback.configurationError'),
             t('oauthCallback.configurationErrorMessage'),
@@ -440,6 +475,7 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
       .status(500)
       .send(
         generateHtmlResponse(
+          t,
           'error',
           t('oauthCallback.internalError'),
           t('oauthCallback.internalErrorMessage'),

--- a/src/middlewares/i18n.ts
+++ b/src/middlewares/i18n.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { getT } from '../utils/i18n.js';
+import { getT, resolveLanguage } from '../utils/i18n.js';
 
 /**
  * i18n middleware to detect user language and attach translation function to request
@@ -19,22 +19,20 @@ export const i18nMiddleware = (req: Request, res: Response, next: NextFunction) 
   } else if (customLanguageHeader) {
     detectedLanguage = customLanguageHeader;
   } else if (acceptLanguage) {
-    // Parse accept-language header and get primary language
-    const primaryLanguage = acceptLanguage.split(',')[0].split('-')[0].trim();
+    // Parse accept-language header: keep the primary tag (with region code intact)
+    // so resolveLanguage can match a region-specific locale (e.g. zh-TW) when one
+    // ships, falling back to the base language otherwise.
+    const primaryLanguage = acceptLanguage.split(',')[0].split(';')[0].trim();
     detectedLanguage = primaryLanguage;
   }
 
-  // Normalize language code (ensure we support it)
-  const supportedLanguages = ['en', 'zh'];
-  if (!supportedLanguages.includes(detectedLanguage)) {
-    detectedLanguage = 'en'; // fallback to English
-  }
+  // Normalize to a supported language (exact match, then base language, then English)
+  const supportedLanguage = resolveLanguage(detectedLanguage);
+  (req as any).language = supportedLanguage;
 
-  // Set language in request (using any type to avoid TypeScript issues)
-  (req as any).language = detectedLanguage;
-
-  // Get translation function for the detected language
-  const t = getT(detectedLanguage);
+  // Get a per-request translation function bound to the detected language.
+  // getT uses getFixedT internally, so this never mutates the shared i18n instance.
+  const t = getT(supportedLanguage);
   (req as any).t = t;
 
   next();

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,6 +1,23 @@
 import i18n from 'i18next';
 import Backend from 'i18next-fs-backend';
 import path from 'path';
+import fs from 'fs';
+
+// Discover available languages from the locales directory so shipped translation
+// files are reachable without maintaining a hardcoded whitelist here.
+const localesDir = path.join(process.cwd(), 'locales');
+const discoverSupportedLanguages = (): string[] => {
+  try {
+    return fs
+      .readdirSync(localesDir)
+      .filter((file) => file.endsWith('.json'))
+      .map((file) => path.basename(file, '.json'));
+  } catch {
+    return ['en'];
+  }
+};
+
+const supportedLanguages = discoverSupportedLanguages();
 
 // Initialize i18n for backend
 const initI18n = async () => {
@@ -20,20 +37,42 @@ const initI18n = async () => {
     // Enable debug mode for development
     debug: false,
 
-    // Preload languages
-    preload: ['en', 'zh'],
+    // Preload all discovered languages
+    preload: supportedLanguages,
 
     // Use sync mode for server
     initImmediate: false,
   });
 };
 
-// Get translation function for a specific language
-export const getT = (language?: string) => {
-  if (language && language !== i18n.language) {
-    i18n.changeLanguage(language);
+// Resolve a language code to a supported language. Falls back to the base
+// language (e.g. zh-TW -> zh) when no region-specific locale file exists, and
+// finally to English. Exported so the middleware can normalize without duplicating
+// the whitelist or stripping region codes itself.
+export const resolveLanguage = (language?: string): string => {
+  if (!language) {
+    return 'en';
   }
-  return i18n.t.bind(i18n);
+
+  const normalized = language.trim();
+  if (supportedLanguages.includes(normalized)) {
+    return normalized;
+  }
+
+  const base = normalized.split('-')[0].toLowerCase();
+  if (base && supportedLanguages.includes(base)) {
+    return base;
+  }
+
+  return 'en';
+};
+
+// Get a translation function bound to a specific language. Uses getFixedT() so
+// concurrent requests with different languages do not race by mutating the
+// shared i18n instance's language.
+export const getT = (language?: string) => {
+  const resolved = resolveLanguage(language);
+  return i18n.getFixedT(resolved);
 };
 
 // Initialize and export

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -8,10 +8,13 @@ import fs from 'fs';
 const localesDir = path.join(process.cwd(), 'locales');
 const discoverSupportedLanguages = (): string[] => {
   try {
-    return fs
+    const languages = fs
       .readdirSync(localesDir)
       .filter((file) => file.endsWith('.json'))
       .map((file) => path.basename(file, '.json'));
+    // Fall back to English if the directory exists but has no locale files,
+    // so i18next preloading and resolution always have a usable language.
+    return languages.length > 0 ? languages : ['en'];
   } catch {
     return ['en'];
   }
@@ -45,23 +48,31 @@ const initI18n = async () => {
   });
 };
 
-// Resolve a language code to a supported language. Falls back to the base
-// language (e.g. zh-TW -> zh) when no region-specific locale file exists, and
-// finally to English. Exported so the middleware can normalize without duplicating
-// the whitelist or stripping region codes itself.
+// Resolve a language code to a supported language. Matching is case-insensitive
+// so client requests like `zh-tw` or `ZH-TW` resolve to a mixed-case locale file
+// such as `zh-TW.json`. Falls back to the base language (e.g. zh-TW -> zh) when
+// no region-specific locale file exists, and finally to English. Exported so
+// the middleware can normalize without duplicating the whitelist or stripping
+// region codes itself.
 export const resolveLanguage = (language?: string): string => {
   if (!language) {
     return 'en';
   }
 
-  const normalized = language.trim();
-  if (supportedLanguages.includes(normalized)) {
-    return normalized;
+  const normalized = language.trim().toLowerCase();
+  const exactMatch = supportedLanguages.find(
+    (lang) => lang.toLowerCase() === normalized,
+  );
+  if (exactMatch) {
+    return exactMatch;
   }
 
-  const base = normalized.split('-')[0].toLowerCase();
-  if (base && supportedLanguages.includes(base)) {
-    return base;
+  const base = normalized.split('-')[0];
+  const baseMatch = supportedLanguages.find(
+    (lang) => lang.toLowerCase() === base,
+  );
+  if (baseMatch) {
+    return baseMatch;
   }
 
   return 'en';


### PR DESCRIPTION
## Summary

Fixes #975 — the upstream OAuth callback result page rendered with mixed languages, duplicated hardcoded English strings, and a style inconsistent with the dashboard.

- **Hardcoded strings → `t()`**: the auto-close notice and the `Close Now` / `Close Window` button labels now go through `t()`. The duplicated hardcoded English auto-close notice is dropped (the `oauthCallback.autoCloseMessage` translation is now rendered exactly once via `t()` in the helper, and removed from the success message body).
- **Dead locale files reachable**: `supportedLanguages` is now derived from `locales/` instead of a hardcoded `['en', 'zh']`, so the shipped `fr.json` and `tr.json` are no longer unreachable. Region codes (e.g. `zh-TW`) fall back to the base language when no region-specific locale file exists, and a future `zh-TW.json` would be matched without code changes.
- **Race condition fixed**: `getT()` now uses `i18n.getFixedT(language)` per request instead of mutating the shared global instance via `changeLanguage()`, so concurrent requests with different languages no longer race.
- **Restyled**: the page now matches the `oauthServerController` authorize consent page (system font, card layout with shadow, blue primary button, icon badge) and is dark-mode aware via `@media (prefers-color-scheme: dark)`. Multi-line messages now render as `<br>` and charset/viewport meta tags were added.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:ci` — 882/882 pass
- [x] `pnpm build` (tsc + vite)
- [x] Manual: hit `/oauth/callback` (missing-state error path) on a running backend and verified rendered output
  - [x] English (default) — `Invalid Request` / `Missing required OAuth state parameter.` / `Close Window`
  - [x] `?lang=zh` — `无效请求` / `缺少必需的 OAuth 状态参数。` / `关闭窗口`
  - [x] `?lang=fr` — French now renders (previously a dead file): `Requête invalide` / `Fermer la fenêtre`
  - [x] `Accept-Language: zh-TW` — folds to `zh`, renders Chinese
  - [x] `?error=...&lang=zh` — error-details path renders translated labels with monospace detail blocks
- [ ] Reviewer: trigger a real upstream OAuth success flow end-to-end and confirm the success page shows the auto-close notice exactly once and auto-closes after 3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)