### PR TITLE
fix: update Docker image glibc compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM python:3.13-slim-bookworm AS base
+FROM python:3.13-slim-trixie AS base
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -31,7 +31,7 @@ RUN if [ "$INSTALL_EXT" = "true" ]; then \
   install -m 0755 -d /etc/apt/keyrings && \
   curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc && \
   chmod a+r /etc/apt/keyrings/docker.asc && \
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
   apt-get update && \
   apt-get install -y docker-ce docker-ce-cli containerd.io && \
   apt-get clean && rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
## Summary

- upgrade the Docker base image from Debian 12 Bookworm to Debian 13 Trixie
- derive the Docker CE repository suite from the base image codename instead of hard-coding `bookworm`
- allow native MCP binaries requiring newer glibc versions to start in the published image

## Root cause

The v1.0.24 image uses `python:3.13-slim-bookworm`, which provides glibc 2.36. `@dbx-app/mcp-server` ships a native binary requiring `GLIBC_2.38`, so the process exits before MCP initialization and MCPHub reports `MCP error -32000: Connection closed`.

Debian 13 Trixie provides glibc 2.41. The Docker CE apt source also needs to follow the selected Debian suite to keep the optional full-image installation path consistent.

Closes #998

## Validation

- `docker build --progress=plain -t mcphub:issue-998 .`
- container reports `ldd (Debian GLIBC 2.41-12+deb13u3) 2.41`
- `npx -y @dbx-app/mcp-server` reaches MCP initialization without the previous glibc loader error
- `GET /health` responds from the built image
- `pnpm lint`
- `pnpm test:ci` — 138 suites and 909 tests passed
- `pnpm build`
- `git diff --check`

The `INSTALL_EXT=true` full image build was skipped at the request of the local verifier.