### PR TITLE
fix(auth): restrict skipAuth guest privileges

### DIFF
--- a/docs/api-reference/config.mdx
+++ b/docs/api-reference/config.mdx
@@ -28,7 +28,7 @@ Updates various parts of the system configuration. You only need to provide the 
 - `bearerAuthKey` (string): Legacy bearer key (used only for one-time migration).
 - `bearerAuthHeaderName` (string): Header name used to receive MCP bearer credentials (default: `Authorization`). Change this when upstream passthrough headers also use `Authorization`.
 - `jsonBodyLimit` (string): Express JSON body size limit (default: `1mb`). This applies to large inline OpenAPI schema uploads too.
-- `skipAuth` (boolean): If true, skips dashboard/web API login requirements so the frontend can call `/api` routes without a session token. Unauthenticated dashboard users are treated as the built-in `guest` administrator, so enable this only in trusted environments. This does **not** disable MCP endpoint authentication.
+- `skipAuth` (boolean): If true, skips dashboard/web API login requirements so the frontend can call `/api` routes without a session token. Unauthenticated dashboard users are treated as the built-in non-admin `guest` user. This does **not** disable MCP endpoint authentication.
 
 #### Install Configuration (`install`)
 

--- a/docs/zh/api-reference/config.mdx
+++ b/docs/zh/api-reference/config.mdx
@@ -26,7 +26,7 @@ import { Card, Cards } from 'mintlify';
 - `enableGroupNameRoute` (boolean): 启用或禁用基于群组的路由 (例如 `/api/mcp/group/:groupName`)。
 - `enableBearerAuth` (boolean): 为 MCP 端点启用 Bearer 令牌身份验证（默认：`true`）。
 - `bearerAuthKey` (string): 旧版 Bearer 密钥（仅用于一次性迁移）。
-- `skipAuth` (boolean): 如果为 true，则跳过仪表盘 / Web API 的登录要求，前端可在没有会话令牌的情况下访问 `/api` 路由。未登录的仪表盘用户会被视为内置 `guest` 管理员，因此仅应在受信任环境中启用，但**不会**关闭 MCP 端点认证。
+- `skipAuth` (boolean): 如果为 true，则跳过仪表盘 / Web API 的登录要求，前端可在没有会话令牌的情况下访问 `/api` 路由。未登录的仪表盘用户会被视为内置的非管理员 `guest` 用户，但**不会**关闭 MCP 端点认证。
 
 #### 安装配置 (`install`)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -63,7 +63,9 @@ function App() {
                       <Route path="/groups" element={<GroupsPage />} />
                       <Route path="/prompts" element={<PromptsPage />} />
                       <Route path="/resources" element={<ResourcesPage />} />
-                      <Route path="/users" element={<UsersPage />} />
+                      <Route element={<ProtectedRoute requireAdmin />}>
+                        <Route path="/users" element={<UsersPage />} />
+                      </Route>
                       <Route path="/market" element={<MarketPage />} />
                       <Route path="/market/:serverName" element={<MarketPage />} />
                       {/* Legacy cloud routes redirect to market with cloud tab */}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/AuthContext';
