### PR TITLE
fix: fail loudly on invalid vector embedding writes

### DIFF
--- a/src/db/repositories/VectorEmbeddingRepository.test.ts
+++ b/src/db/repositories/VectorEmbeddingRepository.test.ts
@@ -1,0 +1,122 @@
+import { VectorEmbedding } from '../entities/VectorEmbedding.js';
+
+const queryMock = jest.fn();
+const getRepositoryMock = jest.fn(() => ({}));
+const getAppDataSourceMock = jest.fn(() => ({
+  getRepository: getRepositoryMock,
+  query: queryMock,
+}));
+
+jest.mock('../connection.js', () => ({
+  getAppDataSource: getAppDataSourceMock,
+}));
+
+import { VectorEmbeddingRepository } from './VectorEmbeddingRepository.js';
+
+describe('VectorEmbeddingRepository.saveEmbedding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['a typed array', new Float32Array([0.1, 0.2])],
+    ['an empty array', []],
+    ['an array containing NaN', [0.1, Number.NaN]],
+    ['an array containing Infinity', [0.1, Number.POSITIVE_INFINITY]],
+  ])('rejects %s before writing', async (_description, embedding) => {
+    const repository = new VectorEmbeddingRepository();
+
+    await expect(
+      repository.saveEmbedding('tool', 'server:tool', 'searchable text', embedding as number[]),
+    ).rejects.toThrow('Invalid embedding for tool "server:tool"');
+
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('fails when PostgreSQL reports that the vector was persisted as NULL', async () => {
+    queryMock.mockResolvedValueOnce([
+      {
+        id: 'embedding-id',
+        created_at: new Date('2026-07-28T00:00:00Z'),
+        has_embedding: false,
+        persisted_dimensions: null,
+      },
+    ]);
+    const repository = new VectorEmbeddingRepository();
+
+    await expect(
+      repository.saveEmbedding('tool', 'server:tool', 'searchable text', [0.1, 0.2]),
+    ).rejects.toThrow('Embedding for tool "server:tool" was persisted as NULL');
+  });
+
+  it('fails when PostgreSQL does not return the persisted row', async () => {
+    queryMock.mockResolvedValueOnce([]);
+    const repository = new VectorEmbeddingRepository();
+
+    await expect(
+      repository.saveEmbedding('tool', 'server:tool', 'searchable text', [0.1, 0.2]),
+    ).rejects.toThrow('Embedding write for tool "server:tool" did not return a persisted row');
+  });
+
+  it('fails when PostgreSQL reports an unexpected vector dimension', async () => {
+    queryMock.mockResolvedValueOnce([
+      {
+        id: 'embedding-id',
+        created_at: new Date('2026-07-28T00:00:00Z'),
+        has_embedding: true,
+        persisted_dimensions: 1,
+      },
+    ]);
+    const repository = new VectorEmbeddingRepository();
+
+    await expect(
+      repository.saveEmbedding('tool', 'server:tool', 'searchable text', [0.1, 0.2]),
+    ).rejects.toThrow('Embedding for tool "server:tool" persisted with 1 dimensions; expected 2');
+  });
+
+  it('returns the saved entity after PostgreSQL confirms a non-null vector', async () => {
+    queryMock.mockResolvedValueOnce([
+      {
+        id: 'embedding-id',
+        created_at: new Date('2026-07-28T00:00:00Z'),
+        has_embedding: true,
+        persisted_dimensions: '2',
+      },
+    ]);
+    const repository = new VectorEmbeddingRepository();
+
+    const result = await repository.saveEmbedding(
+      'tool',
+      'server:tool',
+      'searchable text',
+      [0.1, 0.2],
+      { serverName: 'server' },
+      'embedding-model',
+    );
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /embedding IS NOT NULL AS has_embedding,\s+vector_dims\(embedding\) AS persisted_dimensions/,
+      ),
+      [
+        'tool',
+        'server:tool',
+        'searchable text',
+        '[0.1,0.2]',
+        2,
+        '{"serverName":"server"}',
+        'embedding-model',
+      ],
+    );
+    expect(result).toEqual(
+      expect.objectContaining<Partial<VectorEmbedding>>({
+        id: 'embedding-id',
+        content_type: 'tool',
+        content_id: 'server:tool',
+        dimensions: 2,
+        metadata: { serverName: 'server' },
+        model: 'embedding-model',
+      }),
+    );
+  });
+});

