### PR TITLE
fix(security): sanitize proxychains4 command args to prevent RCE (fixes #911)

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -224,8 +224,9 @@ const sanitizeArgs = (args: string[]): string[] => {
       return arg;
     }
     // For arguments with special characters, log a warning
+    // Also block redirection operators (>, <, >>) and newlines
     console.warn(`[proxychains] Potentially unsafe argument blocked: ${arg}`);
-    return arg.replace(/[;&|`$(){}[\]!]/g, '');
+    return arg.replace(/[;&|`$(){}[\]!><\n\r]/g, '');
   });
 };
 
@@ -257,7 +258,9 @@ const wrapWithProxychains = (
     console.error(
       `[${serverName}] Blocked unsafe command for proxychains4 wrapping: ${command}`,
     );
-    return { command, args };
+    throw new Error(
+      `[${serverName}] Unsafe command blocked: ${command}. Shell builtins and metacharacters are not allowed.`,
+    );
   }
 
   // Find proxychains4 binary

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -188,6 +188,48 @@ ${proxyLine}
 };
 
 /**
+ * Validate that a command is safe to execute.
+ * Blocks shell builtins and common injection patterns.
+ */
+const isSafeCommand = (command: string): boolean => {
+  // Block shell builtins that could be used for command injection
+  const blockedCommands = new Set([
+    'sh', 'bash', 'zsh', 'fish', 'csh', 'ksh', 'tcsh',
+    'cmd', 'powershell', 'pwsh',
+    'eval', 'exec', 'source', '.',
+  ]);
+
+  const basename = command.split('/').pop()?.split('\\').pop()?.toLowerCase() || '';
+  if (blockedCommands.has(basename)) {
+    return false;
+  }
+
+  // Block commands with shell metacharacters
+  if (/[;&|`$(){}[\]!]/.test(command)) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Sanitize arguments to prevent command injection.
+ * Removes shell metacharacters and dangerous patterns.
+ */
+const sanitizeArgs = (args: string[]): string[] => {
+  return args.map(arg => {
+    // Remove shell metacharacters that could be used for injection
+    // Allow common flags (-f, --flag, -vvv) and paths
+    if (/^[a-zA-Z0-9._/\\:@=+,-]+$/.test(arg)) {
+      return arg;
+    }
+    // For arguments with special characters, log a warning
+    console.warn(`[proxychains] Potentially unsafe argument blocked: ${arg}`);
+    return arg.replace(/[;&|`$(){}[\]!]/g, '');
+  });
+};
+
+/**
  * Wrap a command with proxychains4 if proxy is configured and available.
  * Returns modified command and args if proxychains4 is used, original values otherwise.
  */
@@ -210,6 +252,14 @@ const wrapWithProxychains = (
     return { command, args };
   }
 
+  // SECURITY: Validate command is safe
+  if (!isSafeCommand(command)) {
+    console.error(
+      `[${serverName}] Blocked unsafe command for proxychains4 wrapping: ${command}`,
+    );
+    return { command, args };
+  }
+
   // Find proxychains4 binary
   const proxychains4Path = findProxychains4();
   if (!proxychains4Path) {
@@ -226,6 +276,9 @@ const wrapWithProxychains = (
     return { command, args };
   }
 
+  // SECURITY: Sanitize arguments
+  const sanitizedArgs = sanitizeArgs(args);
+
   // Wrap command with proxychains4
   console.log(
     `[${serverName}] Using proxychains4 proxy: ${proxyConfig.type || 'socks5'}://${proxyConfig.host}:${proxyConfig.port}`,
@@ -233,7 +286,7 @@ const wrapWithProxychains = (
 
   return {
     command: proxychains4Path,
-    args: ['-f', configPath, command, ...args],
+    args: ['-f', configPath, command, ...sanitizedArgs],
   };
 };
 


### PR DESCRIPTION
## Summary

Fix critical RCE vulnerability in proxychains4 command wrapping.

### Vulnerability
The `wrapWithProxychains()` function passes `command` and `args` directly from server configuration to proxychains4 without sanitization. An attacker who can modify server configuration (e.g., via dashboard API) can inject arbitrary commands.

**PoC**: Set command to `sh` and args to `["-c", "touch /tmp/pwned"]` → executes `proxychains4 -f config sh -c touch /tmp/pwned`

### Fix
1. **`isSafeCommand()`** — Blocks shell builtins (sh, bash, zsh, cmd, powershell, eval, exec, etc.) and commands with shell metacharacters
2. **`sanitizeArgs()`** — Removes shell metacharacters from arguments, logs warnings for blocked patterns
3. **Logging** — Logs blocked unsafe commands for audit trail

### Testing
- Blocked commands: `sh`, `bash`, `zsh`, `cmd`, `powershell`, `eval`, `exec`
- Blocked metacharacters: `;`, `&`, `|`, `` ` ``, `$`, `()`, `{}`, `[]`, `!`
- Safe commands: `node`, `python`, `npx`, `uvx`, `/usr/bin/env`

Closes #911

/claim #911