### PR TITLE
feat: allow duplicate server names across groups

### DIFF
--- a/docs/api-reference/groups.mdx
+++ b/docs/api-reference/groups.mdx
@@ -51,7 +51,7 @@ Creates a new server group.
 - **Body**:
   - `name` (string, required): The name of the group.
   - `description` (string, optional): A description for the group.
-  - `servers` (array, optional): A list of server names or capability-scoped server configuration objects.
+  - `servers` (array, optional): A list of unique server names or capability-scoped server configuration objects. Use `serverId` when names are duplicated.
 - **Request Example**:
   ```json
   {
@@ -60,6 +60,7 @@ Creates a new server group.
     "servers": [
       "server1",
       {
+        "serverId": "bc13f5e2-9b2c-4b23-a80f-1b4fa18c0f62",
         "name": "server2",
         "tools": ["toolA", "toolB"],
         "prompts": ["draft_prompt"],
@@ -124,11 +125,12 @@ Adds a single server to a group.
 - **Parameters**:
   - `:id` (string, required): The ID or name of the group.
 - **Body**:
-  - `serverName` (string, required): The name of the server to add.
+  - `serverId` (string, recommended): The stable ID of the server to add.
+  - `serverName` (string, legacy): A unique server name. Ambiguous names are rejected.
 - **Request Example**:
   ```json
   {
-    "serverName": "my-server"
+    "serverId": "bc13f5e2-9b2c-4b23-a80f-1b4fa18c0f62"
   }
   ```
 
@@ -148,7 +150,7 @@ Removes a single server from a group.
 
 ### Batch Update Group Servers
 
-Replaces all servers in a group with a new list. The list can be simple strings or detailed configuration objects.
+Replaces all servers in a group with a new list. The list can be simple strings or detailed configuration objects. Stable `serverId` references are required to distinguish servers that share a name.
 
 - **Endpoint**: `/api/groups/:id/servers/batch`
 - **Method**: `PUT`
@@ -167,6 +169,7 @@ Replaces all servers in a group with a new list. The list can be simple strings 
   {
     "servers": [
       {
+        "serverId": "bc13f5e2-9b2c-4b23-a80f-1b4fa18c0f62",
         "name": "server1",
         "tools": "all",
         "prompts": "all",
@@ -184,6 +187,7 @@ Replaces all servers in a group with a new list. The list can be simple strings 
 
 Each detailed server object accepts these optional capability selectors:
 
+- `serverId`: Stable server identity. Prefer this over name-only references.
 - `tools`: `"all"` or an array of tool names.
 - `prompts`: `"all"` or an array of prompt names.
 - `resources`: `"all"` or an array of resource URIs.
@@ -204,6 +208,7 @@ Retrieves the detailed configuration for all servers within a group, including w
     "success": true,
     "data": [
       {
+        "serverId": "bc13f5e2-9b2c-4b23-a80f-1b4fa18c0f62",
         "name": "server1",
         "tools": "all",
         "prompts": "all",

--- a/docs/api-reference/servers.mdx
+++ b/docs/api-reference/servers.mdx
@@ -34,6 +34,7 @@ Retrieves a list of all configured MCP servers, including their status and avail
     "success": true,
     "data": [
       {
+        "id": "bc13f5e2-9b2c-4b23-a80f-1b4fa18c0f62",
         "name": "example-server",
         "status": "connected",
         "tools": [
@@ -60,7 +61,8 @@ Returns the configuration of a single server, including upstream tools/prompts/r
 
 - **Endpoint**: `GET /api/servers/:name`
 - **Authentication**: Required.
-- Returns `404` if the server is not configured.
+- `:name` accepts the stable server ID or a unique server name.
+- Returns `409` with matching server IDs when a name is ambiguous, or `404` if the server is not configured.
 
 ---
 
@@ -82,7 +84,7 @@ Adds a new MCP server to the configuration.
     }
   }
   ```
-  - `name` (string, required): The unique name for the server.
+  - `name` (string, required): The display name for the server. Names may be reused across groups; the response includes the stable server `id`.
   - `config` (object, required): The server configuration object.
     - `type` (string): `stdio`, `sse`, `streamable-http`, or `openapi`.
     - `command` (string): Command to execute for `stdio` type.
@@ -119,6 +121,8 @@ Create several servers in a single request. The body contains a `servers` **arra
 
 Each element is validated independently, and the response contains a per-server `{ name, success, message? }` record so partial batches do not abort the whole request.
 
+Successful records also include `serverId`. Use that ID for later updates and group membership when names are duplicated.
+
 ---
 
 ### Update a Server
@@ -128,7 +132,7 @@ Updates the configuration of an existing MCP server.
 - **Endpoint**: `/api/servers/:name`
 - **Method**: `PUT`
 - **Parameters**:
-  - `:name` (string, required): The name of the server to update.
+  - `:name` (string, required): The stable ID or unique name of the server to update.
 - **Body**:
   ```json
   {

--- a/frontend/src/components/EditServerForm.tsx
+++ b/frontend/src/components/EditServerForm.tsx
@@ -17,7 +17,7 @@ const EditServerForm = ({ server, onEdit, onCancel }: EditServerFormProps) => {
   const handleSubmit = async (payload: any) => {
     try {
       setError(null);
-      const encodedServerName = encodeURIComponent(server.name);
+      const encodedServerName = encodeURIComponent(server.id ?? server.name);
 
       // Check if name is being changed
       const isRenaming = payload.name && payload.name !== server.name;

--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -16,22 +16,25 @@ interface GroupCardProps {
 }
 
 const getServerNames = (servers: string[] | IGroupServerConfig[]): string[] =>
-  servers.map((server) => (typeof server === 'string' ? server : server.name));
+  servers.map((server) => (typeof server === 'string' ? server : (server.serverId ?? server.name)));
 
-const getServerConfig = (group: Group, serverName: string): IGroupServerConfig => {
-  const server = group.servers.find((s) =>
-    typeof s === 'string' ? s === serverName : s.name === serverName,
+const getServerConfig = (group: Group, server: Server): IGroupServerConfig => {
+  const serverIdentifier = server.id ?? server.name;
+  const configEntry = group.servers.find((s) =>
+    typeof s === 'string'
+      ? s === server.name
+      : s.serverId === serverIdentifier || (!s.serverId && s.name === server.name),
   );
-  if (!server) return { name: serverName, tools: 'all', prompts: 'all', resources: 'all' };
-  if (typeof server === 'string') {
-    return { name: server, tools: 'all', prompts: 'all', resources: 'all' };
+  if (!configEntry) return { name: server.name, tools: 'all', prompts: 'all', resources: 'all' };
+  if (typeof configEntry === 'string') {
+    return { name: configEntry, tools: 'all', prompts: 'all', resources: 'all' };
   }
-  return server;
+  return configEntry;
 };
 
-const getServerDisplayName = (group: Group, serverName: string): string => {
-  const config = getServerConfig(group, serverName);
-  return config.alias?.trim() || serverName;
+const getServerDisplayName = (group: Group, server: Server): string => {
+  const config = getServerConfig(group, server);
+  return config.alias?.trim() || server.name;
 };
 
 const copyText = async (value: string): Promise<boolean> => {
@@ -95,10 +98,12 @@ const GroupCard = ({ group, servers, onEdit, onDelete, cost }: GroupCardProps) =
   const groupEndpoint = `${baseUrl}/mcp/${group.name}`;
 
   const serverNames = getServerNames(group.servers);
-  const groupServers = servers.filter((s) => serverNames.includes(s.name));
+  const groupServers = servers.filter(
+    (server) => serverNames.includes(server.id ?? server.name) || serverNames.includes(server.name),
+  );
 
   const tally = (server: Server) => {
-    const cfg = getServerConfig(group, server.name);
+    const cfg = getServerConfig(group, server);
     const prefix = `${server.name}${nameSeparator}`;
     const allTools = server.tools || [];
     const allPrompts = server.prompts || [];
@@ -273,7 +278,7 @@ const GroupCard = ({ group, servers, onEdit, onDelete, cost }: GroupCardProps) =
                     }}
                   />
                   <span className="hub-mono truncate flex-1" style={{ fontSize: 12.5 }}>
-                    <span title={s.name}>{getServerDisplayName(group, s.name)}</span>
+                    <span title={s.name}>{getServerDisplayName(group, s)}</span>
                   </span>
                   <span
                     className="hub-mono hub-num flex-shrink-0"

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -189,6 +189,7 @@ const ServerCard = ({
   const isMcpApp = serverExposesMcpApp(server);
   const enabled = server.enabled !== false;
   const canManage = canManageServer(server, auth.user);
+  const serverIdentifier = server.id ?? server.name;
   // Reinstall is only available for stdio servers using npx or uvx
   const supportsReinstall =
     server.config?.command === 'npx' || server.config?.command === 'uvx';
@@ -319,7 +320,7 @@ const ServerCard = ({
     setShowMenu(false);
     if (!canManage) return;
     try {
-      const result = await exportMCPSettings(server.name);
+      const result = await exportMCPSettings(serverIdentifier);
       if (!result || !result.success || !result.data) {
         showToast(result?.message || t('common.copyFailed') || 'Copy failed', 'error');
         return;
@@ -351,7 +352,7 @@ const ServerCard = ({
   const handleToolToggle = async (toolName: string, enabled: boolean) => {
     try {
       const { toggleTool } = await import('@/services/toolService');
-      const result = await toggleTool(server.name, toolName, enabled);
+      const result = await toggleTool(serverIdentifier, toolName, enabled);
       if (result.success) {
         showToast(t(enabled ? 'tool.enableSuccess' : 'tool.disableSuccess', { name: toolName }), 'success');
         onRefresh?.();
@@ -367,7 +368,7 @@ const ServerCard = ({
   const handlePromptToggle = async (promptName: string, enabled: boolean) => {
     try {
       const { togglePrompt } = await import('@/services/promptService');
-      const result = await togglePrompt(server.name, promptName, enabled);
+      const result = await togglePrompt(serverIdentifier, promptName, enabled);
       if (result.success) {
         showToast(t(enabled ? 'tool.enableSuccess' : 'tool.disableSuccess', { name: promptName }), 'success');
         onRefresh?.();
@@ -383,7 +384,7 @@ const ServerCard = ({
   const handleResourceToggle = async (resourceUri: string, enabled: boolean) => {
     try {
       const { toggleResource } = await import('@/services/resourceService');
-      const result = await toggleResource(server.name, resourceUri, enabled);
+      const result = await toggleResource(serverIdentifier, resourceUri, enabled);
       if (result.success) {
         showToast(t(enabled ? 'tool.enableSuccess' : 'tool.disableSuccess', { name: resourceUri }), 'success');
         onRefresh?.();
@@ -422,8 +423,8 @@ const ServerCard = ({
         '@/services/resourceService'
       );
       const result = options?.restored
-        ? await resetResourceDescription(server.name, resourceUri)
-        : await updateResourceDescription(server.name, resourceUri, description);
+        ? await resetResourceDescription(serverIdentifier, resourceUri)
+        : await updateResourceDescription(serverIdentifier, resourceUri, description);
       if (result.success) {
         showToast(
           options?.restored
@@ -463,7 +464,7 @@ const ServerCard = ({
     return parts.join(' ');
   })();
 
-  const serverEndpoint = `${baseUrl}/mcp/${server.name}`;
+  const serverEndpoint = `${baseUrl}/mcp/${serverIdentifier}`;
   const translateVisibility = (key: string, options?: { defaultValue?: string }) => t(key, options);
   const visibility = getServerVisibilityDisplay(
     translateVisibility,
@@ -926,7 +927,7 @@ const ServerCard = ({
                 {server.tools.map((tool, index) => (
                   <ToolCard
                     key={index}
-                    server={server.name}
+                    server={serverIdentifier}
                     tool={tool}
                     readOnly={!canManage}
                     onToggle={handleToolToggle}
@@ -941,7 +942,7 @@ const ServerCard = ({
                 {server.prompts.map((prompt, index) => (
                   <PromptCard
                     key={index}
-                    server={server.name}
+                    server={serverIdentifier}
                     prompt={prompt}
                     readOnly={!canManage}
                     onToggle={handlePromptToggle}
@@ -981,7 +982,7 @@ const ServerCard = ({
         isOpen={showDeleteDialog}
         onClose={() => setShowDeleteDialog(false)}
         onConfirm={() => {
-          onRemove(server.name);
+          onRemove(serverIdentifier);
           setShowDeleteDialog(false);
         }}
         serverName={server.name}

--- a/frontend/src/components/ServerToolConfig.tsx
+++ b/frontend/src/components/ServerToolConfig.tsx
@@ -48,6 +48,13 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   const { nameSeparator } = useSettingsData();
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
 
+  const getServerId = (server: Server) => server.id ?? server.name;
+  const matchesServer = (config: IGroupServerConfig, serverId: string) => {
+    if (config.serverId) return config.serverId === serverId;
+    const server = servers.find((candidate) => getServerId(candidate) === serverId);
+    return config.name === (server?.name ?? serverId);
+  };
+
   // Normalize current value to IGroupServerConfig[] format
   const normalizedValue: IGroupServerConfig[] = React.useMemo(() => {
     return value.map((item) => {
@@ -72,36 +79,39 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   // Clean up expanded servers when servers are removed from configuration
   // But keep servers that were explicitly expanded even if they have no configuration
   React.useEffect(() => {
-    const configuredServerNames = new Set(normalizedValue.map((config) => config.name));
-    const availableServerNames = new Set(availableServers.map((server) => server.name));
+    const configuredServerIds = new Set(
+      normalizedValue.map((config) => config.serverId ?? config.name),
+    );
+    const availableServerIds = new Set(availableServers.map(getServerId));
 
     setExpandedServers((prev) => {
       const newSet = new Set<string>();
-      prev.forEach((serverName) => {
+      prev.forEach((serverId) => {
         // Keep expanded if server is configured OR if server exists and user manually expanded it
-        if (configuredServerNames.has(serverName) || availableServerNames.has(serverName)) {
-          newSet.add(serverName);
+        if (configuredServerIds.has(serverId) || availableServerIds.has(serverId)) {
+          newSet.add(serverId);
         }
       });
       return newSet;
     });
   }, [normalizedValue, availableServers]);
 
-  const toggleServer = (serverName: string) => {
-    const existingIndex = normalizedValue.findIndex((config) => config.name === serverName);
+  const toggleServer = (server: Server) => {
+    const serverId = getServerId(server);
+    const existingIndex = normalizedValue.findIndex((config) => matchesServer(config, serverId));
 
     if (existingIndex >= 0) {
       // Remove server - this also removes all capability selections
-      const newValue = normalizedValue.filter((config) => config.name !== serverName);
+      const newValue = normalizedValue.filter((config) => !matchesServer(config, serverId));
       onChange(newValue);
     } else {
       // Add server with all capabilities by default
-      const newValue = [...normalizedValue, { name: serverName, ...FULL_SELECTIONS }];
+      const newValue = [...normalizedValue, { serverId, name: server.name, ...FULL_SELECTIONS }];
       onChange(newValue);
     }
   };
 
-  const toggleServerExpanded = (serverName: string) => {
+  const toggleServerExpanded = (serverId: string) => {
     setExpandedServers((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(serverName)) {
@@ -121,27 +131,28 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   };
 
   const updateServerCapability = (
-    serverName: string,
+    server: Server,
     capability: CapabilityKey,
     selection: string[] | 'all',
     keepExpanded = false,
   ) => {
-    const existingServer = normalizedValue.find((config) => config.name === serverName);
+    const serverId = getServerId(server);
+    const existingServer = normalizedValue.find((config) => matchesServer(config, serverId));
     const baseConfig: IGroupServerConfig = existingServer
       ? { ...existingServer }
-      : { name: serverName, ...EMPTY_SELECTIONS };
+      : { serverId, name: server.name, ...EMPTY_SELECTIONS };
     const nextConfig: IGroupServerConfig = {
       ...baseConfig,
       [capability]: selection,
     };
 
     if (!hasAnyCapabilitySelection(nextConfig)) {
-      const newValue = normalizedValue.filter((config) => config.name !== serverName);
+      const newValue = normalizedValue.filter((config) => !matchesServer(config, serverId));
       onChange(newValue);
       if (!keepExpanded) {
         setExpandedServers((prev) => {
           const newSet = new Set(prev);
-          newSet.delete(serverName);
+          newSet.delete(serverId);
           return newSet;
         });
       }
@@ -149,15 +160,18 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
     }
 
     if (existingServer) {
-      onChange(normalizedValue.map((config) => (config.name === serverName ? nextConfig : config)));
+      onChange(
+        normalizedValue.map((config) => (matchesServer(config, serverId) ? nextConfig : config)),
+      );
       return;
     }
 
     onChange([...normalizedValue, nextConfig]);
   };
 
-  const updateServerAlias = (serverName: string, alias: string) => {
-    const existingServer = normalizedValue.find((config) => config.name === serverName);
+  const updateServerAlias = (server: Server, alias: string) => {
+    const serverId = getServerId(server);
+    const existingServer = normalizedValue.find((config) => matchesServer(config, serverId));
     if (!existingServer) return;
 
     const nextConfig: IGroupServerConfig = { ...existingServer };
@@ -167,7 +181,9 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
       delete nextConfig.alias;
     }
 
-    onChange(normalizedValue.map((config) => (config.name === serverName ? nextConfig : config)));
+    onChange(
+      normalizedValue.map((config) => (matchesServer(config, serverId) ? nextConfig : config)),
+    );
   };
 
   const normalizeNamedCapability = (serverName: string, name: string) => {
@@ -225,7 +241,7 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   const getSelectedCapabilityCost = (server: Server, capability: CapabilityKey): number => {
     const costMap = costMapForServer(server.name);
     return getCapabilityItems(server, capability)
-      .filter((item) => isCapabilityItemSelected(server.name, capability, item.value))
+      .filter((item) => isCapabilityItemSelected(server, capability, item.value))
       .reduce((sum, item) => sum + (costMap.get(item.key) ?? 0), 0);
   };
 
@@ -235,33 +251,27 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
       0,
     );
 
-  const toggleCapabilityItem = (
-    serverName: string,
-    capability: CapabilityKey,
-    itemValue: string,
-  ) => {
-    const server = availableServers.find((s) => s.name === serverName);
-    if (!server) return;
-
+  const toggleCapabilityItem = (server: Server, capability: CapabilityKey, itemValue: string) => {
+    const serverId = getServerId(server);
     const allItems = getCapabilityItems(server, capability).map((item) => item.value);
-    const serverConfig = normalizedValue.find((config) => config.name === serverName);
+    const serverConfig = normalizedValue.find((config) => matchesServer(config, serverId));
 
     if (!serverConfig) {
-      updateServerCapability(serverName, capability, [itemValue]);
+      updateServerCapability(server, capability, [itemValue]);
       return;
     }
 
     const currentSelection = serverConfig[capability];
     if (currentSelection === 'all') {
       const nextSelection = allItems.filter((value) => value !== itemValue);
-      updateServerCapability(serverName, capability, nextSelection);
+      updateServerCapability(server, capability, nextSelection);
       return;
     }
 
     if (Array.isArray(currentSelection)) {
       if (currentSelection.includes(itemValue)) {
         updateServerCapability(
-          serverName,
+          server,
           capability,
           currentSelection.filter((value) => value !== itemValue),
         );
@@ -270,23 +280,27 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
 
       const nextSelection = [...currentSelection, itemValue];
       updateServerCapability(
-        serverName,
+        server,
         capability,
         nextSelection.length === allItems.length ? 'all' : nextSelection,
       );
       return;
     }
 
-    updateServerCapability(serverName, capability, [itemValue]);
+    updateServerCapability(server, capability, [itemValue]);
   };
 
-  const isServerSelected = (serverName: string) => {
-    const serverConfig = normalizedValue.find((config) => config.name === serverName);
+  const isServerSelected = (server: Server) => {
+    const serverConfig = normalizedValue.find((config) =>
+      matchesServer(config, getServerId(server)),
+    );
     return Boolean(serverConfig && hasAnyCapabilitySelection(serverConfig));
   };
 
-  const isServerPartiallySelected = (serverName: string) => {
-    const serverConfig = normalizedValue.find((config) => config.name === serverName);
+  const isServerPartiallySelected = (server: Server) => {
+    const serverConfig = normalizedValue.find((config) =>
+      matchesServer(config, getServerId(server)),
+    );
     if (!serverConfig) return false;
 
     return (['tools', 'prompts', 'resources'] as CapabilityKey[]).some((capability) => {
@@ -296,11 +310,13 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   };
 
   const isCapabilityItemSelected = (
-    serverName: string,
+    server: Server,
     capability: CapabilityKey,
     itemValue: string,
   ) => {
-    const serverConfig = normalizedValue.find((config) => config.name === serverName);
+    const serverConfig = normalizedValue.find((config) =>
+      matchesServer(config, getServerId(server)),
+    );
     if (!serverConfig) return false;
 
     const selection = serverConfig[capability];
@@ -309,7 +325,9 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
   };
 
   const getSelectedCapabilityCount = (server: Server, capability: CapabilityKey) => {
-    const serverConfig = normalizedValue.find((config) => config.name === server.name);
+    const serverConfig = normalizedValue.find((config) =>
+      matchesServer(config, getServerId(server)),
+    );
     if (!serverConfig) return 0;
 
     const items = getCapabilityItems(server, capability);
@@ -358,10 +376,11 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
     <div className={cn('space-y-4', className)}>
       <div className="space-y-3">
         {availableServers.map((server) => {
-          const isSelected = isServerSelected(server.name);
-          const isPartiallySelected = isServerPartiallySelected(server.name);
-          const isExpanded = expandedServers.has(server.name);
-          const serverConfig = normalizedValue.find((config) => config.name === server.name);
+          const serverId = getServerId(server);
+          const isSelected = isServerSelected(server);
+          const isPartiallySelected = isServerPartiallySelected(server);
+          const isExpanded = expandedServers.has(serverId);
+          const serverConfig = normalizedValue.find((config) => matchesServer(config, serverId));
           const summaryBadges = getServerSummaryBadges(server);
           const serverCapabilities = capabilityConfigs.filter(
             ({ key }) => getCapabilityItems(server, key).length > 0,
@@ -370,24 +389,24 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
 
           return (
             <div
-              key={server.name}
+              key={serverId}
               className="border border-gray-200 dark:border-gray-700 rounded-lg hover:border-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 transition-colors"
             >
               <div
                 className="flex items-center justify-between p-3 cursor-pointer rounded-lg transition-colors"
-                onClick={() => toggleServerExpanded(server.name)}
+                onClick={() => toggleServerExpanded(serverId)}
               >
                 <div
                   className="flex items-center space-x-3"
                   onClick={(e) => {
                     e.stopPropagation();
-                    toggleServer(server.name);
+                    toggleServer(server);
                   }}
                 >
                   <input
                     type="checkbox"
                     checked={isSelected || isPartiallySelected}
-                    onChange={() => toggleServer(server.name)}
+                    onChange={() => toggleServer(server)}
                     className="w-4 h-4 text-blue-600 bg-gray-100 dark:bg-gray-800 border-gray-300 rounded focus:ring-blue-500"
                   />
                   <span className="font-medium text-gray-900 cursor-pointer select-none">
@@ -449,7 +468,7 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
                           type="text"
                           value={serverConfig.alias || ''}
                           placeholder={server.name}
-                          onChange={(event) => updateServerAlias(server.name, event.target.value)}
+                          onChange={(event) => updateServerAlias(server, event.target.value)}
                           className="w-full rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm text-gray-800 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                         />
                       </div>
@@ -484,7 +503,7 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
                                 type="button"
                                 onClick={() => {
                                   updateServerCapability(
-                                    server.name,
+                                    server,
                                     key,
                                     allSelected ? [] : 'all',
                                     true,
@@ -499,11 +518,7 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
 
                           <div className="grid grid-cols-1 gap-2 max-h-32 overflow-y-auto">
                             {items.map((item) => {
-                              const isChecked = isCapabilityItemSelected(
-                                server.name,
-                                key,
-                                item.value,
-                              );
+                              const isChecked = isCapabilityItemSelected(server, key, item.value);
                               const descriptionInfo =
                                 key === 'tools'
                                   ? getToolDescriptionInfo(
@@ -529,9 +544,7 @@ export const ServerToolConfig: React.FC<ServerToolConfigProps> = ({
                                   <input
                                     type="checkbox"
                                     checked={isChecked}
-                                    onChange={() =>
-                                      toggleCapabilityItem(server.name, key, item.value)
-                                    }
+                                    onChange={() => toggleCapabilityItem(server, key, item.value)}
                                     className="w-3 h-3 text-blue-600 bg-gray-100 dark:bg-gray-800 border-gray-300 rounded focus:ring-blue-500"
                                   />
                                   <span className="text-gray-700 break-all whitespace-nowrap flex-shrink-0">

--- a/frontend/src/contexts/ServerContext.tsx
+++ b/frontend/src/contexts/ServerContext.tsx
@@ -344,7 +344,7 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     async (server: Server) => {
       try {
         // Fetch single server config instead of all settings
-        const encodedServerName = encodeURIComponent(server.name);
+        const encodedServerName = encodeURIComponent(server.id ?? server.name);
         const serverData: ApiResponse<{
           name: string;
           status: string;
@@ -397,7 +397,8 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const handleServerToggle = useCallback(
     async (server: Server, enabled: boolean) => {
       try {
-        const encodedServerName = encodeURIComponent(server.name);
+        const serverIdentifier = server.id ?? server.name;
+        const encodedServerName = encodeURIComponent(serverIdentifier);
         const result = await apiPost(`/servers/${encodedServerName}/toggle`, { enabled });
 
         if (!result || !result.success) {
@@ -406,8 +407,8 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
           return false;
         }
 
-        setServers((prev) => applyServerListPatch(prev, server.name, { enabled }));
-        setAllServers((prev) => applyServerListPatch(prev, server.name, { enabled }));
+        setServers((prev) => applyServerListPatch(prev, serverIdentifier, { enabled }));
+        setAllServers((prev) => applyServerListPatch(prev, serverIdentifier, { enabled }));
         setRefreshKey((prevKey) => prevKey + 1);
         return true;
       } catch (err) {
@@ -422,7 +423,8 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const handleServerVisibilityChange = useCallback(
     async (server: Server, visibility: 'private' | 'group' | 'public') => {
       try {
-        const encodedServerName = encodeURIComponent(server.name);
+        const serverIdentifier = server.id ?? server.name;
+        const encodedServerName = encodeURIComponent(serverIdentifier);
         const serverData: ApiResponse<{
           name: string;
           status: string;
@@ -447,8 +449,8 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
           return false;
         }
 
-        setServers((prev) => applyServerListPatch(prev, server.name, { visibility }));
-        setAllServers((prev) => applyServerListPatch(prev, server.name, { visibility }));
+        setServers((prev) => applyServerListPatch(prev, serverIdentifier, { visibility }));
+        setAllServers((prev) => applyServerListPatch(prev, serverIdentifier, { visibility }));
         setRefreshKey((prevKey) => prevKey + 1);
         return true;
       } catch (err) {
@@ -463,7 +465,7 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const handleServerReload = useCallback(
     async (server: Server) => {
       try {
-        const encodedServerName = encodeURIComponent(server.name);
+        const encodedServerName = encodeURIComponent(server.id ?? server.name);
         const result = await apiPost(`/servers/${encodedServerName}/reload`, {});
 
         if (!result || !result.success) {
@@ -487,7 +489,7 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const handleServerReinstall = useCallback(
     async (server: Server) => {
       try {
-        const encodedServerName = encodeURIComponent(server.name);
+        const encodedServerName = encodeURIComponent(server.id ?? server.name);
         const result = await apiPost(`/servers/${encodedServerName}/reinstall`, {});
 
         if (!result || !result.success) {
@@ -511,7 +513,7 @@ export const ServerProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const handleServerOAuthDisconnect = useCallback(
     async (server: Server) => {
       try {
-        const result = await disconnectServerOAuthRequest(server.name);
+        const result = await disconnectServerOAuthRequest(server.id ?? server.name);
 
         if (!result || !result.success) {
           console.error('Failed to disconnect server OAuth', { serverName: server.name, result });

--- a/frontend/src/pages/ServersPage.tsx
+++ b/frontend/src/pages/ServersPage.tsx
@@ -91,8 +91,7 @@ const ServersPage: React.FC = () => {
           <p className="hub-sub">
             <span className="hub-num">{counts.all}</span> {t('nav.servers').toLowerCase()} ·{' '}
             <span className="hub-num">{counts.online}</span> {t('status.online')} ·{' '}
-            <span className="hub-num">{counts.issues}</span>{' '}
-            {t('common.inactive') || 'issues'}
+            <span className="hub-num">{counts.issues}</span> {t('common.inactive') || 'issues'}
           </p>
         </div>
         <div className="flex gap-2">
@@ -217,7 +216,7 @@ const ServersPage: React.FC = () => {
           <div className="flex flex-col">
             {visibleServers.map((server) => (
               <ServerCard
-                key={server.name}
+                key={server.id ?? server.name}
                 server={server}
                 cost={serverCosts.find((c) => c.name === server.name)}
                 onRemove={handleServerRemove}
@@ -236,7 +235,10 @@ const ServersPage: React.FC = () => {
             <div className="flex-[2]">
               {t('common.showing', {
                 start: (clientPagination.page - 1) * clientPagination.limit + 1,
-                end: Math.min(clientPagination.page * clientPagination.limit, clientPagination.total),
+                end: Math.min(
+                  clientPagination.page * clientPagination.limit,
+                  clientPagination.total,
+                ),
                 total: clientPagination.total,
               })}
             </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -300,6 +300,7 @@ export interface OpenAPISecurityConfig {
 
 // Server types
 export interface Server {
+  id?: string;
   name: string;
   owner?: string;
   visibility?: 'private' | 'group' | 'public';
@@ -320,6 +321,7 @@ export interface Server {
 // Group types
 // Group server configuration - supports tool selection
 export interface IGroupServerConfig {
+  serverId?: string;
   name: string; // Server name
   alias?: string; // Optional exposed name for this server within the group
   tools?: string[] | 'all'; // Array of specific tool names to include, or 'all' for all tools (default: 'all')

--- a/frontend/src/utils/serverListState.ts
+++ b/frontend/src/utils/serverListState.ts
@@ -7,11 +7,11 @@ type ServerListPatch = {
 
 export const applyServerListPatch = (
   servers: Server[],
-  serverName: string,
+  serverIdentifier: string,
   patch: ServerListPatch,
 ): Server[] =>
   servers.map((server) => {
-    if (server.name !== serverName) {
+    if ((server.id ?? server.name) !== serverIdentifier) {
       return server;
     }
 

--- a/src/config/DaoConfigService.ts
+++ b/src/config/DaoConfigService.ts
@@ -12,6 +12,7 @@ import {
   getSystemConfigDao,
   getUserConfigDao,
 } from '../dao/index.js';
+import { serializeServersForSettings } from '../utils/serverSettings.js';
 
 /**
  * Configuration service using DAO layer
@@ -38,11 +39,7 @@ export class DaoConfigService {
     ]);
 
     // Convert servers back to the original format
-    const mcpServers: { [key: string]: ServerConfig } = {};
-    for (const server of servers) {
-      const { name, ...config } = server;
-      mcpServers[name] = config;
-    }
+    const mcpServers = serializeServersForSettings(servers);
 
     const settings: McpSettings = {
       users,
@@ -95,21 +92,42 @@ export class DaoConfigService {
       // Save servers
       if (settings.mcpServers) {
         const currentServers = await this.serverDao.findAll();
-        const currentServerNames = new Set(currentServers.map((s: ServerConfigWithName) => s.name));
+        const retainedServerIds = new Set<string>();
+        const incomingNameCounts = new Map<string, number>();
+        const currentNameCounts = new Map<string, number>();
+        for (const [storageId, storedConfig] of Object.entries(settings.mcpServers)) {
+          const name = storedConfig.name || storageId;
+          incomingNameCounts.set(name, (incomingNameCounts.get(name) ?? 0) + 1);
+        }
+        for (const server of currentServers) {
+          currentNameCounts.set(server.name, (currentNameCounts.get(server.name) ?? 0) + 1);
+        }
 
-        for (const [name, config] of Object.entries(settings.mcpServers)) {
-          const serverWithName: ServerConfigWithName = { name, ...config };
-          if (currentServerNames.has(name)) {
-            promises.push(this.serverDao.update(name, serverWithName));
+        for (const [storageId, storedConfig] of Object.entries(settings.mcpServers)) {
+          const { name: storedName, ...config } = storedConfig;
+          const name = storedName || storageId;
+          const existingById = currentServers.find(
+            (server: ServerConfigWithName) => server.id === storageId,
+          );
+          const canMatchLegacyName =
+            incomingNameCounts.get(name) === 1 && currentNameCounts.get(name) === 1;
+          const existing =
+            existingById ||
+            (canMatchLegacyName
+              ? currentServers.find((server: ServerConfigWithName) => server.name === name)
+              : undefined);
+          if (existing) {
+            retainedServerIds.add(existing.id);
+            promises.push(this.serverDao.update(existing.id, { name, ...config }));
           } else {
-            promises.push(this.serverDao.create(serverWithName));
+            promises.push(this.serverDao.create({ name, ...config }));
           }
         }
 
         // Remove servers that are no longer in the settings
         for (const existingServer of currentServers) {
-          if (!settings.mcpServers[existingServer.name]) {
-            promises.push(this.serverDao.delete(existingServer.name));
+          if (!retainedServerIds.has(existingServer.id)) {
+            promises.push(this.serverDao.delete(existingServer.id));
           }
         }
       }

--- a/src/controllers/configController.ts
+++ b/src/controllers/configController.ts
@@ -14,6 +14,7 @@ import {
   getBearerKeyDao,
 } from '../dao/DaoFactory.js';
 import { getBetterAuthRuntimeConfig } from '../services/betterAuthConfig.js';
+import { serializeServersForSettings } from '../utils/serverSettings.js';
 
 const dataService: DataService = getDataService();
 
@@ -152,7 +153,7 @@ export const getMcpSettingsJson = async (req: Request, res: Response): Promise<v
       }
 
       // Remove the 'name' field from config as it's used as the key
-      const { name, ...configWithoutName } = serverConfig;
+      const { id: _id, name, ...configWithoutName } = serverConfig;
       // Remove null values from the config
       const cleanedConfig = removeNullValues(configWithoutName);
       res.json({
@@ -185,10 +186,7 @@ export const getMcpSettingsJson = async (req: Request, res: Response): Promise<v
         getBearerKeyDao().findAll(),
       ]);
 
-      const mcpServers: Record<string, any> = {};
-      for (const { name: serverConfigName, ...config } of servers) {
-        mcpServers[serverConfigName] = removeNullValues(config);
-      }
+      const mcpServers = removeNullValues(serializeServersForSettings(servers));
 
       const settings = {
         mcpServers,

--- a/src/controllers/groupController.ts
+++ b/src/controllers/groupController.ts
@@ -490,7 +490,8 @@ export const deleteExistingGroup = async (req: Request, res: Response): Promise<
 export const addServerToExistingGroup = async (req: Request, res: Response): Promise<void> => {
   try {
     const { id } = req.params;
-    const { serverName } = req.body;
+    const { serverId, serverName } = req.body;
+    const serverIdentifier = serverId || serverName;
     if (!id) {
       res.status(400).json({
         success: false,
@@ -499,15 +500,15 @@ export const addServerToExistingGroup = async (req: Request, res: Response): Pro
       return;
     }
 
-    if (!serverName) {
+    if (!serverIdentifier) {
       res.status(400).json({
         success: false,
-        message: 'Server name is required',
+        message: 'Server ID or name is required',
       });
       return;
     }
 
-    const updatedGroup = await addServerToGroup(id, serverName);
+    const updatedGroup = await addServerToGroup(id, serverIdentifier, Boolean(serverId));
     if (!updatedGroup) {
       res.status(404).json({
         success: false,

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -46,9 +46,10 @@ import type { UpstreamOAuthDisconnectScope } from '../services/upstreamOAuthDisc
 import { normalizeServerConfigForPersistence } from '../utils/serverConfigPersistence.js';
 import { setCachedSystemConfig } from '../utils/systemConfigCache.js';
 import { DEFAULT_INSTALL_BASE_URL, withResolvedInstallBaseUrl } from '../utils/installBaseUrl.js';
+import { serializeServersForSettings } from '../utils/serverSettings.js';
 
 type DescribableConfig = Record<string, { enabled: boolean; description?: string }>;
-type ServerRecord = ServerConfig & { name: string };
+type ServerRecord = ServerConfig & { id?: string; name: string };
 
 type RequestUser = {
   username: string;
@@ -86,7 +87,16 @@ const loadAuthorizedServer = async (
   serverName: string,
 ): Promise<ServerRecord | null> => {
   const serverDao = getServerDao();
-  const server = await serverDao.findById(serverName);
+  const namedServers = await serverDao.findByName(serverName);
+  if (namedServers.length > 1) {
+    res.status(409).json({
+      success: false,
+      message: `Server name '${serverName}' is ambiguous; use a server ID`,
+      data: namedServers.map((server) => ({ id: server.id, name: server.name })),
+    });
+    return null;
+  }
+  const server = namedServers[0] ?? (await serverDao.findById(serverName));
 
   if (!server) {
     res.status(404).json({
@@ -128,11 +138,7 @@ const ensureNonAdminCanManageConfig = (
   return true;
 };
 
-const assignServerOwner = (
-  req: Request,
-  config: ServerConfig,
-  existingOwner?: string,
-): void => {
+const assignServerOwner = (req: Request, config: ServerConfig, existingOwner?: string): void => {
   const currentUser = getRequestUser(req);
   if (!currentUser) {
     return;
@@ -310,11 +316,7 @@ export const getAllSettings = async (req: Request, res: Response): Promise<void>
     ]);
 
     // Convert servers array to mcpServers map format
-    const mcpServers: McpSettings['mcpServers'] = {};
-    for (const server of servers) {
-      const { name, ...config } = server;
-      mcpServers[name] = config;
-    }
+    const mcpServers = serializeServersForSettings(servers);
 
     const systemConfig = systemConfigResult || {};
 
@@ -357,7 +359,8 @@ export const getAllSettings = async (req: Request, res: Response): Promise<void>
       bearerKeys: bearerKeys.map((key) => ({
         ...key,
         kind: key.kind ?? 'system',
-        token: key.token.length > 12 ? `${key.token.slice(0, 8)}...${key.token.slice(-4)}` : '********',
+        token:
+          key.token.length > 12 ? `${key.token.slice(0, 8)}...${key.token.slice(-4)}` : '********',
       })),
     };
 
@@ -485,8 +488,7 @@ export const createServer = async (req: Request, res: Response): Promise<void> =
 
     // Set default keep-alive interval for SSE servers if not specified
     if (
-      (normalizedConfig.type === 'sse' ||
-        (!normalizedConfig.type && normalizedConfig.url)) &&
+      (normalizedConfig.type === 'sse' || (!normalizedConfig.type && normalizedConfig.url)) &&
       !normalizedConfig.keepAliveInterval
     ) {
       normalizedConfig.keepAliveInterval = 60000; // Default 60 seconds for SSE servers
@@ -499,8 +501,9 @@ export const createServer = async (req: Request, res: Response): Promise<void> =
       res.json({
         success: true,
         message: 'Server added successfully',
+        ...(result.serverId ? { data: { id: result.serverId, name } } : {}),
       });
-      notifyToolChanged(name, { reportEmbeddingProgress: true }).catch((error) => {
+      notifyToolChanged(result.serverId, { reportEmbeddingProgress: true }).catch((error) => {
         console.error('Failed to trigger embedding sync for created server:', error);
       });
     } else {
@@ -643,8 +646,7 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
         const normalizedConfig = normalizeServerConfigForPersistence(config);
 
         if (
-          (normalizedConfig.type === 'sse' ||
-            (!normalizedConfig.type && normalizedConfig.url)) &&
+          (normalizedConfig.type === 'sse' || (!normalizedConfig.type && normalizedConfig.url)) &&
           !normalizedConfig.keepAliveInterval
         ) {
           normalizedConfig.keepAliveInterval = 60000; // Default 60 seconds for SSE servers
@@ -661,13 +663,16 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
         }
 
         // Set owner property if not provided
-        normalizedConfig.owner = currentUser?.isAdmin ? normalizedConfig.owner || defaultOwner : defaultOwner;
+        normalizedConfig.owner = currentUser?.isAdmin
+          ? normalizedConfig.owner || defaultOwner
+          : defaultOwner;
 
         // Attempt to add server
         const result = await addServer(name, normalizedConfig);
         if (result.success) {
           results.push({
             name,
+            serverId: result.serverId,
             success: true,
           });
           successCount++;
@@ -706,8 +711,11 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
 
     if (successCount > 0) {
       const successfulServerNames = results
-        .filter((result): result is BatchServerResult & { name: string; success: true } => result.success)
-        .map((result) => result.name);
+        .filter(
+          (result): result is BatchServerResult & { serverId: string; success: true } =>
+            result.success && Boolean(result.serverId),
+        )
+        .map((result) => result.serverId);
 
       Promise.all(
         successfulServerNames.map((serverName) =>
@@ -742,7 +750,7 @@ export const deleteServer = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
-    const result = await removeServer(existingServer.name);
+    const result = await removeServer(existingServer.id ?? existingServer.name);
     if (result.success) {
       notifyToolChanged();
       res.json({
@@ -865,8 +873,7 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
 
     // Set default keep-alive interval for SSE servers if not specified
     if (
-      (normalizedConfig.type === 'sse' ||
-        (!normalizedConfig.type && normalizedConfig.url)) &&
+      (normalizedConfig.type === 'sse' || (!normalizedConfig.type && normalizedConfig.url)) &&
       !normalizedConfig.keepAliveInterval
     ) {
       normalizedConfig.keepAliveInterval = 60000; // Default 60 seconds for SSE servers
@@ -882,17 +889,8 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
     if (isRenaming) {
       const serverDao = getServerDao();
 
-      // Check if new name already exists
-      if (await serverDao.exists(newName)) {
-        res.status(400).json({
-          success: false,
-          message: `Server name '${newName}' already exists`,
-        });
-        return;
-      }
-
       // Rename the server
-      const renamed = await serverDao.rename(name, newName);
+      const renamed = await serverDao.rename(existingServer.id ?? existingServer.name, newName);
       if (!renamed) {
         res.status(404).json({
           success: false,
@@ -911,11 +909,12 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
     }
 
     // Use the final server name (new name if renaming, otherwise original name)
-    const finalName = isRenaming ? newName : name;
+    const finalName = isRenaming ? newName : existingServer.name;
+    const serverIdentifier = existingServer.id ?? existingServer.name;
 
     if (!isRenaming && isVisibilityOnlyServerUpdate(existingServer, normalizedConfig)) {
       const serverDao = getServerDao();
-      const updatedServer = await serverDao.update(name, normalizedConfig);
+      const updatedServer = await serverDao.update(serverIdentifier, normalizedConfig);
 
       if (!updatedServer) {
         res.status(404).json({
@@ -925,7 +924,7 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
         return;
       }
 
-      updateServerInfoVisibility(finalName, normalizedConfig.visibility ?? 'private');
+      updateServerInfoVisibility(serverIdentifier, normalizedConfig.visibility ?? 'private');
       broadcastToolListChanged();
 
       res.json({
@@ -935,9 +934,9 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
-    const result = await addOrUpdateServer(finalName, normalizedConfig, true); // Allow override for updates
+    const result = await addOrUpdateServer(serverIdentifier, normalizedConfig, true); // Allow override for updates
     if (result.success) {
-      notifyToolChanged(finalName);
+      notifyToolChanged(serverIdentifier);
       res.json({
         success: true,
         message: isRenaming
@@ -969,10 +968,12 @@ export const getServerConfig = async (req: Request, res: Response): Promise<void
 
     // Get runtime info (status, tools) from getServersInfo
     const allServers = await getServersInfo();
-    const serverInfo = allServers.find((s) => s.name === name);
+    const serverInfo = allServers.find((s) =>
+      serverConfig.id ? s.id === serverConfig.id : s.name === serverConfig.name,
+    );
 
     // Extract config without the name field
-    const { name: serverName, ...config } = serverConfig;
+    const { id: serverId, name: serverName, ...config } = serverConfig;
 
     // OpenAPI tools can carry circular $ref cycles left by SwaggerParser.dereference
     // (recursive schemas), which would make res.json throw. Mirror the list endpoint
@@ -980,6 +981,7 @@ export const getServerConfig = async (req: Request, res: Response): Promise<void
     const response: ApiResponse = {
       success: true,
       data: createSafeJSON({
+        ...(serverId ? { id: serverId } : {}),
         name: serverName,
         status: serverInfo?.status || 'disconnected',
         tools: serverInfo?.tools || [],
@@ -1022,7 +1024,7 @@ export const toggleServer = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
-    const result = await toggleServerStatus(existingServer.name, enabled);
+    const result = await toggleServerStatus(existingServer.id ?? existingServer.name, enabled);
     if (result.success) {
       // On disable, toggleServerStatus synchronously closes the server and
       // updates serverInfos, so we broadcast the now-removed tools/prompts/
@@ -1069,7 +1071,7 @@ export const reloadServer = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
-    await reconnectServer(existingServer.name);
+    await reconnectServer(existingServer.id ?? existingServer.name);
 
     res.json({
       success: true,
@@ -1121,7 +1123,9 @@ export const disconnectServerOAuth = async (req: Request, res: Response): Promis
       return;
     }
 
-    const result = await disconnectUpstreamOAuth(existingServer.name, { scope });
+    const result = await disconnectUpstreamOAuth(existingServer.id ?? existingServer.name, {
+      scope,
+    });
     const { success: _success, ...data } = result;
 
     res.json({
@@ -1155,7 +1159,7 @@ export const reinstallServerHandler = async (req: Request, res: Response): Promi
       return;
     }
 
-    await reinstallServer(existingServer.name);
+    await reinstallServer(existingServer.id ?? existingServer.name);
 
     res.json({
       success: true,
@@ -1165,10 +1169,7 @@ export const reinstallServerHandler = async (req: Request, res: Response): Promi
     console.error('Failed to reinstall server:', error);
     const message = error instanceof Error ? error.message : 'Failed to reinstall server';
     // Validation errors (unsupported command, disabled server) → 400
-    if (
-      message.includes('does not support cache refresh') ||
-      message.includes('disabled server')
-    ) {
+    if (message.includes('does not support cache refresh') || message.includes('disabled server')) {
       res.status(400).json({ success: false, message });
     } else {
       res.status(500).json({ success: false, message: 'Failed to reinstall server' });
@@ -1457,8 +1458,7 @@ export const updateSystemConfig = async (req: Request, res: Response): Promise<v
 
     const hasSessionRebuildUpdate = typeof enableSessionRebuild === 'boolean';
 
-    const hasActivityLogUpdate =
-      activityLog && typeof activityLog.storeToolPayload === 'boolean';
+    const hasActivityLogUpdate = activityLog && typeof activityLog.storeToolPayload === 'boolean';
 
     const hasOAuthServerUpdate =
       oauthServer &&
@@ -1750,15 +1750,18 @@ export const updateSystemConfig = async (req: Request, res: Response): Promise<v
             }
           } else {
             // Get current OpenAI config values, preferring new values from request
-            const currentOpenAiKey = typeof smartRouting.openaiApiKey === 'string'
-              ? smartRouting.openaiApiKey.trim()
-              : (systemConfig.smartRouting.openaiApiKey || '').trim();
-            const currentOpenaiApiBaseUrl = typeof smartRouting.openaiApiBaseUrl === 'string'
-              ? smartRouting.openaiApiBaseUrl.trim()
-              : (systemConfig.smartRouting.openaiApiBaseUrl || '').trim();
-            const currentOpenaiApiEmbeddingModel = typeof smartRouting.openaiApiEmbeddingModel === 'string'
-              ? smartRouting.openaiApiEmbeddingModel.trim()
-              : (systemConfig.smartRouting.openaiApiEmbeddingModel || '').trim();
+            const currentOpenAiKey =
+              typeof smartRouting.openaiApiKey === 'string'
+                ? smartRouting.openaiApiKey.trim()
+                : (systemConfig.smartRouting.openaiApiKey || '').trim();
+            const currentOpenaiApiBaseUrl =
+              typeof smartRouting.openaiApiBaseUrl === 'string'
+                ? smartRouting.openaiApiBaseUrl.trim()
+                : (systemConfig.smartRouting.openaiApiBaseUrl || '').trim();
+            const currentOpenaiApiEmbeddingModel =
+              typeof smartRouting.openaiApiEmbeddingModel === 'string'
+                ? smartRouting.openaiApiEmbeddingModel.trim()
+                : (systemConfig.smartRouting.openaiApiEmbeddingModel || '').trim();
 
             if (!currentOpenAiKey || !currentOpenaiApiBaseUrl || !currentOpenaiApiEmbeddingModel) {
               res.status(400).json({
@@ -1801,7 +1804,8 @@ export const updateSystemConfig = async (req: Request, res: Response): Promise<v
         systemConfig.smartRouting.azureOpenaiApiKey = smartRouting.azureOpenaiApiKey?.trim();
       }
       if (typeof smartRouting.azureOpenaiApiVersion === 'string') {
-        systemConfig.smartRouting.azureOpenaiApiVersion = smartRouting.azureOpenaiApiVersion?.trim();
+        systemConfig.smartRouting.azureOpenaiApiVersion =
+          smartRouting.azureOpenaiApiVersion?.trim();
       }
       if (typeof smartRouting.azureOpenaiEmbeddingDeployment === 'string') {
         systemConfig.smartRouting.azureOpenaiEmbeddingDeployment =

--- a/src/dao/GroupDao.ts
+++ b/src/dao/GroupDao.ts
@@ -164,7 +164,7 @@ export class GroupDaoImpl extends JsonFileBaseDao implements GroupDao {
           if (typeof server === 'string') {
             return server === serverName;
           } else {
-            return server.name === serverName;
+            return server.serverId === serverName || server.name === serverName;
           }
         });
       }
@@ -183,7 +183,7 @@ export class GroupDaoImpl extends JsonFileBaseDao implements GroupDao {
       if (typeof server === 'string') {
         return server === serverName;
       } else {
-        return server.name === serverName;
+        return server.serverId === serverName || server.name === serverName;
       }
     });
 
@@ -206,7 +206,7 @@ export class GroupDaoImpl extends JsonFileBaseDao implements GroupDao {
       if (typeof server === 'string') {
         return server !== serverName;
       } else {
-        return server.name !== serverName;
+        return server.serverId !== serverName && server.name !== serverName;
       }
     }) as IGroup['servers'];
 
@@ -238,7 +238,7 @@ export class GroupDaoImpl extends JsonFileBaseDao implements GroupDao {
           }
           return server;
         } else {
-          if (server.name === oldName) {
+          if (!server.serverId && server.name === oldName) {
             updated = true;
             return { ...server, name: newName };
           }

--- a/src/dao/GroupDaoDbImpl.ts
+++ b/src/dao/GroupDaoDbImpl.ts
@@ -95,7 +95,11 @@ export class GroupDaoDbImpl implements GroupDao {
     const allGroups = await this.repository.findAll();
     return allGroups
       .filter((g) =>
-        g.servers.some((s) => (typeof s === 'string' ? s === serverName : s.name === serverName)),
+        g.servers.some((s) =>
+          typeof s === 'string'
+            ? s === serverName
+            : s.serverId === serverName || s.name === serverName,
+        ),
       )
       .map((g) => ({
         id: g.id,
@@ -112,7 +116,7 @@ export class GroupDaoDbImpl implements GroupDao {
 
     // Check if server already exists
     const serverExists = group.servers.some((s) =>
-      typeof s === 'string' ? s === serverName : s.name === serverName,
+      typeof s === 'string' ? s === serverName : s.serverId === serverName || s.name === serverName,
     );
 
     if (!serverExists) {
@@ -128,7 +132,7 @@ export class GroupDaoDbImpl implements GroupDao {
     if (!group) return false;
 
     group.servers = group.servers.filter((s) =>
-      typeof s === 'string' ? s !== serverName : s.name !== serverName,
+      typeof s === 'string' ? s !== serverName : s.serverId !== serverName && s.name !== serverName,
     ) as any;
 
     await this.update(groupId, { servers: group.servers as any });
@@ -166,7 +170,7 @@ export class GroupDaoDbImpl implements GroupDao {
           }
           return server;
         } else {
-          if (server.name === oldName) {
+          if (!server.serverId && server.name === oldName) {
             updated = true;
             return { ...server, name: newName };
           }

--- a/src/dao/ServerDao.ts
+++ b/src/dao/ServerDao.ts
@@ -1,6 +1,7 @@
 import { ServerConfig } from '../types/index.js';
 import { BaseDao } from './base/BaseDao.js';
 import { JsonFileBaseDao } from './base/JsonFileBaseDao.js';
+import { randomUUID } from 'node:crypto';
 
 /**
  * Pagination result interface
@@ -17,6 +18,8 @@ export interface PaginatedResult<T> {
  * Server DAO interface with server-specific operations
  */
 export interface ServerDao extends BaseDao<ServerConfigWithName, string> {
+  /** Find every server with the given user-facing name. */
+  findByName(name: string): Promise<ServerConfigWithName[]>;
   /**
    * Find all servers with pagination
    */
@@ -25,7 +28,11 @@ export interface ServerDao extends BaseDao<ServerConfigWithName, string> {
   /**
    * Find servers by owner with pagination
    */
-  findByOwnerPaginated(owner: string, page: number, limit: number): Promise<PaginatedResult<ServerConfigWithName>>;
+  findByOwnerPaginated(
+    owner: string,
+    page: number,
+    limit: number,
+  ): Promise<PaginatedResult<ServerConfigWithName>>;
 
   /**
    * Find servers visible to a non-admin user with pagination.
@@ -91,6 +98,7 @@ export interface ServerDao extends BaseDao<ServerConfigWithName, string> {
  * Server configuration with name for DAO operations
  */
 export interface ServerConfigWithName extends ServerConfig {
+  id: string;
   name: string;
 }
 
@@ -98,13 +106,24 @@ export interface ServerConfigWithName extends ServerConfig {
  * JSON file-based Server DAO implementation
  */
 export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
+  private resolveIndex(servers: ServerConfigWithName[], identifier: string): number {
+    const byId = servers.findIndex((server) => server.id === identifier);
+    if (byId !== -1) return byId;
+    const byName = servers
+      .map((server, index) => ({ server, index }))
+      .filter(({ server }) => server.name === identifier);
+    return byName.length === 1 ? byName[0].index : -1;
+  }
+
   protected async getAll(): Promise<ServerConfigWithName[]> {
     const settings = await this.loadSettings();
     const servers: ServerConfigWithName[] = [];
 
-    for (const [name, config] of Object.entries(settings.mcpServers || {})) {
+    for (const [id, storedConfig] of Object.entries(settings.mcpServers || {})) {
+      const { name: storedName, ...config } = storedConfig;
       servers.push({
-        name,
+        id,
+        name: storedName || id,
         ...config,
       });
     }
@@ -117,18 +136,21 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     settings.mcpServers = {};
 
     for (const server of servers) {
-      const { name, ...config } = server;
-      settings.mcpServers[name] = config;
+      const { id, name, ...config } = server;
+      settings.mcpServers[id] = {
+        ...(id === name ? {} : { name }),
+        ...config,
+      };
     }
 
     await this.saveSettings(settings);
   }
 
   protected getEntityId(server: ServerConfigWithName): string {
-    return server.name;
+    return server.id;
   }
 
-  protected createEntity(_data: Omit<ServerConfigWithName, 'name'>): ServerConfigWithName {
+  protected createEntity(_data: Omit<ServerConfigWithName, 'id'>): ServerConfigWithName {
     throw new Error('Server name must be provided');
   }
 
@@ -148,22 +170,24 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     return this.getAll();
   }
 
-  async findById(name: string): Promise<ServerConfigWithName | null> {
+  async findById(identifier: string): Promise<ServerConfigWithName | null> {
     const servers = await this.getAll();
-    return servers.find((server) => server.name === name) || null;
+    const byId = servers.find((server) => server.id === identifier);
+    if (byId) return byId;
+    const byName = servers.filter((server) => server.name === identifier);
+    return byName.length === 1 ? byName[0] : null;
   }
 
-  async create(
-    data: Omit<ServerConfigWithName, 'name'> & { name: string },
-  ): Promise<ServerConfigWithName> {
+  async findByName(name: string): Promise<ServerConfigWithName[]> {
+    const servers = await this.getAll();
+    return servers.filter((server) => server.name === name);
+  }
+
+  async create(data: Omit<ServerConfigWithName, 'id'>): Promise<ServerConfigWithName> {
     const servers = await this.getAll();
 
-    // Check if server already exists
-    if (servers.find((server) => server.name === data.name)) {
-      throw new Error(`Server ${data.name} already exists`);
-    }
-
     const newServer: ServerConfigWithName = {
+      id: randomUUID(),
       enabled: true, // Default to enabled
       owner: 'admin', // Default owner
       ...data,
@@ -176,11 +200,11 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
   }
 
   async update(
-    name: string,
+    identifier: string,
     updates: Partial<ServerConfigWithName>,
   ): Promise<ServerConfigWithName | null> {
     const servers = await this.getAll();
-    const index = servers.findIndex((server) => server.name === name);
+    const index = this.resolveIndex(servers, identifier);
 
     if (index === -1) {
       return null;
@@ -193,9 +217,9 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     return updatedServer;
   }
 
-  async delete(name: string): Promise<boolean> {
+  async delete(identifier: string): Promise<boolean> {
     const servers = await this.getAll();
-    const index = servers.findIndex((server) => server.name === name);
+    const index = this.resolveIndex(servers, identifier);
     if (index === -1) {
       return false;
     }
@@ -205,9 +229,9 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     return true;
   }
 
-  async exists(name: string): Promise<boolean> {
-    const server = await this.findById(name);
-    return server !== null;
+  async exists(identifier: string): Promise<boolean> {
+    const servers = await this.getAll();
+    return servers.some((server) => server.id === identifier || server.name === identifier);
   }
 
   async count(): Promise<number> {
@@ -215,7 +239,10 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     return servers.length;
   }
 
-  async findAllPaginated(page: number, limit: number): Promise<PaginatedResult<ServerConfigWithName>> {
+  async findAllPaginated(
+    page: number,
+    limit: number,
+  ): Promise<PaginatedResult<ServerConfigWithName>> {
     const allServers = await this.getAll();
     // Sort: enabled servers first, then by creation time
     const sortedServers = allServers.sort((a, b) => {
@@ -226,7 +253,7 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
       }
       return 0; // Keep original order for same enabled status
     });
-    
+
     const total = sortedServers.length;
     const totalPages = Math.ceil(total / limit);
     const startIndex = (page - 1) * limit;
@@ -242,7 +269,11 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     };
   }
 
-  async findByOwnerPaginated(owner: string, page: number, limit: number): Promise<PaginatedResult<ServerConfigWithName>> {
+  async findByOwnerPaginated(
+    owner: string,
+    page: number,
+    limit: number,
+  ): Promise<PaginatedResult<ServerConfigWithName>> {
     const allServers = await this.getAll();
     const filteredServers = allServers.filter((server) => server.owner === owner);
     // Sort: enabled servers first, then by creation time
@@ -254,7 +285,7 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
       }
       return 0; // Keep original order for same enabled status
     });
-    
+
     const total = sortedServers.length;
     const totalPages = Math.ceil(total / limit);
     const startIndex = (page - 1) * limit;
@@ -349,15 +380,10 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
 
   async rename(oldName: string, newName: string): Promise<boolean> {
     const servers = await this.getAll();
-    const index = servers.findIndex((server) => server.name === oldName);
+    const index = this.resolveIndex(servers, oldName);
 
     if (index === -1) {
       return false;
-    }
-
-    // Check if newName already exists
-    if (servers.find((server) => server.name === newName)) {
-      throw new Error(`Server ${newName} already exists`);
     }
 
     servers[index] = { ...servers[index], name: newName };

--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -11,6 +11,13 @@ export class ServerDaoDbImpl implements ServerDao {
     this.repository = new ServerRepository();
   }
 
+  private async resolveServer(identifier: string) {
+    const byId = await this.repository.findById(identifier);
+    if (byId) return byId;
+    const byName = await this.repository.findAllByName(identifier);
+    return byName.length === 1 ? byName[0] : null;
+  }
+
   async findAll(): Promise<ServerConfigWithName[]> {
     const servers = await this.repository.findAll();
     return servers.map((s) => this.mapToServerConfig(s));
@@ -67,11 +74,16 @@ export class ServerDaoDbImpl implements ServerDao {
   }
 
   async findById(name: string): Promise<ServerConfigWithName | null> {
-    const server = await this.repository.findByName(name);
+    const server = await this.resolveServer(name);
     return server ? this.mapToServerConfig(server) : null;
   }
 
-  async create(entity: ServerConfigWithName): Promise<ServerConfigWithName> {
+  async findByName(name: string): Promise<ServerConfigWithName[]> {
+    const servers = await this.repository.findAllByName(name);
+    return servers.map((server) => this.mapToServerConfig(server));
+  }
+
+  async create(entity: Omit<ServerConfigWithName, 'id'>): Promise<ServerConfigWithName> {
     const server = await this.repository.create({
       name: entity.name,
       type: entity.type,
@@ -147,16 +159,20 @@ export class ServerDaoDbImpl implements ServerDao {
     assignNullable('passthroughHeaders');
     assignNullable('perSessionClient');
 
-    const server = await this.repository.update(name, updateData as any);
+    const existing = await this.resolveServer(name);
+    if (!existing) return null;
+    const server = await this.repository.update(existing.id, updateData as any);
     return server ? this.mapToServerConfig(server) : null;
   }
 
   async delete(name: string): Promise<boolean> {
-    return await this.repository.delete(name);
+    const existing = await this.resolveServer(name);
+    return existing ? await this.repository.delete(existing.id) : false;
   }
 
   async exists(name: string): Promise<boolean> {
-    return await this.repository.exists(name);
+    if (await this.repository.exists(name)) return true;
+    return (await this.repository.findAllByName(name)).length > 0;
   }
 
   async count(): Promise<number> {
@@ -179,7 +195,9 @@ export class ServerDaoDbImpl implements ServerDao {
   }
 
   async setEnabled(name: string, enabled: boolean): Promise<boolean> {
-    const server = await this.repository.setEnabled(name, enabled);
+    const existing = await this.resolveServer(name);
+    if (!existing) return false;
+    const server = await this.repository.setEnabled(existing.id, enabled);
     return server !== null;
   }
 
@@ -208,15 +226,12 @@ export class ServerDaoDbImpl implements ServerDao {
   }
 
   async rename(oldName: string, newName: string): Promise<boolean> {
-    // Check if newName already exists
-    if (await this.repository.exists(newName)) {
-      throw new Error(`Server ${newName} already exists`);
-    }
-
-    return await this.repository.rename(oldName, newName);
+    const existing = await this.resolveServer(oldName);
+    return existing ? await this.repository.rename(existing.id, newName) : false;
   }
 
   private mapToServerConfig(server: {
+    id: string;
     name: string;
     type?: string;
     description?: string;
@@ -241,6 +256,7 @@ export class ServerDaoDbImpl implements ServerDao {
     perSessionClient?: boolean;
   }): ServerConfigWithName {
     return {
+      id: server.id,
       name: server.name,
       type: server.type as 'stdio' | 'sse' | 'streamable-http' | 'openapi' | undefined,
       description: server.description,

--- a/src/db/entities/Group.ts
+++ b/src/db/entities/Group.ts
@@ -24,6 +24,7 @@ export class Group {
   servers: Array<
     | string
     | {
+        serverId?: string;
         name: string;
         alias?: string;
         tools?: string[] | 'all';

--- a/src/db/entities/Server.ts
+++ b/src/db/entities/Server.ts
@@ -14,7 +14,7 @@ export class Server {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ type: 'varchar', length: 255, unique: true })
+  @Column({ type: 'varchar', length: 255 })
   name: string;
 
   @Column({ type: 'varchar', length: 50, nullable: true })

--- a/src/db/repositories/ServerRepository.ts
+++ b/src/db/repositories/ServerRepository.ts
@@ -26,6 +26,14 @@ export class ServerRepository {
     return await this.repository.findOne({ where: { name } });
   }
 
+  async findAllByName(name: string): Promise<Server[]> {
+    return await this.repository.find({ where: { name }, order: { createdAt: 'ASC' } });
+  }
+
+  async findById(id: string): Promise<Server | null> {
+    return await this.repository.findOne({ where: { id } });
+  }
+
   /**
    * Create a new server
    */
@@ -37,8 +45,8 @@ export class ServerRepository {
   /**
    * Update an existing server
    */
-  async update(name: string, serverData: Partial<Server>): Promise<Server | null> {
-    const server = await this.findByName(name);
+  async update(id: string, serverData: Partial<Server>): Promise<Server | null> {
+    const server = await this.findById(id);
     if (!server) {
       return null;
     }
@@ -49,16 +57,16 @@ export class ServerRepository {
   /**
    * Delete a server
    */
-  async delete(name: string): Promise<boolean> {
-    const result = await this.repository.delete({ name });
+  async delete(id: string): Promise<boolean> {
+    const result = await this.repository.delete({ id });
     return (result.affected ?? 0) > 0;
   }
 
   /**
    * Check if server exists
    */
-  async exists(name: string): Promise<boolean> {
-    const count = await this.repository.count({ where: { name } });
+  async exists(id: string): Promise<boolean> {
+    const count = await this.repository.count({ where: { id } });
     return count > 0;
   }
 
@@ -75,9 +83,9 @@ export class ServerRepository {
   async findAllPaginated(page: number, limit: number): Promise<{ data: Server[]; total: number }> {
     const skip = (page - 1) * limit;
     const [data, total] = await this.repository.findAndCount({
-      order: { 
-        enabled: 'DESC',  // Enabled servers first
-        createdAt: 'ASC'  // Then by creation time
+      order: {
+        enabled: 'DESC', // Enabled servers first
+        createdAt: 'ASC', // Then by creation time
       },
       skip,
       take: limit,
@@ -89,13 +97,17 @@ export class ServerRepository {
   /**
    * Find servers by owner with pagination
    */
-  async findByOwnerPaginated(owner: string, page: number, limit: number): Promise<{ data: Server[]; total: number }> {
+  async findByOwnerPaginated(
+    owner: string,
+    page: number,
+    limit: number,
+  ): Promise<{ data: Server[]; total: number }> {
     const skip = (page - 1) * limit;
     const [data, total] = await this.repository.findAndCount({
       where: { owner },
-      order: { 
-        enabled: 'DESC',  // Enabled servers first
-        createdAt: 'ASC'  // Then by creation time
+      order: {
+        enabled: 'DESC', // Enabled servers first
+        createdAt: 'ASC', // Then by creation time
       },
       skip,
       take: limit,
@@ -143,15 +155,15 @@ export class ServerRepository {
   /**
    * Set server enabled status
    */
-  async setEnabled(name: string, enabled: boolean): Promise<Server | null> {
-    return await this.update(name, { enabled });
+  async setEnabled(id: string, enabled: boolean): Promise<Server | null> {
+    return await this.update(id, { enabled });
   }
 
   /**
    * Rename a server
    */
-  async rename(oldName: string, newName: string): Promise<boolean> {
-    const server = await this.findByName(oldName);
+  async rename(id: string, newName: string): Promise<boolean> {
+    const server = await this.findById(id);
     if (!server) {
       return false;
     }

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -291,7 +291,7 @@ export const addServerToGroup = async (
     notifyToolChanged();
     return group;
   } catch (error) {
-    console.error(`Failed to add server ${serverIdentifier} to group ${groupId}:`, error);
+    console.error('Failed to add server to group:', error);
     return null;
   }
 };
@@ -316,7 +316,7 @@ export const removeServerFromGroup = async (
 
     return await groupDao.update(groupId, { servers: filteredServers });
   } catch (error) {
-    console.error(`Failed to remove server ${serverIdentifier} from group ${groupId}:`, error);
+    console.error('Failed to remove server from group:', error);
     return null;
   }
 };

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -17,6 +17,7 @@ export const normalizeGroupServers = (
     // New format: ensure capability selections default to 'all' if not specified
     const alias = server.alias?.trim();
     return {
+      ...(server.serverId ? { serverId: server.serverId } : {}),
       name: server.name,
       ...(alias ? { alias } : {}),
       tools: server.tools || 'all',
@@ -40,6 +41,31 @@ const hasDuplicateExposedServerName = (servers: IGroupServerConfig[]): boolean =
     seen.add(exposedName);
   }
   return false;
+};
+
+const resolveGroupServers = async (
+  servers: string[] | IGroupServerConfig[],
+): Promise<IGroupServerConfig[]> => {
+  const serverDao = getServerDao();
+  const resolved = await Promise.all(
+    normalizeGroupServers(servers).map(async (serverConfig) => {
+      const namedServers = serverConfig.serverId
+        ? []
+        : await serverDao.findByName(serverConfig.name);
+      const server = serverConfig.serverId
+        ? await serverDao.findById(serverConfig.serverId)
+        : namedServers.length === 1
+          ? namedServers[0]
+          : null;
+      if (!server) return null;
+      return {
+        ...serverConfig,
+        serverId: server.id,
+        name: server.name,
+      };
+    }),
+  );
+  return resolved.flatMap((server) => (server ? [server] : []));
 };
 
 const canMutateGroup = (group: IGroup): boolean => {
@@ -91,7 +117,6 @@ export const createGroup = async (
 ): Promise<IGroup | null> => {
   try {
     const groupDao = getGroupDao();
-    const serverDao = getServerDao();
 
     // Check if group with same name already exists
     const existingGroup = await groupDao.findByName(name);
@@ -100,12 +125,7 @@ export const createGroup = async (
     }
 
     // Normalize servers configuration and filter out non-existent servers
-    const normalizedServers = normalizeGroupServers(servers);
-    const allServers = await serverDao.findAll();
-    const serverNames = new Set(allServers.map((s) => s.name));
-    const validServers: IGroupServerConfig[] = normalizedServers.filter((serverConfig) =>
-      serverNames.has(serverConfig.name),
-    );
+    const validServers = await resolveGroupServers(servers);
     if (hasDuplicateExposedServerName(validServers)) {
       return null;
     }
@@ -130,7 +150,6 @@ export const createGroup = async (
 export const updateGroup = async (id: string, data: Partial<IGroup>): Promise<IGroup | null> => {
   try {
     const groupDao = getGroupDao();
-    const serverDao = getServerDao();
 
     const existingGroup = await groupDao.findById(id);
     if (!existingGroup || !canMutateGroup(existingGroup)) {
@@ -147,10 +166,7 @@ export const updateGroup = async (id: string, data: Partial<IGroup>): Promise<IG
 
     // If servers array is provided, validate server existence and normalize format
     if (data.servers) {
-      const normalizedServers = normalizeGroupServers(data.servers);
-      const allServers = await serverDao.findAll();
-      const serverNames = new Set(allServers.map((s) => s.name));
-      data.servers = normalizedServers.filter((serverConfig) => serverNames.has(serverConfig.name));
+      data.servers = await resolveGroupServers(data.servers);
       if (hasDuplicateExposedServerName(data.servers)) {
         return null;
       }
@@ -177,7 +193,6 @@ export const updateGroupServers = async (
 ): Promise<IGroup | null> => {
   try {
     const groupDao = getGroupDao();
-    const serverDao = getServerDao();
 
     const existingGroup = await groupDao.findById(groupId);
     if (!existingGroup || !canMutateGroup(existingGroup)) {
@@ -185,12 +200,7 @@ export const updateGroupServers = async (
     }
 
     // Normalize and filter out non-existent servers
-    const normalizedServers = normalizeGroupServers(servers);
-    const allServers = await serverDao.findAll();
-    const serverNames = new Set(allServers.map((s) => s.name));
-    const validServers = normalizedServers.filter((serverConfig) =>
-      serverNames.has(serverConfig.name),
-    );
+    const validServers = await resolveGroupServers(servers);
     if (hasDuplicateExposedServerName(validServers)) {
       return null;
     }
@@ -228,14 +238,20 @@ export const deleteGroup = async (id: string): Promise<boolean> => {
 // Add server to group
 export const addServerToGroup = async (
   groupId: string,
-  serverName: string,
+  serverIdentifier: string,
+  byId: boolean = false,
 ): Promise<IGroup | null> => {
   try {
     const groupDao = getGroupDao();
     const serverDao = getServerDao();
 
     // Verify server exists
-    const server = await serverDao.findById(serverName);
+    const namedServers = byId ? [] : await serverDao.findByName(serverIdentifier);
+    const server = byId
+      ? await serverDao.findById(serverIdentifier)
+      : namedServers.length === 1
+        ? namedServers[0]
+        : null;
     if (!server) {
       return null;
     }
@@ -248,8 +264,21 @@ export const addServerToGroup = async (
     const normalizedServers = normalizeGroupServers(group.servers);
 
     // Add server to group if not already in it
-    if (!normalizedServers.some((s) => s.name === serverName)) {
-      normalizedServers.push({ name: serverName, tools: 'all', prompts: 'all', resources: 'all' });
+    if (!normalizedServers.some((s) => s.serverId === server.id)) {
+      if (
+        normalizedServers.some(
+          (configured) => getGroupServerExposedName(configured) === server.name,
+        )
+      ) {
+        return null;
+      }
+      normalizedServers.push({
+        serverId: server.id,
+        name: server.name,
+        tools: 'all',
+        prompts: 'all',
+        resources: 'all',
+      });
       const updatedGroup = await groupDao.update(groupId, { servers: normalizedServers });
 
       if (updatedGroup) {
@@ -262,7 +291,7 @@ export const addServerToGroup = async (
     notifyToolChanged();
     return group;
   } catch (error) {
-    console.error(`Failed to add server ${serverName} to group ${groupId}:`, error);
+    console.error(`Failed to add server ${serverIdentifier} to group ${groupId}:`, error);
     return null;
   }
 };
@@ -270,7 +299,7 @@ export const addServerToGroup = async (
 // Remove server from group
 export const removeServerFromGroup = async (
   groupId: string,
-  serverName: string,
+  serverIdentifier: string,
 ): Promise<IGroup | null> => {
   try {
     const groupDao = getGroupDao();
@@ -281,11 +310,13 @@ export const removeServerFromGroup = async (
     }
 
     const normalizedServers = normalizeGroupServers(group.servers);
-    const filteredServers = normalizedServers.filter((server) => server.name !== serverName);
+    const filteredServers = normalizedServers.filter(
+      (server) => server.serverId !== serverIdentifier && server.name !== serverIdentifier,
+    );
 
     return await groupDao.update(groupId, { servers: filteredServers });
   } catch (error) {
-    console.error(`Failed to remove server ${serverName} from group ${groupId}:`, error);
+    console.error(`Failed to remove server ${serverIdentifier} from group ${groupId}:`, error);
     return null;
   }
 };
@@ -306,7 +337,9 @@ export const getServerConfigInGroup = async (
   const group = await getGroupByIdOrName(groupId);
   if (!group) return undefined;
   const normalizedServers = normalizeGroupServers(group.servers);
-  return normalizedServers.find((server) => server.name === serverName);
+  return normalizedServers.find(
+    (server) => server.serverId === serverName || server.name === serverName,
+  );
 };
 
 // Get all server configurations in a group
@@ -339,7 +372,9 @@ export const updateServerToolsInGroup = async (
 
     const normalizedServers = normalizeGroupServers(group.servers);
 
-    const serverIndex = normalizedServers.findIndex((s) => s.name === serverName);
+    const serverIndex = normalizedServers.findIndex(
+      (configured) => configured.serverId === server.id || configured.name === serverName,
+    );
     if (serverIndex === -1) {
       return null; // Server not in group
     }

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -194,9 +194,20 @@ ${proxyLine}
 const isSafeCommand = (command: string): boolean => {
   // Block shell builtins that could be used for command injection
   const blockedCommands = new Set([
-    'sh', 'bash', 'zsh', 'fish', 'csh', 'ksh', 'tcsh',
-    'cmd', 'powershell', 'pwsh',
-    'eval', 'exec', 'source', '.',
+    'sh',
+    'bash',
+    'zsh',
+    'fish',
+    'csh',
+    'ksh',
+    'tcsh',
+    'cmd',
+    'powershell',
+    'pwsh',
+    'eval',
+    'exec',
+    'source',
+    '.',
   ]);
 
   const basename = command.split('/').pop()?.split('\\').pop()?.toLowerCase() || '';
@@ -217,7 +228,7 @@ const isSafeCommand = (command: string): boolean => {
  * Removes shell metacharacters and dangerous patterns.
  */
 const sanitizeArgs = (args: string[]): string[] => {
-  return args.map(arg => {
+  return args.map((arg) => {
     // Remove shell metacharacters that could be used for injection
     // Allow common flags (-f, --flag, -vvv) and paths
     if (/^[a-zA-Z0-9._/\\:@=+,-]+$/.test(arg)) {
@@ -255,9 +266,7 @@ const wrapWithProxychains = (
 
   // SECURITY: Validate command is safe
   if (!isSafeCommand(command)) {
-    console.error(
-      `[${serverName}] Blocked unsafe command for proxychains4 wrapping: ${command}`,
-    );
+    console.error(`[${serverName}] Blocked unsafe command for proxychains4 wrapping: ${command}`);
     throw new Error(
       `[${serverName}] Unsafe command blocked: ${command}. Shell builtins and metacharacters are not allowed.`,
     );
@@ -472,7 +481,10 @@ const getOrCreateIsolatedClient = async (
     }
 
     const reservedClients = sessionIsolatedClients.get(sessionId);
-    const transport = await createTransportFromConfig(serverInfo.name, serverConfig);
+    const transport = await createTransportFromConfig(
+      serverInfo.id ?? serverInfo.name,
+      serverConfig,
+    );
     const client = createUpstreamMcpClient(serverInfo.name, () => serverInfo);
 
     try {
@@ -1204,9 +1216,7 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
   // Admin-owned servers may legitimately target internal services, so they
   // skip the internal-IP blocklist. allowInternal also governs per-hop
   // redirect validation in createRedirectValidatingFetch below.
-  const ownerUser = conf.owner
-    ? await getUserDao().findByUsername(conf.owner)
-    : null;
+  const ownerUser = conf.owner ? await getUserDao().findByUsername(conf.owner) : null;
   const allowInternal = !!ownerUser?.isAdmin;
 
   if (conf.url) {
@@ -1333,7 +1343,6 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
   return transport;
 };
 
-
 type IsolatedClientContext = {
   sessionId: string;
   client: Client;
@@ -1374,12 +1383,15 @@ const callToolWithReconnect = async (
         );
 
         try {
-          const server = await getServerDao().findById(serverInfo.name);
+          const server = await getServerDao().findById(serverInfo.id ?? serverInfo.name);
           if (!server) {
             throw new Error(`Server configuration not found for: ${serverInfo.name}`);
           }
 
-          const newTransport = await createTransportFromConfig(serverInfo.name, server);
+          const newTransport = await createTransportFromConfig(
+            serverInfo.id ?? serverInfo.name,
+            server,
+          );
           const newClient = createUpstreamMcpClient(serverInfo.name, () => serverInfo);
 
           // Reconnect with new transport
@@ -1389,9 +1401,17 @@ const callToolWithReconnect = async (
             // Isolated path: close only this session's stale connection and
             // replace its entry in the per-session map. Never touch the shared
             // serverInfo client/transport.
-            try { client.close(); } catch { /* empty */ }
-            try { transport.close(); } catch { /* empty */ }
-            
+            try {
+              client.close();
+            } catch {
+              /* empty */
+            }
+            try {
+              transport.close();
+            } catch {
+              /* empty */
+            }
+
             setSessionIsolatedClient(isolated.sessionId, serverInfo.name, newClient, newTransport);
           } else {
             // Shared path: tear down and replace the shared connection.
@@ -1399,8 +1419,16 @@ const callToolWithReconnect = async (
               clearInterval(serverInfo.keepAliveIntervalId);
               serverInfo.keepAliveIntervalId = undefined;
             }
-            try { serverInfo.client?.close(); } catch { /* empty */ }
-            try { transport.close(); } catch { /* empty */ }
+            try {
+              serverInfo.client?.close();
+            } catch {
+              /* empty */
+            }
+            try {
+              transport.close();
+            } catch {
+              /* empty */
+            }
 
             serverInfo.client = newClient;
             serverInfo.transport = newTransport;
@@ -1484,7 +1512,8 @@ export const initializeClientsFromSettings = async (
 
   try {
     for (const conf of allServers) {
-      const { name } = conf;
+      const { id, name } = conf;
+      const serverId = id ?? name;
 
       // Expand environment variables in all configuration values
       const expandedConf = replaceEnvVars(conf as any) as ServerConfigWithName;
@@ -1493,6 +1522,7 @@ export const initializeClientsFromSettings = async (
       if (expandedConf.enabled === false) {
         console.log(`Skipping disabled server: ${name}`);
         nextServerInfos.push({
+          id: serverId,
           name,
           owner: expandedConf.owner,
           visibility: expandedConf.visibility,
@@ -1517,14 +1547,12 @@ export const initializeClientsFromSettings = async (
       //   server's state if it is already connected, or if an OAuth
       //   authorization is in flight. Reconnecting during PKCE authorization
       //   would replace the pending code verifier and break the callback.
-      const existingServer = existingServerInfos.find((s) => s.name === name);
-      const isDifferentServer = Boolean(serverName) && serverName !== name;
+      const existingServer = existingServerInfos.find((s) => (s.id ?? s.name) === serverId);
+      const isDifferentServer =
+        Boolean(serverName) && serverName !== serverId && serverName !== name;
       const hasInflightOAuthAuthorization =
         existingServer?.status === 'oauth_required' &&
-        Boolean(
-          expandedConf.oauth?.pendingAuthorization?.state ||
-            existingServer.oauth?.state,
-        );
+        Boolean(expandedConf.oauth?.pendingAuthorization?.state || existingServer.oauth?.state);
       if (
         existingServer &&
         (isDifferentServer ||
@@ -1551,6 +1579,7 @@ export const initializeClientsFromSettings = async (
             `Skipping OpenAPI server '${name}': missing OpenAPI specification URL or schema`,
           );
           nextServerInfos.push({
+            id: serverId,
             name,
             owner: expandedConf.owner,
             visibility: expandedConf.visibility,
@@ -1566,6 +1595,7 @@ export const initializeClientsFromSettings = async (
 
         // Create server info first and keep reference to it
         const serverInfo: ServerInfo = {
+          id: serverId,
           name,
           owner: expandedConf.owner,
           visibility: expandedConf.visibility,
@@ -1599,7 +1629,7 @@ export const initializeClientsFromSettings = async (
                 openapi: openapiConfig,
               };
 
-              await getServerDao().update(name, {
+              await getServerDao().update(serverId, {
                 openapi: openapiConfig,
               });
             },
@@ -1656,7 +1686,7 @@ export const initializeClientsFromSettings = async (
           continue;
         }
       } else {
-        transport = await createTransportFromConfig(name, expandedConf);
+        transport = await createTransportFromConfig(serverId, expandedConf);
       }
 
       const serverInfoRef: { current?: ServerInfo } = {};
@@ -1679,6 +1709,7 @@ export const initializeClientsFromSettings = async (
 
       // Create server info first and keep reference to it
       const serverInfo: ServerInfo = {
+        id: serverId,
         name,
         owner: expandedConf.owner,
         visibility: expandedConf.visibility,
@@ -1862,21 +1893,22 @@ export const getServersInfo = async (
   // a POST /api/servers immediately followed by GET /api/servers would not
   // return the newly created server until background initialization completes.
   const combinedServerInfos: ServerInfo[] = [...serverInfos];
-  const existingNames = new Set(combinedServerInfos.map((s) => s.name));
+  const existingIds = new Set(combinedServerInfos.map((s) => s.id ?? s.name));
 
   // Create a set of server names we're interested in (for pagination)
-  const requestedServerNames = new Set(allServers.map((s) => s.name));
+  const requestedServerIds = new Set(allServers.map((s) => s.id ?? s.name));
 
   // Filter serverInfos to only include requested servers if pagination is used
   const filteredServerInfos = isPaginated
-    ? combinedServerInfos.filter((s) => requestedServerNames.has(s.name))
+    ? combinedServerInfos.filter((s) => requestedServerIds.has(s.id ?? s.name))
     : combinedServerInfos;
 
   // Add servers from DAO that don't have runtime info yet
   for (const server of allServers) {
-    if (!existingNames.has(server.name)) {
+    if (!existingIds.has(server.id ?? server.name)) {
       const isEnabled = server.enabled === undefined ? true : server.enabled;
       filteredServerInfos.push({
+        id: server.id,
         name: server.name,
         owner: server.owner,
         visibility: server.visibility,
@@ -1904,9 +1936,10 @@ export const getServersInfo = async (
       : filteredServerInfos;
 
   const infos = filterServerInfos
-    .filter((info) => requestedServerNames.has(info.name)) // Only include requested servers
+    .filter((info) => requestedServerIds.has(info.id ?? info.name)) // Only include requested servers
     .map(
       ({
+        id,
         name,
         version,
         instructions,
@@ -1920,7 +1953,9 @@ export const getServersInfo = async (
         error,
         oauth,
       }) => {
-        const serverConfig = allServers.find((server) => server.name === name);
+        const serverConfig = allServers.find(
+          (server) => (server.id ?? server.name) === (id ?? name),
+        );
         const enabled = serverConfig ? serverConfig.enabled !== false : true;
         const resolvedType = inferServerType(serverConfig);
         const oauthConnected = Boolean(
@@ -1943,6 +1978,7 @@ export const getServersInfo = async (
         });
 
         return {
+          id,
           name,
           version,
           instructions,
@@ -1988,7 +2024,10 @@ export const getServersInfo = async (
 
 // Get server by name
 export const getServerByName = (name: string): ServerInfo | undefined => {
-  return serverInfos.find((serverInfo) => serverInfo.name === name);
+  const byId = serverInfos.find((serverInfo) => serverInfo.id === name);
+  if (byId) return byId;
+  const byName = serverInfos.filter((serverInfo) => serverInfo.name === name);
+  return byName.length === 1 ? byName[0] : undefined;
 };
 
 // Get server by OAuth state parameter
@@ -2112,11 +2151,10 @@ const getServerByTool = (toolName: string): ServerInfo | undefined => {
 export const addServer = async (
   name: string,
   config: ServerConfig,
-): Promise<{ success: boolean; message?: string }> => {
-  const server: ServerConfigWithName = { name, ...config };
-  const result = await getServerDao().create(server);
+): Promise<{ success: boolean; message?: string; serverId?: string }> => {
+  const result = await getServerDao().create({ name, ...config });
   if (result) {
-    return { success: true, message: 'Server added successfully' };
+    return { success: true, message: 'Server added successfully', serverId: result.id };
   } else {
     return { success: false, message: 'Failed to add server' };
   }
@@ -2124,9 +2162,17 @@ export const addServer = async (
 
 // Remove server
 export const removeServer = async (
-  name: string,
+  identifier: string,
 ): Promise<{ success: boolean; message?: string }> => {
-  const result = await getServerDao().delete(name);
+  const storedServer = await getServerDao().findById(identifier);
+  const runtimeMatches = serverInfos.filter(
+    (serverInfo) =>
+      (serverInfo.id ?? serverInfo.name) === identifier || serverInfo.name === identifier,
+  );
+  const runtimeServer = runtimeMatches.length === 1 ? runtimeMatches[0] : undefined;
+  const serverId = storedServer?.id ?? runtimeServer?.id ?? identifier;
+  const serverName = storedServer?.name ?? runtimeServer?.name ?? identifier;
+  const result = await getServerDao().delete(serverId);
   if (!result) {
     return { success: false, message: 'Failed to remove server' };
   }
@@ -2135,15 +2181,15 @@ export const removeServer = async (
   // dropping the serverInfos reference. Without this, a stdio child launched
   // via npx / npm exec outlives the request and becomes an unkillable orphan
   // that leaks memory until the container is restarted.
-  closeServer(name);
+  closeServer(serverId);
 
   try {
-    await removeServerToolEmbeddings(name);
+    await removeServerToolEmbeddings(serverName);
   } catch (error) {
-    console.warn('Failed to remove embeddings for server', { serverName: name, error });
+    console.warn('Failed to remove embeddings for server', { serverName, error });
   }
 
-  serverInfos = serverInfos.filter((serverInfo) => serverInfo.name !== name);
+  serverInfos = serverInfos.filter((serverInfo) => (serverInfo.id ?? serverInfo.name) !== serverId);
   return { success: true, message: 'Server removed successfully' };
 };
 
@@ -2154,26 +2200,28 @@ export const addOrUpdateServer = async (
   allowOverride: boolean = false,
 ): Promise<{ success: boolean; message?: string }> => {
   try {
-    const exists = await getServerDao().exists(name);
-    if (exists && !allowOverride) {
+    const existing = await getServerDao().findById(name);
+    if (existing && !allowOverride) {
       return { success: false, message: 'Server name already exists' };
     }
 
     // If overriding an existing server, close connections and clear keep-alive timers
-    if (exists) {
+    if (existing) {
       // Close existing server connections (clears keep-alive intervals as well)
-      closeServer(name);
+      closeServer(existing.id);
       // Remove from server infos
-      serverInfos = serverInfos.filter((serverInfo) => serverInfo.name !== name);
+      serverInfos = serverInfos.filter(
+        (serverInfo) => (serverInfo.id ?? serverInfo.name) !== existing.id,
+      );
     }
 
-    if (exists) {
-      await getServerDao().update(name, config);
+    if (existing) {
+      await getServerDao().update(existing.id, config);
     } else {
       await getServerDao().create({ name, ...config });
     }
 
-    const action = exists ? 'updated' : 'added';
+    const action = existing ? 'updated' : 'added';
     return { success: true, message: `Server ${action} successfully` };
   } catch (error) {
     console.error('Failed to add/update server', { serverName: name, error });
@@ -2244,14 +2292,14 @@ const closeServerRuntime = (serverInfo: ServerInfo): void => {
 
 // Close server client and transport
 function closeServer(name: string) {
-  const serverInfo = serverInfos.find((serverInfo) => serverInfo.name === name);
+  const serverInfo = getServerByName(name);
   if (serverInfo) {
     closeServerRuntime(serverInfo);
   }
 }
 
 export const resetServerOAuthConnection = (name: string): boolean => {
-  const serverInfo = serverInfos.find((serverInfo) => serverInfo.name === name);
+  const serverInfo = getServerByName(name);
   if (!serverInfo) {
     return false;
   }
@@ -2336,13 +2384,21 @@ export const toggleServerStatus = async (
   enabled: boolean,
 ): Promise<{ success: boolean; message?: string }> => {
   try {
-    await getServerDao().setEnabled(name, enabled);
+    const storedServer = await getServerDao().findById(name);
+    const runtimeMatches = serverInfos.filter(
+      (serverInfo) => (serverInfo.id ?? serverInfo.name) === name || serverInfo.name === name,
+    );
+    const runtimeServer = runtimeMatches.length === 1 ? runtimeMatches[0] : undefined;
+    const serverId = storedServer?.id ?? runtimeServer?.id ?? name;
+    const serverName = storedServer?.name ?? runtimeServer?.name ?? name;
+    const updated = await getServerDao().setEnabled(serverId, enabled);
+    if (!updated) return { success: false, message: 'Server not found' };
     // If disabling, disconnect the server and remove from active servers
     if (!enabled) {
-      closeServer(name);
+      closeServer(serverId);
 
       // Update the server info to show as disconnected and disabled
-      const index = serverInfos.findIndex((s) => s.name === name);
+      const index = serverInfos.findIndex((s) => (s.id ?? s.name) === serverId);
       if (index !== -1) {
         serverInfos[index] = {
           ...serverInfos[index],
@@ -2353,11 +2409,11 @@ export const toggleServerStatus = async (
 
       // Remove tool embeddings when server is disabled (for smart routing consistency)
       try {
-        await removeServerToolEmbeddings(name);
-        console.log(`Removed tool embeddings for disabled server: ${name}`);
+        await removeServerToolEmbeddings(serverName);
+        console.log(`Removed tool embeddings for disabled server: ${serverName}`);
       } catch (embeddingError) {
         console.warn('Failed to remove embeddings for server', {
-          serverName: name,
+          serverName,
           error: summarizeErrorForLogging(embeddingError),
         });
       }
@@ -2508,7 +2564,7 @@ const resolveToolInGroup = async (
       continue;
     }
 
-    const serverConfig = serverConfigsByName.get(serverInfo.name);
+    const serverConfig = serverConfigsByName.get(serverInfo.id ?? serverInfo.name);
     const internalToolName = resolveNameFromGroup(toolName, serverInfo.name, serverConfig);
     const tool = findToolOnServer(serverInfo, internalToolName, allowRawName);
     if (!tool) {
@@ -2548,7 +2604,7 @@ async function resolvePromptInGroup(
       continue;
     }
 
-    const serverConfig = serverConfigsByName.get(serverInfo.name);
+    const serverConfig = serverConfigsByName.get(serverInfo.id ?? serverInfo.name);
     const internalPromptName = resolveNameFromGroup(promptName, serverInfo.name, serverConfig);
     const prompt = serverInfo.prompts.find((item) => item.name === internalPromptName);
     if (!prompt) {
@@ -2607,7 +2663,7 @@ export const handleListToolsRequest = async (_: any, extra: any) => {
   const allTools = [];
   for (const serverInfo of filteredServerInfos) {
     if (serverInfo.tools && serverInfo.tools.length > 0) {
-      const groupServerConfig = serverConfigsByName.get(serverInfo.name);
+      const groupServerConfig = serverConfigsByName.get(serverInfo.id ?? serverInfo.name);
 
       // Filter tools based on server configuration
       let tools = await filterToolsByConfig(serverInfo.name, serverInfo.tools);
@@ -2616,7 +2672,7 @@ export const handleListToolsRequest = async (_: any, extra: any) => {
       tools = await filterToolsByGroup(group, serverInfo.name, tools, groupServerConfig);
 
       // Apply custom descriptions from server configuration
-      const serverConfig = await getServerDao().findById(serverInfo.name);
+      const serverConfig = await getServerDao().findById(serverInfo.id ?? serverInfo.name);
       const toolsWithCustomDescriptions = tools.map((tool) => {
         const toolConfig = serverConfig?.tools?.[tool.name];
         return {
@@ -2916,8 +2972,7 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
         : undefined;
     const serverInfo = appsRouteContext.enabled
       ? appsRouteContext.serverInfo
-      : (groupTool?.serverInfo ??
-        (lookupGroup ? undefined : getServerByTool(request.params.name)));
+      : (groupTool?.serverInfo ?? (lookupGroup ? undefined : getServerByTool(request.params.name)));
     const routeToolName = groupTool?.toolName ?? request.params.name;
     const tool =
       groupTool?.tool ??
@@ -3224,10 +3279,10 @@ export const handleListPromptsRequest = async (_: any, extra: any) => {
 
   for (const serverInfo of filteredServerInfos) {
     if (serverInfo.prompts && serverInfo.prompts.length > 0) {
-      const groupServerConfig = serverConfigsByName.get(serverInfo.name);
+      const groupServerConfig = serverConfigsByName.get(serverInfo.id ?? serverInfo.name);
 
       // Filter prompts based on server configuration
-      const serverConfig = await getServerDao().findById(serverInfo.name);
+      const serverConfig = await getServerDao().findById(serverInfo.id ?? serverInfo.name);
 
       let enabledPrompts = serverInfo.prompts;
       if (serverConfig && serverConfig.prompts) {
@@ -3288,7 +3343,7 @@ export const handleListResourcesRequest = async (_: any, extra: any) => {
   for (const serverInfo of filteredServerInfos) {
     if (serverInfo.resources && serverInfo.resources.length > 0) {
       // Filter resources based on server configuration
-      const serverConfig = await getServerDao().findById(serverInfo.name);
+      const serverConfig = await getServerDao().findById(serverInfo.id ?? serverInfo.name);
 
       let enabledResources = serverInfo.resources;
       if (serverConfig && serverConfig.resources) {
@@ -3302,7 +3357,7 @@ export const handleListResourcesRequest = async (_: any, extra: any) => {
         lookupGroup,
         serverInfo.name,
         enabledResources,
-        serverConfigsByName.get(serverInfo.name),
+        serverConfigsByName.get(serverInfo.id ?? serverInfo.name),
       );
 
       // Apply custom descriptions from server configuration
@@ -3351,7 +3406,7 @@ export const handleListResourceTemplatesRequest = async (_: any, extra: any) => 
         lookupGroup,
         serverInfo.name,
         templates.resourceTemplates || [],
-        serverConfigsByName.get(serverInfo.name),
+        serverConfigsByName.get(serverInfo.id ?? serverInfo.name),
       );
       return appsRouteContext.enabled
         ? filteredTemplates
@@ -3396,7 +3451,7 @@ export const handleReadResourceRequest = async (request: any, extra: any) => {
       if (serverInfo.status !== 'connected') {
         continue;
       }
-      const serverConfig = await getServerDao().findById(serverInfo.name);
+      const serverConfig = await getServerDao().findById(serverInfo.id ?? serverInfo.name);
       let enabledResources = serverInfo.resources;
       if (serverConfig?.resources) {
         enabledResources = enabledResources.filter(
@@ -3407,7 +3462,7 @@ export const handleReadResourceRequest = async (request: any, extra: any) => {
         lookupGroup,
         serverInfo.name,
         enabledResources,
-        serverConfigsByName.get(serverInfo.name),
+        serverConfigsByName.get(serverInfo.id ?? serverInfo.name),
       );
       if (enabledResources.some((resource) => resource.uri === uri)) {
         server = serverInfo;
@@ -3527,13 +3582,32 @@ export const getFilteredServerInfosForGroup = async (
     }
   }
 
-  const serverNamesInGroup = new Set(serverConfigs.map((serverConfig) => serverConfig.name));
+  const serverIdsInGroup = new Set(
+    serverConfigs.flatMap((serverConfig) => (serverConfig.serverId ? [serverConfig.serverId] : [])),
+  );
+  const legacyServerNamesInGroup = new Set(
+    serverConfigs
+      .filter((serverConfig) => !serverConfig.serverId)
+      .map((serverConfig) => serverConfig.name),
+  );
   const serverConfigsByName = new Map(
-    serverConfigs.map((serverConfig) => [serverConfig.name, serverConfig] as const),
+    serverConfigs.map(
+      (serverConfig) => [serverConfig.serverId ?? serverConfig.name, serverConfig] as const,
+    ),
   );
 
+  const visibleServerInfos = getDataService().filterData(serverInfos);
+  const directServer =
+    group && serverIdsInGroup.size === 0 && legacyServerNamesInGroup.size === 0
+      ? (visibleServerInfos.find((serverInfo) => serverInfo.id === group) ??
+        (() => {
+          const byName = visibleServerInfos.filter((serverInfo) => serverInfo.name === group);
+          return byName.length === 1 ? byName[0] : undefined;
+        })())
+      : undefined;
+
   const filteredServerInfos: ServerInfo[] = [];
-  for (const serverInfo of getDataService().filterData(serverInfos)) {
+  for (const serverInfo of visibleServerInfos) {
     if (serverInfo.enabled === false) continue;
     if (options?.requireClient && !serverInfo.client) continue;
 
@@ -3542,14 +3616,17 @@ export const getFilteredServerInfosForGroup = async (
       continue;
     }
 
-    if (serverNamesInGroup.size === 0) {
-      if (serverInfo.name === group) {
+    if (serverIdsInGroup.size === 0 && legacyServerNamesInGroup.size === 0) {
+      if (serverInfo === directServer) {
         filteredServerInfos.push(serverInfo);
       }
       continue;
     }
 
-    if (serverNamesInGroup.has(serverInfo.name)) {
+    if (
+      (serverInfo.id && serverIdsInGroup.has(serverInfo.id)) ||
+      legacyServerNamesInGroup.has(serverInfo.name)
+    ) {
       filteredServerInfos.push(serverInfo);
     }
   }

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -266,10 +266,8 @@ const wrapWithProxychains = (
 
   // SECURITY: Validate command is safe
   if (!isSafeCommand(command)) {
-    console.error(`[${serverName}] Blocked unsafe command for proxychains4 wrapping: ${command}`);
-    throw new Error(
-      `[${serverName}] Unsafe command blocked: ${command}. Shell builtins and metacharacters are not allowed.`,
-    );
+    console.error('Blocked unsafe command for proxychains4 wrapping');
+    throw new Error('Unsafe command blocked. Shell builtins and metacharacters are not allowed.');
   }
 
   // Find proxychains4 binary
@@ -2186,7 +2184,9 @@ export const removeServer = async (
   try {
     await removeServerToolEmbeddings(serverName);
   } catch (error) {
-    console.warn('Failed to remove embeddings for server', { serverName, error });
+    console.warn('Failed to remove server tool embeddings', {
+      error: summarizeErrorForLogging(error),
+    });
   }
 
   serverInfos = serverInfos.filter((serverInfo) => (serverInfo.id ?? serverInfo.name) !== serverId);
@@ -2410,10 +2410,9 @@ export const toggleServerStatus = async (
       // Remove tool embeddings when server is disabled (for smart routing consistency)
       try {
         await removeServerToolEmbeddings(serverName);
-        console.log(`Removed tool embeddings for disabled server: ${serverName}`);
+        console.log('Removed tool embeddings for disabled server');
       } catch (embeddingError) {
-        console.warn('Failed to remove embeddings for server', {
-          serverName,
+        console.warn('Failed to remove server tool embeddings', {
           error: summarizeErrorForLogging(embeddingError),
         });
       }

--- a/src/services/oauthService.ts
+++ b/src/services/oauthService.ts
@@ -237,12 +237,13 @@ export const initializeAllOAuthClients = async (): Promise<void> => {
 
   for (const serverConfig of allServers) {
     const serverName = serverConfig.name;
+    const serverId = serverConfig.id;
 
     // Only initialize servers with explicitly enabled dynamic registration
     // Others will be auto-detected and registered on first 401 response
     if (serverConfig.oauth?.dynamicRegistration?.enabled === true) {
       registrationPromises.push(
-        initializeOAuthForServer(serverName, serverConfig)
+        initializeOAuthForServer(serverId, serverConfig)
           .then((clientInfo) => {
             if (clientInfo) {
               console.log('OAuth client pre-registered for server', { serverName });

--- a/src/services/oauthSettingsStore.ts
+++ b/src/services/oauthSettingsStore.ts
@@ -18,7 +18,7 @@ export const loadServerConfig = async (serverName: string): Promise<ServerConfig
   if (!server) {
     return undefined;
   }
-  const { name: _, ...config } = server;
+  const { id: _id, name: _, ...config } = server;
   return config;
 };
 
@@ -38,7 +38,7 @@ export const mutateOAuthSettings = async (
     return undefined;
   }
 
-  const { name: _, ...serverConfig } = server;
+  const { id: _id, name: _, ...serverConfig } = server;
 
   if (!serverConfig.oauth) {
     serverConfig.oauth = {};
@@ -51,7 +51,7 @@ export const mutateOAuthSettings = async (
 
   mutator(context);
 
-  const updated = await serverDao.update(serverName, { oauth: serverConfig.oauth });
+  const updated = await serverDao.update(server.id, { oauth: serverConfig.oauth });
   if (!updated) {
     throw new Error(`Failed to persist OAuth settings for server ${serverName}`);
   }

--- a/src/services/smartRoutingService.ts
+++ b/src/services/smartRoutingService.ts
@@ -463,7 +463,7 @@ export const handleSearchToolsRequest = async (
           const tools = await filterToolsByConfigFn(server.name, [actualTool]);
           if (tools.length > 0) {
             // Apply custom description from configuration
-            const serverConfig = await getServerDao().findById(server.name);
+            const serverConfig = await getServerDao().findById(server.id ?? server.name);
             const toolConfig = serverConfig?.tools?.[actualTool.name];
 
             // Return the actual tool info from serverInfos with custom description
@@ -623,7 +623,7 @@ export const handleDescribeToolRequest = async (
     }
 
     // Get custom description from configuration
-    const serverConfig = await getServerDao().findById(serverInfo.name);
+    const serverConfig = await getServerDao().findById(serverInfo.id ?? serverInfo.name);
     const toolConfig = serverConfig?.tools?.[tool.name];
 
     // Return full tool information

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ export interface IGroup {
 
 // Server configuration within a group - supports tool selection
 export interface IGroupServerConfig {
+  serverId?: string; // Stable server identity; legacy entries may only contain name
   name: string; // Server name
   alias?: string; // Optional exposed name for this server within the group
   tools?: string[] | 'all'; // Array of specific tool names to include, or 'all' for all tools (default: 'all')
@@ -359,7 +360,7 @@ export interface BearerKey {
 export interface McpSettings {
   users?: IUser[]; // Array of user credentials and permissions
   mcpServers: {
-    [key: string]: ServerConfig; // Key-value pairs of server names and their configurations
+    [key: string]: ServerConfig & { name?: string }; // Stable ID keys; legacy files use names
   };
   groups?: IGroup[]; // Array of server groups
   systemConfig?: SystemConfig; // System-wide configuration settings
@@ -510,7 +511,8 @@ export interface OpenAPISecurityConfig {
 
 // Information about a server's status and tools
 export interface ServerInfo {
-  name: string; // Unique name of the server
+  id?: string; // Stable server identity; optional only for legacy/test fixtures
+  name: string; // User-facing server name; may be reused across groups
   version?: string; // Upstream server version reported during MCP initialization
   instructions?: string; // Upstream server instructions reported during MCP initialization
   owner?: string; // Owner of the server, defaults to 'admin' user
@@ -623,6 +625,7 @@ export interface BatchCreateServersRequest {
 // Result for a single server in batch operation
 export interface BatchServerResult {
   name: string; // Server name
+  serverId?: string; // Stable server identity when creation succeeds
   success: boolean; // Whether the operation succeeded
   message?: string; // Error message if failed
 }

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -60,14 +60,18 @@ export async function migrateToDatabase(): Promise<boolean> {
       }
     }
 
+    const migratedServerIds = new Map<string, string>();
+
     // Migrate servers
     if (settings.mcpServers) {
       const serverNames = Object.keys(settings.mcpServers);
       console.log(`Migrating ${serverNames.length} servers...`);
-      for (const [name, config] of Object.entries(settings.mcpServers)) {
-        const exists = await serverRepo.exists(name);
-        if (!exists) {
-          await serverRepo.create({
+      for (const [storageId, config] of Object.entries(settings.mcpServers)) {
+        const name = config.name || storageId;
+        const legacyMatches = config.name ? [] : await serverRepo.findAllByName(name);
+        const existing = legacyMatches.length === 1 ? legacyMatches[0] : null;
+        if (!existing) {
+          const created = await serverRepo.create({
             name,
             type: config.type,
             description: config.description,
@@ -90,8 +94,10 @@ export async function migrateToDatabase(): Promise<boolean> {
             passthroughHeaders: config.passthroughHeaders,
             perSessionClient: config.perSessionClient,
           });
+          migratedServerIds.set(storageId, created.id);
           console.log(`  - Created server: ${name}`);
         } else {
+          migratedServerIds.set(storageId, existing.id);
           console.log(`  - Server already exists: ${name}`);
         }
       }
@@ -106,7 +112,18 @@ export async function migrateToDatabase(): Promise<boolean> {
           await groupRepo.create({
             name: group.name,
             description: group.description,
-            servers: Array.isArray(group.servers) ? group.servers : [],
+            servers: Array.isArray(group.servers)
+              ? group.servers.map((server) => {
+                  if (typeof server === 'string') {
+                    const serverId = migratedServerIds.get(server);
+                    return serverId ? { serverId, name: server } : server;
+                  }
+
+                  const storageId = server.serverId ?? server.name;
+                  const serverId = migratedServerIds.get(storageId);
+                  return serverId ? { ...server, serverId } : server;
+                })
+              : [],
             owner: group.owner,
           });
           console.log(`  - Created group: ${group.name}`);

--- a/src/utils/serverSettings.ts
+++ b/src/utils/serverSettings.ts
@@ -1,0 +1,22 @@
+import type { ServerConfigWithName } from '../dao/ServerDao.js';
+import type { McpSettings } from '../types/index.js';
+
+export const serializeServersForSettings = (
+  servers: ServerConfigWithName[],
+): McpSettings['mcpServers'] => {
+  const nameCounts = new Map<string, number>();
+  for (const server of servers) {
+    nameCounts.set(server.name, (nameCounts.get(server.name) ?? 0) + 1);
+  }
+
+  const result: McpSettings['mcpServers'] = {};
+  for (const server of servers) {
+    const { id, name, ...config } = server;
+    const key = nameCounts.get(name) === 1 ? name : id;
+    result[key] = {
+      ...(key === name ? {} : { name }),
+      ...config,
+    };
+  }
+  return result;
+};

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 
 const mockServerDao = {
   findById: jest.fn(),
+  findByName: jest.fn(),
   findAll: jest.fn(),
   findAllPaginated: jest.fn(),
   findByOwnerPaginated: jest.fn(),
@@ -80,7 +81,9 @@ jest.mock('../../src/services/mcpService.js', () => ({
   syncToolEmbedding: jest.fn((...args: unknown[]) => mockSyncToolEmbedding(...args)),
   toggleServerStatus: mockToggleServerStatus,
   reconnectServer: mockReconnectServer,
-  updateServerInfoVisibility: jest.fn((...args: unknown[]) => mockUpdateServerInfoVisibility(...args)),
+  updateServerInfoVisibility: jest.fn((...args: unknown[]) =>
+    mockUpdateServerInfoVisibility(...args),
+  ),
 }));
 
 jest.mock('../../src/services/userContextService.js', () => ({
@@ -108,6 +111,10 @@ import {
   updateServer,
   updateSystemConfig,
 } from '../../src/controllers/serverController.js';
+
+beforeEach(() => {
+  mockServerDao.findByName.mockResolvedValue([]);
+});
 
 describe('serverController - getAllSettings', () => {
   beforeEach(() => {
@@ -860,6 +867,32 @@ describe('serverController - system bearer auth context', () => {
     });
   });
 
+  it('returns 409 when a legacy name-addressed request matches multiple servers', async () => {
+    mockServerDao.findByName.mockResolvedValue([
+      { id: 'server-a', name: 'notion', owner: 'system-owner' },
+      { id: 'server-b', name: 'notion', owner: 'system-owner' },
+    ]);
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'notion' },
+      user: { username: 'system-owner', isAdmin: true },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+
+    await getServerConfig(req, res);
+
+    expect(status).toHaveBeenCalledWith(409);
+    expect(json).toHaveBeenCalledWith({
+      success: false,
+      message: "Server name 'notion' is ambiguous; use a server ID",
+      data: [
+        { id: 'server-a', name: 'notion' },
+        { id: 'server-b', name: 'notion' },
+      ],
+    });
+  });
+
   it('allows updating an existing server with system bearer admin context', async () => {
     mockServerDao.findById.mockResolvedValue({
       name: 'existing-server',
@@ -1086,9 +1119,7 @@ describe('serverController - toggleServer (issue #938)', () => {
     expect(mockBroadcastToolListChanged).not.toHaveBeenCalled();
     expect(mockBroadcastPromptListChanged).not.toHaveBeenCalled();
     expect(mockBroadcastResourceListChanged).not.toHaveBeenCalled();
-    expect(json).toHaveBeenCalledWith(
-      expect.objectContaining({ success: true }),
-    );
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 
   it('disabling a server broadcasts tools/prompts/resources and does not trigger a fleet-wide re-init', async () => {
@@ -1101,9 +1132,7 @@ describe('serverController - toggleServer (issue #938)', () => {
     expect(mockBroadcastToolListChanged).toHaveBeenCalledTimes(1);
     expect(mockBroadcastPromptListChanged).toHaveBeenCalledTimes(1);
     expect(mockBroadcastResourceListChanged).toHaveBeenCalledTimes(1);
-    expect(json).toHaveBeenCalledWith(
-      expect.objectContaining({ success: true }),
-    );
+    expect(json).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 });
 

--- a/tests/dao/serverDao-identity.test.ts
+++ b/tests/dao/serverDao-identity.test.ts
@@ -1,0 +1,91 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { ServerDaoImpl } from '../../src/dao/ServerDao.js';
+import { clearSettingsCache } from '../../src/config/index.js';
+
+describe('ServerDaoImpl stable server identity', () => {
+  let tmpDir: string;
+  let settingsPath: string;
+  let originalSettingsPath: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcphub-server-identity-'));
+    settingsPath = path.join(tmpDir, 'mcp_settings.json');
+    originalSettingsPath = process.env.MCPHUB_SETTING_PATH;
+    process.env.MCPHUB_SETTING_PATH = settingsPath;
+    fs.writeFileSync(settingsPath, JSON.stringify({ mcpServers: {}, groups: [] }), 'utf8');
+    clearSettingsCache();
+  });
+
+  afterEach(() => {
+    if (originalSettingsPath === undefined) {
+      delete process.env.MCPHUB_SETTING_PATH;
+    } else {
+      process.env.MCPHUB_SETTING_PATH = originalSettingsPath;
+    }
+    clearSettingsCache();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('stores independent servers with the same name under stable ids', async () => {
+    const dao = new ServerDaoImpl();
+
+    const first = await dao.create({
+      name: 'notion',
+      owner: 'alice',
+      type: 'streamable-http',
+      url: 'https://team-a.example/mcp',
+    });
+    const second = await dao.create({
+      name: 'notion',
+      owner: 'alice',
+      type: 'streamable-http',
+      url: 'https://team-b.example/mcp',
+    });
+
+    expect(first.id).toBeTruthy();
+    expect(second.id).toBeTruthy();
+    expect(second.id).not.toBe(first.id);
+    await expect(dao.findById(first.id)).resolves.toMatchObject({
+      id: first.id,
+      name: 'notion',
+      url: 'https://team-a.example/mcp',
+    });
+    await expect(dao.findById(second.id)).resolves.toMatchObject({
+      id: second.id,
+      name: 'notion',
+      url: 'https://team-b.example/mcp',
+    });
+
+    const persisted = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    expect(Object.keys(persisted.mcpServers)).toEqual(
+      expect.arrayContaining([first.id, second.id]),
+    );
+  });
+
+  it('loads legacy name-keyed settings without rewriting them first', async () => {
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        mcpServers: {
+          notion: {
+            type: 'streamable-http',
+            url: 'https://legacy.example/mcp',
+          },
+        },
+      }),
+      'utf8',
+    );
+    clearSettingsCache();
+
+    const dao = new ServerDaoImpl();
+
+    await expect(dao.findById('notion')).resolves.toMatchObject({
+      id: 'notion',
+      name: 'notion',
+      url: 'https://legacy.example/mcp',
+    });
+  });
+});

--- a/tests/dao/serverDaoDbImpl.test.ts
+++ b/tests/dao/serverDaoDbImpl.test.ts
@@ -3,6 +3,8 @@ const mockRepository = {
   findAllPaginated: jest.fn(),
   findByOwnerPaginated: jest.fn(),
   findByName: jest.fn(),
+  findById: jest.fn(),
+  findAllByName: jest.fn(),
   create: jest.fn(),
   update: jest.fn(),
   delete: jest.fn(),
@@ -22,12 +24,15 @@ import { ServerDaoDbImpl } from '../../src/dao/ServerDaoDbImpl.js';
 describe('ServerDaoDbImpl', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRepository.findById.mockImplementation(async (id: string) => ({ id, name: id }));
+    mockRepository.findAllByName.mockResolvedValue([]);
   });
 
   it('should persist and map server description field', async () => {
     const dao = new ServerDaoDbImpl();
 
     mockRepository.create.mockResolvedValue({
+      id: 'server-id',
       name: 'serena',
       type: 'stdio',
       command: 'npx',
@@ -52,6 +57,22 @@ describe('ServerDaoDbImpl', () => {
     );
 
     expect(result.description).toBe('my server note');
+    expect(result.id).toBe('server-id');
+  });
+
+  it('finds a server by stable id instead of treating id as a name', async () => {
+    const dao = new ServerDaoDbImpl();
+    mockRepository.findById.mockResolvedValue({
+      id: 'server-b',
+      name: 'notion',
+      url: 'https://team-b.example/mcp',
+      enabled: true,
+    });
+
+    const result = await dao.findById('server-b');
+
+    expect(mockRepository.findById).toHaveBeenCalledWith('server-b');
+    expect(result).toMatchObject({ id: 'server-b', name: 'notion' });
   });
 
   it('should persist and map passthroughHeaders field', async () => {

--- a/tests/services/groupService-authorization.test.ts
+++ b/tests/services/groupService-authorization.test.ts
@@ -10,6 +10,7 @@ const mockGroupDao = {
 const mockServerDao = {
   findAll: jest.fn(),
   findById: jest.fn(),
+  findByName: jest.fn(),
 };
 
 const mockUserContextService = {
@@ -74,8 +75,14 @@ describe('groupService authorization', () => {
     }));
     mockGroupDao.delete.mockResolvedValue(true);
 
-    mockServerDao.findAll.mockResolvedValue([{ name: 'server-1' }, { name: 'server-2' }]);
-    mockServerDao.findById.mockResolvedValue({ name: 'server-1' });
+    mockServerDao.findAll.mockResolvedValue([
+      { id: 'server-1-id', name: 'server-1' },
+      { id: 'server-2-id', name: 'server-2' },
+    ]);
+    mockServerDao.findById.mockResolvedValue({ id: 'server-1-id', name: 'server-1' });
+    mockServerDao.findByName.mockImplementation(async (name: string) => [
+      { id: `${name}-id`, name },
+    ]);
   });
 
   it('rejects updateGroup for non-owner non-admin users', async () => {
@@ -94,7 +101,7 @@ describe('groupService authorization', () => {
   });
 
   it('rejects addServerToGroup for non-owner non-admin users', async () => {
-    mockServerDao.findById.mockResolvedValue({ name: 'server-2' });
+    mockServerDao.findById.mockResolvedValue({ id: 'server-2-id', name: 'server-2' });
 
     await expect(addServerToGroup('group-1', 'server-2')).resolves.toBeNull();
     expect(mockGroupDao.update).not.toHaveBeenCalled();
@@ -106,7 +113,9 @@ describe('groupService authorization', () => {
   });
 
   it('rejects updateServerToolsInGroup for non-owner non-admin users', async () => {
-    await expect(updateServerToolsInGroup('group-1', 'server-1', ['dangerous-tool'])).resolves.toBeNull();
+    await expect(
+      updateServerToolsInGroup('group-1', 'server-1', ['dangerous-tool']),
+    ).resolves.toBeNull();
     expect(mockGroupDao.update).not.toHaveBeenCalled();
   });
 

--- a/tests/services/groupService-capabilities.test.ts
+++ b/tests/services/groupService-capabilities.test.ts
@@ -5,6 +5,8 @@ const mockGroupDao = {
 
 const mockServerDao = {
   findAll: jest.fn(),
+  findByName: jest.fn(),
+  findById: jest.fn(),
 };
 
 jest.mock('../../src/dao/index.js', () => ({
@@ -32,6 +34,9 @@ describe('groupService capability selections', () => {
     jest.clearAllMocks();
     mockGroupDao.findByName.mockResolvedValue(null);
     mockServerDao.findAll.mockResolvedValue([{ name: 'server1' }, { name: 'server2' }]);
+    mockServerDao.findByName.mockImplementation(async (name: string) => [
+      { id: `${name}-id`, name },
+    ]);
     mockGroupDao.create.mockImplementation(async (group: any) => group);
   });
 
@@ -53,6 +58,7 @@ describe('groupService capability selections', () => {
 
     expect(result?.servers).toEqual([
       {
+        serverId: 'server1-id',
         name: 'server1',
         alias: 'fetch',
         tools: ['search'],
@@ -79,6 +85,7 @@ describe('groupService capability selections', () => {
 
     expect(result?.servers).toEqual([
       {
+        serverId: 'server1-id',
         name: 'server1',
         tools: [],
         prompts: [],

--- a/tests/services/mcpService-group-server-id.test.ts
+++ b/tests/services/mcpService-group-server-id.test.ts
@@ -1,0 +1,144 @@
+import { jest } from '@jest/globals';
+import type { IGroup, ServerInfo } from '../../src/types/index.js';
+
+const groups: IGroup[] = [
+  {
+    id: 'group-a',
+    name: 'team-a',
+    owner: 'alice',
+    servers: [{ serverId: 'server-a', name: 'notion', tools: 'all' }],
+  },
+  {
+    id: 'group-b',
+    name: 'team-b',
+    owner: 'alice',
+    servers: [{ serverId: 'server-b', name: 'notion', tools: 'all' }],
+  },
+];
+
+const callTeamA = jest.fn();
+const callTeamB = jest.fn();
+
+jest.mock('../../src/dao/index.js', () => ({
+  getGroupDao: jest.fn(() => ({
+    findByName: jest.fn(
+      async (name: string) => groups.find((group) => group.name === name) ?? null,
+    ),
+    findById: jest.fn(async (id: string) => groups.find((group) => group.id === id) ?? null),
+  })),
+  getServerDao: jest.fn(() => ({
+    findById: jest.fn(async () => null),
+  })),
+  getSystemConfigDao: jest.fn(() => ({ get: jest.fn(async () => ({})) })),
+  getBuiltinPromptDao: jest.fn(() => ({ findEnabled: jest.fn(async () => []) })),
+  getBuiltinResourceDao: jest.fn(() => ({ findEnabled: jest.fn(async () => []) })),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({ filterData: (data: unknown[]) => data })),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn((sessionId: string) => (sessionId === 'session-a' ? 'team-a' : 'team-b')),
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  initSmartRoutingService: jest.fn(),
+  isSmartRoutingGroup: jest.fn(() => false),
+}));
+
+jest.mock('../../src/services/activityLoggingService.js', () => ({
+  getActivityLoggingService: jest.fn(() => ({ logToolCall: jest.fn(async () => undefined) })),
+}));
+
+jest.mock('../../src/services/hostedAuthService.js', () => ({
+  assertHostedToolAllowed: jest.fn(),
+  filterHostedTools: jest.fn((_auth, _serverName, tools) => tools),
+  reserveHostedToolCall: jest.fn(async () => null),
+  settleHostedToolCall: jest.fn(async () => undefined),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  removeServerToolEmbeddings: jest.fn(),
+  saveToolsAsVectorEmbeddings: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthService.js', () => ({ initializeAllOAuthClients: jest.fn() }));
+jest.mock('../../src/services/mcpOAuthProvider.js', () => ({ createOAuthProvider: jest.fn() }));
+jest.mock('../../src/services/keepAliveService.js', () => ({
+  setupClientKeepAlive: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../src/services/proxy.js', () => ({
+  createFetchWithProxy: jest.fn(),
+  getProxyConfigFromEnv: jest.fn(() => undefined),
+}));
+jest.mock('../../src/config/index.js', () => ({
+  expandEnvVars: jest.fn((value: string) => value),
+  replaceEnvVars: jest.fn((value: unknown) => value),
+  getNameSeparator: jest.fn(() => '-'),
+  default: { mcpHubName: 'test-hub', mcpHubVersion: '1.0.0', initTimeout: 60000 },
+}));
+
+import {
+  cleanupAllServers,
+  handleCallToolRequest,
+  handleListToolsRequest,
+  setServerInfosForTest,
+} from '../../src/services/mcpService.js';
+
+const serverInfo = (id: string, callTool: jest.Mock): ServerInfo =>
+  ({
+    id,
+    name: 'notion',
+    owner: 'alice',
+    status: 'connected',
+    enabled: true,
+    tools: [{ name: 'notion-search', description: 'Search', inputSchema: { type: 'object' } }],
+    prompts: [],
+    resources: [],
+    client: { callTool },
+    options: {},
+    createTime: Date.now(),
+  }) as unknown as ServerInfo;
+
+describe('mcpService group server ids', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    cleanupAllServers();
+    callTeamA.mockResolvedValue({ content: [{ type: 'text', text: 'a' }], isError: false });
+    callTeamB.mockResolvedValue({ content: [{ type: 'text', text: 'b' }], isError: false });
+    setServerInfosForTest([serverInfo('server-a', callTeamA), serverInfo('server-b', callTeamB)]);
+  });
+
+  afterEach(() => cleanupAllServers());
+
+  it('lists the same clean tool name in separate groups', async () => {
+    const teamA = await handleListToolsRequest({}, { sessionId: 'session-a' });
+    const teamB = await handleListToolsRequest({}, { sessionId: 'session-b' });
+
+    expect(teamA.tools.map((tool) => tool.name)).toEqual(['notion-search']);
+    expect(teamB.tools.map((tool) => tool.name)).toEqual(['notion-search']);
+  });
+
+  it('routes the same tool name to the server referenced by each group', async () => {
+    await handleCallToolRequest(
+      { params: { name: 'notion-search', arguments: { query: 'a' } } },
+      { sessionId: 'session-a' },
+    );
+    await handleCallToolRequest(
+      { params: { name: 'notion-search', arguments: { query: 'b' } } },
+      { sessionId: 'session-b' },
+    );
+
+    expect(callTeamA).toHaveBeenCalledWith(
+      { name: 'search', arguments: { query: 'a' } },
+      undefined,
+      expect.anything(),
+    );
+    expect(callTeamB).toHaveBeenCalledWith(
+      { name: 'search', arguments: { query: 'b' } },
+      undefined,
+      expect.anything(),
+    );
+  });
+});

--- a/tests/utils/serverSettings.test.ts
+++ b/tests/utils/serverSettings.test.ts
@@ -1,0 +1,25 @@
+import { serializeServersForSettings } from '../../src/utils/serverSettings.js';
+
+describe('serializeServersForSettings', () => {
+  it('keeps unique names as legacy-compatible keys', () => {
+    expect(
+      serializeServersForSettings([
+        { id: 'server-id', name: 'fetch', command: 'npx', args: ['fetch-server'] },
+      ]),
+    ).toEqual({
+      fetch: { command: 'npx', args: ['fetch-server'] },
+    });
+  });
+
+  it('uses stable ids and explicit names when names are duplicated', () => {
+    expect(
+      serializeServersForSettings([
+        { id: 'server-a', name: 'notion', url: 'https://a.example/mcp' },
+        { id: 'server-b', name: 'notion', url: 'https://b.example/mcp' },
+      ]),
+    ).toEqual({
+      'server-a': { name: 'notion', url: 'https://a.example/mcp' },
+      'server-b': { name: 'notion', url: 'https://b.example/mcp' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- introduce stable server IDs while preserving user-facing names and legacy name-keyed settings
- persist group membership by server ID so separate groups can expose the same server/tool names without collisions
- return `409` for ambiguous name-based management requests and support IDs across API/UI lifecycle actions
- preserve duplicate identities through JSON/DB migration, import/export, and group editing
- document the ID-based API contract

## Verification

- `pnpm lint`
- `pnpm test:ci` — 141 suites, 917 tests
- `pnpm build`
- `node scripts/verify-dist.js`
- production startup + `GET /health` (server started successfully; sample config reported expected degraded state while two optional upstreams were not ready)

Closes #988