--- a/src/db/repositories/VectorEmbeddingRepository.ts
+++ b/src/db/repositories/VectorEmbeddingRepository.ts
@@ -69,6 +69,8 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
     metadata: Record<string, any> = {},
     model = 'default',
   ): Promise<VectorEmbedding> {
+    this.validateEmbedding(embedding, contentType, contentId);
+
     // TypeORM cannot serialize the pgvector `vector` column type — it silently
     // stores NULL when the entity is saved through the ORM. Bypass TypeORM
     // entirely and use a single atomic INSERT ... ON CONFLICT DO UPDATE so that
@@ -88,9 +90,32 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
              metadata      = EXCLUDED.metadata,
              model         = EXCLUDED.model,
              updated_at    = NOW()
-       RETURNING id, created_at`,
+       RETURNING id,
+                 created_at,
+                 embedding IS NOT NULL AS has_embedding,
+                 vector_dims(embedding) AS persisted_dimensions`,
       [contentType, contentId, textContent, rawEmbedding, embedding.length, metadataJson, model],
     );
+
+    if (!row) {
+      throw new Error(
+        `Embedding write for ${contentType} "${contentId}" did not return a persisted row`,
+      );
+    }
+
+    const hasEmbedding = row.has_embedding === true || row.has_embedding === 't';
+    if (!hasEmbedding) {
+      throw new Error(`Embedding for ${contentType} "${contentId}" was persisted as NULL`);
+    }
+
+    const persistedDimensions = Number(row.persisted_dimensions);
+    if (persistedDimensions !== embedding.length) {
+      throw new Error(
+        `Embedding for ${contentType} "${contentId}" persisted with ${String(
+          row.persisted_dimensions,
+        )} dimensions; expected ${embedding.length}`,
+      );
+    }
 
     const result = new VectorEmbedding();
     result.id = row.id;
@@ -361,23 +386,35 @@ export class VectorEmbeddingRepository extends BaseRepository<VectorEmbedding> {
    * @param embedding Array of embedding values
    * @returns Properly formatted vector string for pgvector
    */
-  private formatEmbeddingForPgVector(embedding: number[] | string): string | null {
-    if (!embedding) return null;
+  private formatEmbeddingForPgVector(embedding: number[]): string {
+    return `[${embedding.join(',')}]`;
+  }
 
-    // If it's already a string and starts with '[', assume it's formatted
-    if (typeof embedding === 'string') {
-      if (embedding.startsWith('[') && embedding.endsWith(']')) {
-        return embedding;
-      }
-      return `[${embedding}]`;
+  /**
+   * Validate embedding values before they reach PostgreSQL. Passing null as the
+   * vector parameter is valid SQL, so malformed runtime values must fail here
+   * instead of silently creating an unusable search index.
+   */
+  private validateEmbedding(embedding: number[], contentType: string, contentId: string): void {
+    const runtimeType =
+      embedding && typeof embedding === 'object'
+        ? embedding.constructor?.name || 'object'
+        : typeof embedding;
+
+    if (!Array.isArray(embedding) || embedding.length === 0) {
+      throw new TypeError(
+        `Invalid embedding for ${contentType} "${contentId}": expected a non-empty number array, received ${runtimeType}`,
+      );
     }
 
-    // Format array as proper pgvector string
-    if (Array.isArray(embedding)) {
-      return `[${embedding.join(',')}]`;
+    const invalidIndex = embedding.findIndex(
+      (value) => typeof value !== 'number' || !Number.isFinite(value),
+    );
+    if (invalidIndex >= 0) {
+      throw new TypeError(
+        `Invalid embedding for ${contentType} "${contentId}": value at index ${invalidIndex} is not a finite number`,
+      );
     }
-
-    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

- validate generated embeddings before serializing them for pgvector
- verify the stored vector is non-null and has the expected dimensions in the UPSERT `RETURNING` clause
- fail the embedding sync immediately when PostgreSQL does not confirm a valid persisted vector
- add focused repository regression coverage for malformed inputs and invalid write results

## Why

Issue #1002 reports successful embedding-sync logs while every persisted vector is NULL. We could not reproduce the NULL write with the published AMD64 1.0.25 image against the reported PostgreSQL 14 / pgvector 0.8.1 / pgvecto.rs 0.2.0 / VectorChord 0.4.3 stack, so the environmental root cause remains unconfirmed.

The current implementation can nevertheless turn a malformed runtime embedding into a SQL NULL and reports success without checking the stored value. This change closes that observability gap: invalid inputs fail before the query, and invalid database results fail before `Saved tool embeddings` can be logged.

This intentionally does not pin TypeORM because the raw query path and PostgreSQL query runner are byte-identical between the tested 0.3.29 and 0.3.31 installations.

Related to #1002.

## Validation

- `pnpm exec jest --runInBand src/db/repositories/VectorEmbeddingRepository.test.ts` — 8 tests passed
- `pnpm lint`
- `pnpm test:ci` — 139 suites / 917 tests passed
- `pnpm build`
- `git diff --check`

The first sandboxed full-test attempt could not bind local test ports; the same `pnpm test:ci` command passed outside the sandbox.