### PR TITLE
fix: allow stdio servers without arguments

### DIFF
--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -1181,7 +1181,6 @@ const ServerForm = ({
                 onChange={(e) => handleArgsChange(e.target.value)}
                 className="w-full py-2 px-3 form-input"
                 placeholder="e.g.: -y time-mcp"
-                required={serverType === 'stdio'}
               />
             </div>
 

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -414,12 +414,12 @@ export const createServer = async (req: Request, res: Response): Promise<void> =
       !normalizedConfig.url &&
       !normalizedConfig.openapi?.url &&
       !normalizedConfig.openapi?.schema &&
-      (!normalizedConfig.command || !normalizedConfig.args)
+      !normalizedConfig.command
     ) {
       res.status(400).json({
         success: false,
         message:
-          'Server configuration must include either a URL, OpenAPI specification URL or schema, or command with arguments',
+          'Server configuration must include either a URL, OpenAPI specification URL or schema, or command',
       });
       return;
     }
@@ -558,12 +558,12 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
         !normalizedConfig.url &&
         !normalizedConfig.openapi?.url &&
         !normalizedConfig.openapi?.schema &&
-        (!normalizedConfig.command || !normalizedConfig.args)
+        !normalizedConfig.command
       ) {
         return {
           valid: false,
           message:
-            'Server configuration must include either a URL, OpenAPI specification URL or schema, or command with arguments',
+            'Server configuration must include either a URL, OpenAPI specification URL or schema, or command',
         };
       }
 
@@ -789,12 +789,12 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
       !normalizedConfig.url &&
       !normalizedConfig.openapi?.url &&
       !normalizedConfig.openapi?.schema &&
-      (!normalizedConfig.command || !normalizedConfig.args)
+      !normalizedConfig.command
     ) {
       res.status(400).json({
         success: false,
         message:
-          'Server configuration must include either a URL, OpenAPI specification URL or schema, or command with arguments',
+          'Server configuration must include either a URL, OpenAPI specification URL or schema, or command',
       });
       return;
     }

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1272,7 +1272,7 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     options.fetch = requestAwareFetch;
 
     transport = new SSEClientTransport(new URL(conf.url), options);
-  } else if (conf.command && conf.args) {
+  } else if (conf.command) {
     // Stdio transport
     env['PATH'] = expandEnvVars(process.env.PATH as string) || '';
 
@@ -1298,7 +1298,7 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     }
 
     // Apply proxychains4 wrapper if proxy is configured (Linux/macOS only)