+import { canAccessAdminPages } from '../utils/navigationPermissions';
 
 interface ProtectedRouteProps {
   redirectPath?: string;
+  requireAdmin?: boolean;
 }
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
-  redirectPath = '/login'
+  redirectPath = '/login',
+  requireAdmin = false,
 }) => {
   const { t } = useTranslation();
   const { auth } = useAuth();
@@ -19,6 +22,10 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 
   if (!auth.isAuthenticated) {
     return <Navigate to={redirectPath} replace />;
+  }
+
+  if (requireAdmin && !canAccessAdminPages(auth.user)) {
+    return <Navigate to="/" replace />;
   }
 
   return <Outlet />;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -44,7 +44,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           loading: false,
           user: {
             username: 'guest',
-            isAdmin: true,
+            isAdmin: false,
             permissions,
           },
           error: null,

--- a/frontend/src/utils/navigationPermissions.ts
+++ b/frontend/src/utils/navigationPermissions.ts
@@ -3,3 +3,5 @@ type UserLike = {
 } | null | undefined;
 
 export const canViewSystemLogs = (user: UserLike): boolean => Boolean(user?.isAdmin);
+
+export const canAccessAdminPages = (user: UserLike): boolean => Boolean(user?.isAdmin);

--- a/locales/en.json
+++ b/locales/en.json
@@ -698,7 +698,7 @@
     "selectAtLeastOneGroup": "Please select at least one group",
     "selectAtLeastOneServer": "Please select at least one server",
     "skipAuth": "Skip Authentication",
-    "skipAuthDescription": "Allow dashboard access without login; unauthenticated users get guest admin access (does not affect MCP endpoint auth)",
+    "skipAuthDescription": "Allow dashboard access without login; unauthenticated users get non-admin guest access (does not affect MCP endpoint auth)",
     "jsonBodyLimit": "JSON Body Size Limit",
     "jsonBodyLimitDescription": "Express JSON request size limit. This affects large OpenAPI schema uploads as well.",
     "jsonBodyLimitPlaceholder": "e.g. 1mb, 5mb, 1024kb",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -689,7 +689,7 @@
     "selectAtLeastOneGroup": "Veuillez sélectionner au moins un groupe",
     "selectAtLeastOneServer": "Veuillez sélectionner au moins un serveur",
     "skipAuth": "Ignorer l'authentification",
-    "skipAuthDescription": "Autoriser l'accès au tableau de bord sans connexion ; les utilisateurs non authentifiés obtiennent un accès administrateur guest (n'affecte pas l'auth MCP)",
+    "skipAuthDescription": "Autoriser l'accès au tableau de bord sans connexion ; les utilisateurs non authentifiés obtiennent un accès guest non administrateur (n'affecte pas l'auth MCP)",
     "jsonBodyLimit": "Limite de taille du corps JSON",
     "jsonBodyLimitDescription": "Limite de taille des requêtes JSON Express. Les gros téléchargements de schémas OpenAPI utilisent aussi ce paramètre.",
     "jsonBodyLimitPlaceholder": "ex. 1mb, 5mb, 1024kb",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -688,7 +688,7 @@
     "selectAtLeastOneGroup": "Lütfen en az bir grup seçin",
     "selectAtLeastOneServer": "Lütfen en az bir sunucu seçin",
     "skipAuth": "Kimlik Doğrulamayı Atla",
-    "skipAuthDescription": "Kontrol paneline giriş olmadan erişime izin ver; kimliği doğrulanmamış kullanıcılar guest yönetici erişimi alır (MCP kimlik doğrulamasını etkilemez)",
+    "skipAuthDescription": "Kontrol paneline giriş olmadan erişime izin ver; kimliği doğrulanmamış kullanıcılar yönetici olmayan guest erişimi alır (MCP kimlik doğrulamasını etkilemez)",
     "jsonBodyLimit": "JSON Gövde Boyutu Sınırı",
     "jsonBodyLimitDescription": "Express JSON istek boyutu sınırı. Büyük OpenAPI şema yüklemeleri de bu ayardan etkilenir.",
     "jsonBodyLimitPlaceholder": "örn. 1mb, 5mb, 1024kb",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -700,7 +700,7 @@
     "selectAtLeastOneGroup": "请至少选择一个分组",
     "selectAtLeastOneServer": "请至少选择一个服务器",
     "skipAuth": "免登录开关",
-    "skipAuthDescription": "允许仪表盘免登录；未认证用户将获得 guest 管理员访问权限（不影响 MCP 端点认证）",
+    "skipAuthDescription": "允许仪表盘免登录；未认证用户将获得非管理员 guest 访问权限（不影响 MCP 端点认证）",
     "jsonBodyLimit": "JSON 请求体大小限制",
     "jsonBodyLimitDescription": "Express JSON 请求体大小限制，大型 OpenAPI schema 上传也会受此配置影响。",
     "jsonBodyLimitPlaceholder": "例如：1mb、5mb、1024kb",

--- a/src/controllers/configController.ts
+++ b/src/controllers/configController.ts
@@ -70,7 +70,7 @@ export const getPublicConfig = async (req: Request, res: Response): Promise<void
       const user: IUser = {
         username: 'guest',
         password: '',
-        isAdmin: true,
+        isAdmin: false,
       };
       permissions = dataService.getPermissions(user);
     }

