### PR TITLE
fix: preserve in-flight OAuth state on full reload

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1281,8 +1281,8 @@ export const initializeClientsFromSettings = async (
       const hasInflightOAuthAuthorization =
         existingServer?.status === 'oauth_required' &&
         Boolean(
-          expandedConf.oauth?.pendingAuthorization?.codeVerifier ||
-            existingServer.oauth?.codeVerifier,
+          expandedConf.oauth?.pendingAuthorization?.state ||
+            existingServer.oauth?.state,
         );
       if (
         existingServer &&

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1272,19 +1272,32 @@ export const initializeClientsFromSettings = async (
       //   status. Reloading one server must not reconnect unrelated servers
       //   (e.g. failed/disconnected ones), which would also leak their
       //   previous stdio child processes. See #921.
-      // - a general/full initialization (no serverName) — only preserve this
-      //   server's state if it is already connected.
+      // - a general/full initialization (no serverName) — preserve this
+      //   server's state if it is already connected, or if an OAuth
+      //   authorization is in flight. Reconnecting during PKCE authorization
+      //   would replace the pending code verifier and break the callback.
       const existingServer = existingServerInfos.find((s) => s.name === name);
       const isDifferentServer = Boolean(serverName) && serverName !== name;
+      const hasInflightOAuthAuthorization =
+        existingServer?.status === 'oauth_required' &&
+        Boolean(
+          expandedConf.oauth?.pendingAuthorization?.codeVerifier ||
+            existingServer.oauth?.codeVerifier,
+        );
       if (
         existingServer &&
-        (isDifferentServer || (!serverName && existingServer.status === 'connected'))
+        (isDifferentServer ||
+          (!serverName && (existingServer.status === 'connected' || hasInflightOAuthAuthorization)))
       ) {
         nextServerInfos.push({
           ...existingServer,
           enabled: expandedConf.enabled === undefined ? true : expandedConf.enabled,
         });
-        console.log(`Server '${name}' is already connected.`);
+        console.log(
+          hasInflightOAuthAuthorization
+            ? `Server '${name}' has an in-flight OAuth authorization; preserving existing state.`
+            : `Server '${name}' is already connected.`,
+        );
         continue;
       }
 

--- a/tests/services/mcpService-toggle.test.ts
+++ b/tests/services/mcpService-toggle.test.ts
@@ -99,11 +99,21 @@ jest.mock('../../src/services/activityLoggingService.js', () => ({
 }));
 
 // Import after mocks
-import { summarizeServerConnections, toggleServerStatus } from '../../src/services/mcpService.js';
+import {
+  getServerByName,
+  initializeClientsFromSettings,
+  setServerInfosForTest,
+  summarizeServerConnections,
+  toggleServerStatus,
+} from '../../src/services/mcpService.js';
 
 describe('mcpService toggleServerStatus', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setServerInfosForTest([]);
+    mockServerDao.findAll.mockResolvedValue([]);
+    mockServerDao.setEnabled.mockResolvedValue(true);
+    mockClientConnect.mockResolvedValue(undefined);
   });
 
   describe('when disabling a server', () => {
@@ -165,6 +175,66 @@ describe('mcpService toggleServerStatus', () => {
       expect(result.success).toBe(false);
       expect(result.message).toBe('Failed to toggle server status');
     });
+  });
+});
+
+describe('mcpService initializeClientsFromSettings OAuth authorization reuse', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setServerInfosForTest([]);
+    mockServerDao.findAll.mockResolvedValue([]);
+    mockClientConnect.mockResolvedValue(undefined);
+  });
+
+  it('does not reconnect a server with an in-flight OAuth authorization during full reload', async () => {
+    setServerInfosForTest([
+      {
+        name: 'notion',
+        status: 'oauth_required',
+        error: null,
+        tools: [],
+        prompts: [],
+        resources: [],
+        createTime: 123,
+        enabled: true,
+        oauth: {
+          authorizationUrl: 'https://auth.example/authorize?code_challenge=old',
+          state: 'state-1',
+          codeVerifier: 'verifier-1',
+        },
+      } as any,
+    ]);
+    mockServerDao.findAll.mockResolvedValueOnce([
+      {
+        name: 'notion',
+        enabled: true,
+        command: 'node',
+        args: ['server.js'],
+        oauth: {
+          pendingAuthorization: {
+            authorizationUrl: 'https://auth.example/authorize?code_challenge=old',
+            state: 'state-1',
+            codeVerifier: 'verifier-1',
+          },
+        },
+      },
+    ]);
+
+    const servers = await initializeClientsFromSettings(false);
+
+    expect(mockClientConnect).not.toHaveBeenCalled();
+    expect(servers).toHaveLength(1);
+    expect(servers[0]).toMatchObject({
+      name: 'notion',
+      status: 'oauth_required',
+      enabled: true,
+      oauth: {
+        authorizationUrl: 'https://auth.example/authorize?code_challenge=old',
+        state: 'state-1',
+        codeVerifier: 'verifier-1',
+      },
+    });
+    expect(getServerByName('notion')?.oauth?.codeVerifier).toBe('verifier-1');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #978.

- Preserve an existing `oauth_required` server during a full `initializeClientsFromSettings` reload when PKCE authorization is already in flight.
- Avoid reconnecting that server and regenerating the pending OAuth `codeVerifier`, which can break the callback with `Invalid PKCE code_verifier`.
- Add a regression test covering the full-reload path so `client.connect` is not called for the pending OAuth server.

## Root Cause

Full reloads only reused servers whose runtime status was `connected`. Servers in `oauth_required` were reconnected, and the SDK auth path could call `saveCodeVerifier()` again before the user returned from the provider callback. That overwrote the verifier for the original authorization URL.

## Validation

- `corepack pnpm lint`
- `corepack pnpm test:ci` (132 suites, 883 tests)
- `corepack pnpm build`
- `git diff --check`