-    let resolvedArgs = replaceEnvVars(conf.args) as string[];
+    let resolvedArgs = replaceEnvVars(conf.args ?? []) as string[];
 
     // If this server is pending a reinstall, inject cache-busting flags (uvx only).
     // For npx, the cache directory was already cleared before reconnect.

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -96,6 +96,7 @@ jest.mock('../../src/services/upstreamOAuthDisconnectService.js', () => ({
 }));
 
 import {
+  batchCreateServers,
   createServer,
   disconnectServerOAuth,
   getAllSettings,
@@ -108,6 +109,134 @@ import {
   updateServer,
   updateSystemConfig,
 } from '../../src/controllers/serverController.js';
+
+describe('serverController - stdio servers without arguments', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAddServer.mockResolvedValue({ success: true });
+    mockAddOrUpdateServer.mockResolvedValue({ success: true });
+    mockNotifyToolChanged.mockResolvedValue(undefined);
+    mockServerDao.findById.mockResolvedValue({
+      name: 'no-args-server',
+      type: 'stdio',
+      command: '/usr/bin/some-tool',
+      args: [],
+      owner: 'admin',
+      visibility: 'private',
+    });
+  });
+
+  const createResponse = () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    return { json, status, response: { json, status } as unknown as Response };
+  };
+
+  const adminUser = {
+    username: 'admin',
+    isAdmin: true,
+  };
+
+  it('creates a stdio server with an empty arguments array', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      body: {
+        name: 'no-args-server',
+        config: {
+          type: 'stdio',
+          command: '/usr/bin/some-tool',
+          args: [],
+        },
+      },
+      user: adminUser,
+    } as unknown as Request;
+
+    await createServer(request, response);
+
+    expect(status).not.toHaveBeenCalledWith(400);
+    expect(mockAddServer).toHaveBeenCalledWith(
+      'no-args-server',
+      expect.objectContaining({
+        type: 'stdio',
+        command: '/usr/bin/some-tool',
+      }),
+    );
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server added successfully',
+    });
+  });
+
+  it('updates a stdio server with an empty arguments array', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      params: { name: 'no-args-server' },
+      body: {
+        config: {
+          type: 'stdio',
+          command: '/usr/bin/some-tool',
+          args: [],
+        },
+      },
+      user: adminUser,
+    } as unknown as Request;
+
+    await updateServer(request, response);
+
+    expect(status).not.toHaveBeenCalledWith(400);
+    expect(mockAddOrUpdateServer).toHaveBeenCalledWith(
+      'no-args-server',
+      expect.objectContaining({
+        type: 'stdio',
+        command: '/usr/bin/some-tool',
+      }),
+      true,
+    );
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server updated successfully',
+    });
+  });
+
+  it('imports a stdio server with an empty arguments array', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      body: {
+        servers: [
+          {
+            name: 'no-args-server',
+            config: {
+              type: 'stdio',
+              command: '/usr/bin/some-tool',
+              args: [],
+            },
+          },
+        ],
+      },
+      user: adminUser,
+    } as unknown as Request;
+
+    await batchCreateServers(request, response);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(mockAddServer).toHaveBeenCalledWith(
+      'no-args-server',
+      expect.objectContaining({
+        type: 'stdio',
+        command: '/usr/bin/some-tool',
+      }),
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        data: expect.objectContaining({
+          successCount: 1,
+          failureCount: 0,
+        }),
+      }),
+    );
+  });
+});
 
 describe('serverController - getAllSettings', () => {
   beforeEach(() => {

--- a/tests/services/mcpService-passthrough-headers.test.ts
+++ b/tests/services/mcpService-passthrough-headers.test.ts
@@ -257,4 +257,23 @@ describe('MCP Service - passthrough headers for upstream MCP transports', () => 
       }),
     );
   });
+
+  it('should create a stdio transport when command arguments are omitted', async () => {
+    (StdioClientTransport as jest.Mock).mockImplementation(() => ({
+      stderr: {
+        on: jest.fn(),
+      },
+    }));
+
+    await createTransportFromConfig('demo-stdio-without-args', {
+      command: '/usr/bin/some-tool',
+    });
+
+    expect(StdioClientTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: '/usr/bin/some-tool',
+        args: [],
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- make the stdio Arguments field optional in the dashboard
- accept command-only stdio configurations in create, update, and batch import APIs
- default omitted stdio arguments to an empty array when creating the runtime transport
- add regression coverage for create, update, import, and runtime transport behavior

## Root cause

The dashboard marked Arguments as required, while persistence normalization converted an empty `args` array to `undefined`. Controller validation and the runtime transport branch both then treated `args` as mandatory, even though stdio processes can legitimately run with only a command.

The runtime change is necessary in addition to relaxing controller validation; otherwise an accepted command-only configuration would still fail with `Unable to create transport`.

Closes #1004

## Validation

- `pnpm exec jest --runInBand tests/controllers/serverController.test.ts` — 25 passed
- `pnpm exec jest --runInBand tests/services/mcpService-passthrough-headers.test.ts -t "should create a stdio transport when command arguments are omitted"` — passed
- `pnpm lint` — passed
- `pnpm test:ci` — 138 suites, 913 tests passed
- `pnpm build` — backend and frontend builds passed

## Manual checks

- Not run; behavior is covered by controller/runtime regression tests and the production frontend build.