--- a/src/middlewares/auth.test.ts
+++ b/src/middlewares/auth.test.ts
@@ -223,7 +223,7 @@ describe('auth middleware', () => {
     expect(response.body).toEqual({ success: false, message: 'No token, authorization denied' });
   });
 
-  it('attaches a guest admin user when skipAuth is true', async () => {
+  it('attaches a non-admin guest user when skipAuth is true', async () => {
     currentSystemConfig.routing.skipAuth = true;
 
     const app = express();
@@ -250,7 +250,7 @@ describe('auth middleware', () => {
       success: true,
       user: {
         username: 'guest',
-        isAdmin: true,
+        isAdmin: false,
       },
     });
   });

--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -83,7 +83,7 @@ const checkReadonly = (req: Request): boolean => {
 
 const createSkipAuthUser = () => ({
   username: 'guest',
-  isAdmin: true,
+  isAdmin: false,
 });
 
 const isDashboardApiRequest = (req: Request): boolean => {

--- a/tests/controllers/configController.publicConfig.test.ts
+++ b/tests/controllers/configController.publicConfig.test.ts
@@ -39,7 +39,7 @@ describe('ConfigController - getPublicConfig', () => {
     };
   });
 
-  it('uses DAO-backed routing and Better Auth configuration for public config', async () => {
+  it('grants only non-admin guest permissions when skipAuth is enabled', async () => {
     const systemConfig = {
       routing: {
         skipAuth: true,
@@ -52,9 +52,7 @@ describe('ConfigController - getPublicConfig', () => {
     };
 
     getSystemConfigMock.mockResolvedValue(systemConfig);
-    getPermissionsMock.mockReturnValue({
-      settings: ['manage'],
-    });
+    getPermissionsMock.mockReturnValue(['']);
     getBetterAuthRuntimeConfigMock.mockResolvedValue({
       enabled: true,
       basePath: '/api/auth/better',
@@ -80,15 +78,13 @@ describe('ConfigController - getPublicConfig', () => {
     expect(getPermissionsMock).toHaveBeenCalledWith({
       username: 'guest',
       password: '',
-      isAdmin: true,
+      isAdmin: false,
     });
     expect(mockJson).toHaveBeenCalledWith({
       success: true,
       data: {
         skipAuth: true,
-        permissions: {
-          settings: ['manage'],
-        },
+        permissions: [''],
         betterAuth: {
           enabled: true,
           basePath: '/api/auth/better',

--- a/tests/frontend/navigationPermissions.test.ts
+++ b/tests/frontend/navigationPermissions.test.ts
@@ -1,4 +1,21 @@
-import { canViewSystemLogs } from '../../frontend/src/utils/navigationPermissions';
+import {
+  canAccessAdminPages,
+  canViewSystemLogs,
+} from '../../frontend/src/utils/navigationPermissions';
+
+describe('canAccessAdminPages', () => {
+  it('allows authenticated administrators', () => {
+    expect(canAccessAdminPages({ username: 'admin', isAdmin: true })).toBe(true);
+  });
+
+  it('denies non-admin skipAuth guests', () => {
+    expect(canAccessAdminPages({ username: 'guest', isAdmin: false })).toBe(false);
+  });
+
+  it('denies access when no user is signed in', () => {
+    expect(canAccessAdminPages(null)).toBe(false);
+  });
+});
 
 describe('canViewSystemLogs', () => {
   it('allows admins to access the system logs menu', () => {


### PR DESCRIPTION
## Summary

- treat the built-in `skipAuth` guest as a non-admin in both frontend and backend auth state
- guard the `/users` page so non-admin guests cannot navigate directly to user management
- update skipAuth documentation and localized UI descriptions to match the safer behavior

## Root cause

`skipAuth` synthesized an unauthenticated `guest` identity with `isAdmin: true` on both sides of the dashboard API boundary. That made enabling login bypass equivalent to granting anonymous administrator access. CORS cannot prevent direct navigation or non-browser API clients, so the fix is applied at the authorization boundary instead.

## Test plan

- `corepack pnpm jest tests/frontend/navigationPermissions.test.ts src/middlewares/auth.test.ts tests/controllers/configController.publicConfig.test.ts --runInBand`
- `corepack pnpm lint`
- `corepack pnpm test:ci`
- `corepack pnpm build`
- `git diff --check`

Closes #994