### PR TITLE
fix: recover stale PostgreSQL connections

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -100,9 +100,9 @@ useDatabase = (USE_DB === 'true') OR (USE_DB unset AND DB_URL is set)
 | `USE_DAO_LAYER` | unset | Force the DAO layer on even in file mode (advanced; usually unnecessary). |
 | `DB_POOL_SIZE` | `10` | Maximum TypeORM connection pool size. |
 | `DB_POOL_IDLE_TIMEOUT` | `30000` | Idle pool connection timeout (ms). |
-| `DB_CONNECTION_TIMEOUT` | `30000` | Initial connect timeout (ms). |
-| `DB_CONNECTION_RETRY_DELAY` | `2000` | Base delay between connection retries (ms). |
-| `DB_MAX_CONNECTION_RETRIES` | `5` | Maximum connection retry attempts at startup. |
+| `DB_CONNECTION_TIMEOUT` | `60000` | Initial connect timeout (ms). |
+| `DB_CONNECTION_RETRY_DELAY` | `3000` | Base delay between automatic reconnection attempts (ms). |
+| `DB_MAX_CONNECTION_RETRIES` | `5` | Maximum automatic reconnection attempts. |
 | `DB_ENABLE_HEALTH_CHECK` | `true` | Run periodic DB health probes (consumed by `/health`). |
 | `DB_HEALTH_CHECK_INTERVAL` | `30000` | Health-probe interval (ms). |
 

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -1,0 +1,128 @@
+import { ConnectionIsNotSetError, TypeORMError } from 'typeorm';
+
+const dataSources: Array<{
+  options: Record<string, unknown>;
+  isInitialized: boolean;
+  initialize: jest.Mock;
+  destroy: jest.Mock;
+  query: jest.Mock;
+}> = [];
+
+jest.mock('typeorm', () => {
+  const actual = jest.requireActual<typeof import('typeorm')>('typeorm');
+
+  return {
+    ...actual,
+    DataSource: jest.fn().mockImplementation((options: Record<string, unknown>) => {
+      const dataSource = {
+        options,
+        isInitialized: false,
+        initialize: jest.fn(async function (this: { isInitialized: boolean }) {
+          if (this.isInitialized) {
+            throw new Error('Cannot connect because the DataSource is already initialized');
+          }
+          this.isInitialized = true;
+          return this;
+        }),
+        destroy: jest.fn(async function (this: { isInitialized: boolean }) {
+          this.isInitialized = false;
+        }),
+        query: jest.fn(async () => []),
+      };
+      dataSources.push(dataSource);
+      return dataSource;
+    }),
+  };
+});
+
+const getSmartRoutingConfigMock = jest.fn(async () => ({
+  dbUrl: 'postgresql://mcphub:test@postgres:5432/mcphub',
+}));
+
+jest.mock('../utils/smartRouting.js', () => ({
+  getSmartRoutingConfig: getSmartRoutingConfigMock,
+}));
+
+jest.mock('../services/vectorSearchService.js', () => ({
+  createVectorIndex: jest.fn(async () => ({ success: true })),
+}));
+
+jest.mock('./types/postgresVectorType.js', () => ({
+  registerPostgresVectorType: jest.fn(),
+}));
+
+import {
+  checkDatabaseHealth,
+  closeDatabase,
+  reconnectDatabase,
+  stopHealthCheck,
+  updateDataSourceConfig,
+} from './connection.js';
+
+describe('database connection recovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    stopHealthCheck();
+    await closeDatabase();
+  });
+
+  it('reuses the existing configuration when recovering an uninitialized or disconnected driver', async () => {
+    const dataSource = await updateDataSourceConfig();
+
+    await expect(checkDatabaseHealth()).resolves.toBe(true);
+    expect(dataSource.initialize).toHaveBeenCalledTimes(1);
+
+    dataSource.query.mockRejectedValueOnce(new TypeORMError('Driver not Connected'));
+
+    await expect(checkDatabaseHealth()).resolves.toBe(true);
+    expect(dataSource.destroy).toHaveBeenCalledTimes(1);
+    expect(dataSource.initialize).toHaveBeenCalledTimes(2);
+    expect(getSmartRoutingConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares one reconnection attempt between concurrent callers', async () => {
+    const dataSource = await updateDataSourceConfig();
+    let finishInitialization!: () => void;
+    dataSource.initialize.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishInitialization = () => {
+            dataSource.isInitialized = true;
+            resolve(dataSource);
+          };
+        }),
+    );
+
+    const firstReconnect = reconnectDatabase();
+    const secondReconnect = reconnectDatabase();
+
+    expect(dataSource.initialize).toHaveBeenCalledTimes(1);
+    finishInitialization();
+
+    await expect(Promise.all([firstReconnect, secondReconnect])).resolves.toEqual([
+      dataSource,
+      dataSource,
+    ]);
+    expect(dataSource.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers when the driver pool is gone but TypeORM still reports the DataSource as initialized', async () => {
+    jest.useFakeTimers();
+    const dataSource = await updateDataSourceConfig();
+    dataSource.isInitialized = true;
+    dataSource.destroy.mockRejectedValueOnce(new ConnectionIsNotSetError('postgres'));
+
+    try {
+      const recovery = reconnectDatabase();
+      await jest.runAllTimersAsync();
+
+      await expect(recovery).resolves.toBe(dataSource);
+      expect(dataSource.initialize).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/db/connection.test.ts
+++ b/src/db/connection.test.ts
@@ -54,10 +54,14 @@ jest.mock('./types/postgresVectorType.js', () => ({
 import {
   checkDatabaseHealth,
   closeDatabase,
+  initializeDatabase,
   reconnectDatabase,
   stopHealthCheck,
   updateDataSourceConfig,
 } from './connection.js';
+import { registerPostgresVectorType } from './types/postgresVectorType.js';
+
+const registerPostgresVectorTypeMock = jest.mocked(registerPostgresVectorType);
 
 describe('database connection recovery', () => {
   beforeEach(() => {
@@ -83,7 +87,7 @@ describe('database connection recovery', () => {
     expect(getSmartRoutingConfigMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shares one reconnection attempt between concurrent callers', async () => {
+  it('shares one reconnection attempt with concurrent initialization callers', async () => {
     const dataSource = await updateDataSourceConfig();
     let finishInitialization!: () => void;
     dataSource.initialize.mockImplementationOnce(
@@ -98,15 +102,36 @@ describe('database connection recovery', () => {
 
     const firstReconnect = reconnectDatabase();
     const secondReconnect = reconnectDatabase();
+    const concurrentInitialization = initializeDatabase();
 
-    expect(dataSource.initialize).toHaveBeenCalledTimes(1);
+    await new Promise((resolve) => setImmediate(resolve));
+    const initializationCallsBeforeRelease = dataSource.initialize.mock.calls.length;
     finishInitialization();
 
-    await expect(Promise.all([firstReconnect, secondReconnect])).resolves.toEqual([
-      dataSource,
-      dataSource,
-    ]);
+    await expect(
+      Promise.all([firstReconnect, secondReconnect, concurrentInitialization]),
+    ).resolves.toEqual([dataSource, dataSource, dataSource]);
+    expect(initializationCallsBeforeRelease).toBe(1);
     expect(dataSource.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up an initialized connection when post-initialization setup fails', async () => {
+    jest.useFakeTimers();
+    const dataSource = await updateDataSourceConfig();
+    registerPostgresVectorTypeMock.mockImplementationOnce(() => {
+      throw new Error('vector type registration failed');
+    });
+
+    try {
+      const recovery = reconnectDatabase();
+      await jest.runAllTimersAsync();
+
+      await expect(recovery).resolves.toBe(dataSource);
+      expect(dataSource.initialize).toHaveBeenCalledTimes(2);
+      expect(dataSource.destroy).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('recovers when the driver pool is gone but TypeORM still reports the DataSource as initialized', async () => {

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -14,7 +14,7 @@ const CONNECTION_CONFIG = {
   poolIdleTimeout: parseInt(process.env.DB_POOL_IDLE_TIMEOUT || '30000', 10), // 30 seconds
   connectionTimeout: parseInt(process.env.DB_CONNECTION_TIMEOUT || '60000', 10), // 60 seconds
 
-  // Retry settings for initial connection
+  // Automatic reconnection settings
   maxConnectionRetries: parseInt(process.env.DB_MAX_CONNECTION_RETRIES || '5', 10),
   connectionRetryDelayMs: parseInt(process.env.DB_CONNECTION_RETRY_DELAY || '3000', 10),
 
@@ -28,6 +28,7 @@ let healthCheckInterval: NodeJS.Timeout | null = null;
 let isHealthy = false;
 let lastHealthCheckError: Error | null = null;
 let reconnectionInProgress = false;
+let reconnectionPromise: Promise<DataSource> | null = null;
 
 // Helper function to create required PostgreSQL extensions
 const createRequiredExtensions = async (dataSource: DataSource): Promise<void> => {
@@ -141,21 +142,10 @@ export const getAppDataSource = (): DataSource => {
   return appDataSource;
 };
 
-// Reconnect database with updated configuration
+// Reconnect the database using the current DataSource configuration
 export const reconnectDatabase = async (): Promise<DataSource> => {
   try {
-    // Close existing connection if it exists
-    if (appDataSource && appDataSource.isInitialized) {
-      console.log('Closing existing database connection...');
-      await appDataSource.destroy();
-    }
-
-    // Reset initialization promise to allow fresh initialization
-    initializationPromise = null;
-
-    // Update configuration and reconnect
-    appDataSource = await updateDataSourceConfig();
-    return await initializeDatabase();
+    return await attemptReconnection();
   } catch (error) {
     console.error('Error during database reconnection:', error);
     throw error;
@@ -424,10 +414,25 @@ export const getDatabaseHealth = (): {
 
 // Perform a health check on the database connection
 export const checkDatabaseHealth = async (): Promise<boolean> => {
-  if (!appDataSource || !appDataSource.isInitialized) {
+  if (!appDataSource) {
     isHealthy = false;
     lastHealthCheckError = new Error('Database not initialized');
     return false;
+  }
+
+  if (!appDataSource.isInitialized) {
+    isHealthy = false;
+    lastHealthCheckError = new Error('Database not initialized');
+    console.log('[DB Health] DataSource is disconnected, attempting reconnection...');
+
+    try {
+      await attemptReconnection();
+      return true;
+    } catch (error) {
+      lastHealthCheckError = error instanceof Error ? error : new Error(String(error));
+      console.error('[DB Health] Reconnection attempt failed:', lastHealthCheckError.message);
+      return false;
+    }
   }
 
   try {
@@ -442,11 +447,16 @@ export const checkDatabaseHealth = async (): Promise<boolean> => {
     console.warn('[DB Health] Health check failed:', lastHealthCheckError.message);
 
     // If it's a retryable error, attempt reconnection
-    if (isRetryableDbError(error) && !reconnectionInProgress) {
+    if (isRetryableDbError(error)) {
       console.log('[DB Health] Detected connection issue, attempting reconnection...');
-      attemptReconnection().catch((err) => {
-        console.error('[DB Health] Reconnection attempt failed:', err.message);
-      });
+      try {
+        await attemptReconnection();
+        return true;
+      } catch (reconnectError) {
+        lastHealthCheckError =
+          reconnectError instanceof Error ? reconnectError : new Error(String(reconnectError));
+        console.error('[DB Health] Reconnection attempt failed:', lastHealthCheckError.message);
+      }
     }
 
     return false;
@@ -481,64 +491,79 @@ export const stopHealthCheck = (): void => {
 };
 
 // Attempt to reconnect to the database with retries
-const attemptReconnection = async (): Promise<void> => {
-  if (reconnectionInProgress) {
-    console.log('[DB Reconnect] Reconnection already in progress, skipping...');
-    return;
+const attemptReconnection = (): Promise<DataSource> => {
+  if (reconnectionPromise) {
+    console.log('[DB Reconnect] Reconnection already in progress, waiting...');
+    return reconnectionPromise;
   }
 
-  reconnectionInProgress = true;
-  console.log('[DB Reconnect] Starting reconnection attempt...');
+  reconnectionPromise = (async () => {
+    reconnectionInProgress = true;
+    console.log('[DB Reconnect] Starting reconnection attempt...');
 
-  try {
-    // Close existing connection if it exists
-    if (appDataSource && appDataSource.isInitialized) {
-      try {
-        console.log('[DB Reconnect] Closing existing connection...');
-        await appDataSource.destroy();
-      } catch (closeError: any) {
-        console.warn('[DB Reconnect] Error closing connection:', closeError.message);
+    try {
+      if (!appDataSource) {
+        return await initializeDatabase();
       }
-    }
 
-    // Reset state
-    initializationPromise = null;
+      const dataSource = appDataSource;
 
-    // Retry connection with exponential backoff
-    let lastError: Error | null = null;
-    for (let attempt = 1; attempt <= CONNECTION_CONFIG.maxConnectionRetries; attempt++) {
-      try {
-        console.log(
-          `[DB Reconnect] Connection attempt ${attempt}/${CONNECTION_CONFIG.maxConnectionRetries}...`,
-        );
-
-        appDataSource = await updateDataSourceConfig();
-        await performDatabaseInitialization();
-
-        console.log('[DB Reconnect] Successfully reconnected to database');
-        isHealthy = true;
-        lastHealthCheckError = null;
-        return;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-        console.warn(`[DB Reconnect] Attempt ${attempt} failed: ${lastError.message}`);
-
-        if (attempt < CONNECTION_CONFIG.maxConnectionRetries) {
-          const delay = CONNECTION_CONFIG.connectionRetryDelayMs * Math.pow(2, attempt - 1);
-          console.log(`[DB Reconnect] Waiting ${delay}ms before next attempt...`);
-          await new Promise((resolve) => setTimeout(resolve, delay));
+      if (dataSource.isInitialized) {
+        try {
+          console.log('[DB Reconnect] Closing existing connection...');
+          await dataSource.destroy();
+        } catch (closeError: any) {
+          console.warn('[DB Reconnect] Error closing connection:', closeError.message);
+          // TypeORM only clears this flag after driver.disconnect() succeeds.
+          // If the driver pool is already gone, destroy() throws first and leaves
+          // the DataSource incorrectly marked as initialized.
+          Object.assign(dataSource, { isInitialized: false });
         }
       }
-    }
 
-    // All retries exhausted
-    console.error(
-      `[DB Reconnect] Failed to reconnect after ${CONNECTION_CONFIG.maxConnectionRetries} attempts`,
-    );
-    lastHealthCheckError = lastError;
-  } finally {
-    reconnectionInProgress = false;
-  }
+      // Reuse the existing DataSource options. Resolving the URL through the
+      // database-backed system config is impossible while that database is down.
+      initializationPromise = null;
+
+      let lastError: Error | null = null;
+      for (let attempt = 1; attempt <= CONNECTION_CONFIG.maxConnectionRetries; attempt++) {
+        try {
+          console.log(
+            `[DB Reconnect] Connection attempt ${attempt}/${CONNECTION_CONFIG.maxConnectionRetries}...`,
+          );
+
+          await dataSource.initialize();
+          registerPostgresVectorType(dataSource);
+          appDataSource = dataSource;
+
+          console.log('[DB Reconnect] Successfully reconnected to database');
+          isHealthy = true;
+          lastHealthCheckError = null;
+          return dataSource;
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+          console.warn(`[DB Reconnect] Attempt ${attempt} failed: ${lastError.message}`);
+
+          if (attempt < CONNECTION_CONFIG.maxConnectionRetries) {
+            const delay = CONNECTION_CONFIG.connectionRetryDelayMs * Math.pow(2, attempt - 1);
+            console.log(`[DB Reconnect] Waiting ${delay}ms before next attempt...`);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+        }
+      }
+
+      console.error(
+        `[DB Reconnect] Failed to reconnect after ${CONNECTION_CONFIG.maxConnectionRetries} attempts`,
+      );
+      lastHealthCheckError = lastError;
+      throw lastError || new Error('Database reconnection failed');
+    } finally {
+      reconnectionInProgress = false;
+      reconnectionPromise = null;
+    }
+  })();
+
+  return reconnectionPromise;
 };
 
 // Close database connection

--- a/src/db/connection.ts
+++ b/src/db/connection.ts
@@ -497,7 +497,7 @@ const attemptReconnection = (): Promise<DataSource> => {
     return reconnectionPromise;
   }
 
-  reconnectionPromise = (async () => {
+  const promise = (async () => {
     reconnectionInProgress = true;
     console.log('[DB Reconnect] Starting reconnection attempt...');
 
@@ -521,10 +521,6 @@ const attemptReconnection = (): Promise<DataSource> => {
         }
       }
 
-      // Reuse the existing DataSource options. Resolving the URL through the
-      // database-backed system config is impossible while that database is down.
-      initializationPromise = null;
-
       let lastError: Error | null = null;
       for (let attempt = 1; attempt <= CONNECTION_CONFIG.maxConnectionRetries; attempt++) {
         try {
@@ -544,6 +540,18 @@ const attemptReconnection = (): Promise<DataSource> => {
           lastError = error instanceof Error ? error : new Error(String(error));
           console.warn(`[DB Reconnect] Attempt ${attempt} failed: ${lastError.message}`);
 
+          if (dataSource.isInitialized) {
+            try {
+              await dataSource.destroy();
+            } catch (destroyError: any) {
+              console.warn(
+                '[DB Reconnect] Error cleaning up partially initialized connection:',
+                destroyError.message,
+              );
+              Object.assign(dataSource, { isInitialized: false });
+            }
+          }
+
           if (attempt < CONNECTION_CONFIG.maxConnectionRetries) {
             const delay = CONNECTION_CONFIG.connectionRetryDelayMs * Math.pow(2, attempt - 1);
             console.log(`[DB Reconnect] Waiting ${delay}ms before next attempt...`);
@@ -560,10 +568,17 @@ const attemptReconnection = (): Promise<DataSource> => {
     } finally {
       reconnectionInProgress = false;
       reconnectionPromise = null;
+      initializationPromise = null;
     }
   })();
 
-  return reconnectionPromise;
+  // Reuse the existing DataSource options. Resolving the URL through the
+  // database-backed system config is impossible while that database is down.
+  // Initialization callers must wait for the same reconnection attempt.
+  reconnectionPromise = promise;
+  initializationPromise = promise;
+
+  return promise;
 };
 
 // Close database connection

--- a/src/db/repositories/SystemConfigRepository.test.ts
+++ b/src/db/repositories/SystemConfigRepository.test.ts
@@ -1,0 +1,59 @@
+import { TypeORMError } from 'typeorm';
+import { SystemConfig } from '../entities/SystemConfig.js';
+
+const disconnectedRepository = {
+  findOne: jest.fn<() => Promise<SystemConfig | null>>(),
+};
+const reconnectedRepository = {
+  findOne: jest.fn<() => Promise<SystemConfig | null>>(),
+};
+
+let activeRepository: typeof disconnectedRepository | typeof reconnectedRepository;
+
+const getAppDataSourceMock = jest.fn(() => ({
+  getRepository: jest.fn(() => activeRepository),
+}));
+const reconnectDatabaseMock = jest.fn(async () => {
+  activeRepository = reconnectedRepository;
+});
+
+jest.mock('../connection.js', () => ({
+  getAppDataSource: getAppDataSourceMock,
+  reconnectDatabase: reconnectDatabaseMock,
+}));
+
+import { SystemConfigRepository } from './SystemConfigRepository.js';
+
+describe('SystemConfigRepository connection recovery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    activeRepository = disconnectedRepository;
+  });
+
+  it('reconnects and retries when TypeORM reports that its driver is disconnected', async () => {
+    const storedConfig = Object.assign(new SystemConfig(), {
+      id: 'default',
+      routing: {},
+      smartRouting: {},
+    });
+    disconnectedRepository.findOne.mockRejectedValueOnce(new TypeORMError('Driver not Connected'));
+    reconnectedRepository.findOne.mockResolvedValueOnce(storedConfig);
+
+    const repository = new SystemConfigRepository();
+
+    await expect(repository.get()).resolves.toBe(storedConfig);
+    expect(reconnectDatabaseMock).toHaveBeenCalledTimes(1);
+    expect(disconnectedRepository.findOne).toHaveBeenCalledTimes(1);
+    expect(reconnectedRepository.findOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reconnect for non-connection errors', async () => {
+    const queryError = new Error('invalid system config query');
+    disconnectedRepository.findOne.mockRejectedValueOnce(queryError);
+
+    const repository = new SystemConfigRepository();
+
+    await expect(repository.get()).rejects.toBe(queryError);
+    expect(reconnectDatabaseMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/db/repositories/SystemConfigRepository.ts
+++ b/src/db/repositories/SystemConfigRepository.ts
@@ -1,29 +1,41 @@
 import { Repository } from 'typeorm';
 import { SystemConfig } from '../entities/SystemConfig.js';
-import { getAppDataSource } from '../connection.js';
+import { getAppDataSource, reconnectDatabase } from '../connection.js';
 import { cloneDefaultOAuthServerConfig } from '../../constants/oauthServerDefaults.js';
+import { isRetryableDbError } from '../../utils/dbRetry.js';
 
 /**
  * Repository for SystemConfig entity
  * Uses singleton pattern with id = 'default'
  */
 export class SystemConfigRepository {
-  private repository: Repository<SystemConfig>;
   private readonly DEFAULT_ID = 'default';
 
-  constructor() {
-    this.repository = getAppDataSource().getRepository(SystemConfig);
+  private getRepository(): Repository<SystemConfig> {
+    return getAppDataSource().getRepository(SystemConfig);
   }
 
-  /**
-   * Get system configuration (singleton)
-   */
-  async get(): Promise<SystemConfig> {
-    let config = await this.repository.findOne({ where: { id: this.DEFAULT_ID } });
+  private async withConnectionRecovery<T>(
+    operation: (repository: Repository<SystemConfig>) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await operation(this.getRepository());
+    } catch (error) {
+      if (!isRetryableDbError(error)) {
+        throw error;
+      }
 
-    // Create default if doesn't exist
+      console.warn('[DB Recovery] System config operation failed, reconnecting...');
+      await reconnectDatabase();
+      return await operation(this.getRepository());
+    }
+  }
+
+  private async getConfig(repository: Repository<SystemConfig>): Promise<SystemConfig> {
+    let config = await repository.findOne({ where: { id: this.DEFAULT_ID } });
+
     if (!config) {
-      config = this.repository.create({
+      config = repository.create({
         id: this.DEFAULT_ID,
         routing: {},
         install: {},
@@ -37,27 +49,38 @@ export class SystemConfigRepository {
         enableSessionRebuild: false,
         discovery: {},
       });
-      config = await this.repository.save(config);
+      config = await repository.save(config);
     }
 
     return config;
   }
 
   /**
+   * Get system configuration (singleton)
+   */
+  async get(): Promise<SystemConfig> {
+    return this.withConnectionRecovery((repository) => this.getConfig(repository));
+  }
+
+  /**
    * Update system configuration
    */
   async update(configData: Partial<SystemConfig>): Promise<SystemConfig> {
-    const config = await this.get();
-    const updated = this.repository.merge(config, configData);
-    return await this.repository.save(updated);
+    return this.withConnectionRecovery(async (repository) => {
+      const config = await this.getConfig(repository);
+      const updated = repository.merge(config, configData);
+      return await repository.save(updated);
+    });
   }
 
   /**
    * Reset system configuration to defaults
    */
   async reset(): Promise<SystemConfig> {
-    await this.repository.delete({ id: this.DEFAULT_ID });
-    return await this.get();
+    return this.withConnectionRecovery(async (repository) => {
+      await repository.delete({ id: this.DEFAULT_ID });
+      return await this.getConfig(repository);
+    });
   }
 
   /**

--- a/src/utils/dbRetry.test.ts
+++ b/src/utils/dbRetry.test.ts
@@ -1,0 +1,8 @@
+import { TypeORMError } from 'typeorm';
+import { isRetryableDbError } from './dbRetry.js';
+
+describe('isRetryableDbError', () => {
+  it('treats a disconnected TypeORM driver as retryable', () => {
+    expect(isRetryableDbError(new TypeORMError('Driver not Connected'))).toBe(true);
+  });
+});

--- a/src/utils/dbRetry.ts
+++ b/src/utils/dbRetry.ts
@@ -56,6 +56,7 @@ const RETRYABLE_ERROR_CODES = new Set([
  * Known database connection error message patterns that should trigger a retry
  */
 const RETRYABLE_ERROR_PATTERNS = [
+  /driver.*not.*connected/i,
   /connection.*reset/i,
   /connection.*closed/i,
   /connection.*lost/i,


### PR DESCRIPTION
## Summary

- classify TypeORM `Driver not Connected` failures as retryable
- rebuild the existing DataSource with single-flight reconnects and recover stale `isInitialized` state
- retry system-config repository operations after reconnect and document the database retry defaults

## Root cause

TypeORM can lose its PostgreSQL driver pool while leaving the shared DataSource unusable. The health check did not recover once the DataSource became uninitialized, reconnect resolution tried to read DB-backed configuration while the database was unavailable, and system-config operations propagated the first connection failure.

## Impact

DB-backed MCP requests can recover automatically after idle or stale PostgreSQL connections instead of returning HTTP 500 until the process is restarted.

## Verification

- `pnpm lint`
- `pnpm test:ci` — 138 suites, 908 tests
- `pnpm build`
- `node scripts/verify-dist.js`
- `git diff --check`

Closes #989