### PR TITLE
feat: support MCP Apps passthrough on multi-server groups

### DIFF
--- a/docs/features/mcp-apps.mdx
+++ b/docs/features/mcp-apps.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'MCP Apps'
-description: 'Proxy interactive MCP Apps through single-server MCPHub routes'
+description: 'Proxy interactive MCP Apps through MCPHub routes, including multi-server groups'
 ---
 
 ## Overview
@@ -11,30 +11,37 @@ No MCPHub configuration switch is required. Support is enabled automatically whe
 
 ## Routing Requirements
 
-MCP Apps passthrough is enabled only when a request route resolves to exactly one connected MCP upstream server:
+MCP Apps passthrough is enabled whenever a request route resolves to at least one connected MCP upstream server:
 
 - `/mcp/{server}`
-- `/mcp/{group}` when the group contains one visible MCP server
-- `/mcp` when only one MCP server is visible to the caller
+- `/mcp/{group}`, whether the group contains one visible MCP server or several
+- `/mcp` when at least one MCP server is visible to the caller
 
-Aggregate routes and `$smart` routes continue to work as ordinary MCP routes. On those routes MCPHub:
+`$smart` routes are the one exception and continue to work as ordinary MCP routes, since Smart Routing tools aren't addressed by name at all. On that route MCPHub:
 
 - hides app-only tools such as tools with `_meta.ui.visibility: ["app"]`
 - removes Apps-specific `_meta.ui` and legacy `_meta["ui/resourceUri"]` fields
 - rejects direct calls to app-only tools
 - rejects unlisted `ui://` resource reads
 
+Routes with more than one connected server behave differently from single-server routes in one respect: tool names. See below.
+
 ## Tool Names
 
-Ordinary MCPHub routes expose qualified tool names such as `weather::forecast`, using your configured name separator.
+Ordinary (non-Apps) MCPHub routes expose qualified tool names such as `weather::forecast`, using your configured name separator.
 
-An eligible MCP Apps route exposes the upstream tool names unchanged, such as `forecast`. This allows calls from the app iframe to pass through without rewriting. Qualified aliases remain accepted for compatibility.
+A route eligible for Apps passthrough that resolves to a **single** connected server exposes the upstream tool names unchanged, such as `forecast`. This allows calls from the app iframe to pass through without rewriting, which is what most Apps widgets expect when they call back into a single-server host.
+
+A route that resolves to **more than one** connected server keeps the qualified name (`weather-station::forecast`) instead, since more than one upstream server could otherwise expose a tool with the same bare name. Apps metadata (`_meta.ui`) and app-only tools are still fully surfaced on these multi-server routes — only the tool-name qualification differs from the single-server case. A widget on a multi-server route should read its own qualified name from the tool listing (or the host context passed to it) rather than assume the bare name.
 
 ## UI Resources
 
-MCP Apps servers may omit UI-only resources from `resources/list`. On an eligible Apps route, MCPHub forwards direct `resources/read` calls for unlisted `ui://` URIs to the single upstream server.
+MCP Apps servers may omit UI-only resources from `resources/list`. On an Apps-eligible route, MCPHub forwards direct `resources/read` calls for unlisted `ui://` URIs:
 
-Ordinary listed resources remain readable, but Apps-specific metadata is removed outside eligible Apps routes.
+- On a single-server route, the request goes straight to that server.
+- On a multi-server route, MCPHub has no prior way to know which upstream owns a given `ui://` URI, since it isn't listed. It probes each connected server in the group in turn and returns the first successful response.
+
+Ordinary listed resources remain readable, but Apps-specific metadata is removed outside Apps-eligible routes.
 
 ## Dynamic Lists
 

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -2383,7 +2383,16 @@ export const toggleServerStatus = async (
 
 type McpAppsRouteContext = {
   enabled: boolean;
+  // Set when the route resolves to exactly one connected upstream server.
+  // Preserves the existing behavior of exposing raw (unqualified) tool
+  // names, which most Apps widgets assume when calling back into a
+  // single-server host.
   serverInfo?: ServerInfo;
+  // Set when the route resolves to more than one connected upstream
+  // server. Tool names stay qualified (server::tool) in this case so
+  // calls can still be routed unambiguously; Apps metadata and app-only
+  // tools are still surfaced, unlike ordinary (non-Apps) group routes.
+  serverInfos?: ServerInfo[];
 };
 
 const getMcpAppsRouteContext = async (
@@ -2399,17 +2408,24 @@ const getMcpAppsRouteContext = async (
   }
 
   const { filteredServerInfos } = await getFilteredServerInfosForGroup(group);
-  if (
-    filteredServerInfos.length !== 1 ||
-    filteredServerInfos[0].status !== 'connected' ||
-    !filteredServerInfos[0].client
-  ) {
+  const connectedServerInfos = filteredServerInfos.filter(
+    (serverInfo) => serverInfo.status === 'connected' && !!serverInfo.client,
+  );
+
+  if (connectedServerInfos.length === 0) {
     return { enabled: false };
+  }
+
+  if (connectedServerInfos.length === 1) {
+    return {
+      enabled: true,
+      serverInfo: connectedServerInfos[0],
+    };
   }
 
   return {
     enabled: true,
-    serverInfo: filteredServerInfos[0],
+    serverInfos: connectedServerInfos,
   };
 };
 
@@ -2582,11 +2598,21 @@ const projectToolForDownstream = (
   }
 
   const projectedTool = appsRouteContext.enabled ? tool : stripMcpAppsMetadata(tool);
+
+  // Single connected server: keep the existing raw (unqualified) name so
+  // widgets that call back with the bare tool name continue to work.
+  if (appsRouteContext.serverInfo) {
+    return {
+      ...projectedTool,
+      name: normalizeToolNameForServer(serverName, projectedTool.name),
+    };
+  }
+
+  // Multiple connected servers (Apps-enabled) or Apps disabled: qualify the
+  // name so it can still be routed to the right server unambiguously.
   return {
     ...projectedTool,
-    name: appsRouteContext.enabled
-      ? normalizeToolNameForServer(serverName, projectedTool.name)
-      : projectNameForGroup(projectedTool.name, serverName, serverConfig),
+    name: projectNameForGroup(projectedTool.name, serverName, serverConfig),
   };
 };
 
@@ -2713,15 +2739,20 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
       }
 
       const { arguments: toolArgs } = request.params.arguments || {};
+      // A single connected server on an Apps-enabled route is addressed by
+      // its raw (unqualified) tool name, same as before. A multi-server
+      // Apps-enabled route falls through to qualified-name group
+      // resolution below, same as an ordinary (non-Apps) group route.
+      const singleServerAppsRoute = !!appsRouteContext.serverInfo;
       let targetServerInfo: ServerInfo | undefined;
       let targetToolName = toolName;
       let targetTool: Tool | undefined;
-      if (appsRouteContext.enabled) {
+      if (singleServerAppsRoute) {
         targetServerInfo = appsRouteContext.serverInfo;
       } else if (extra && extra.server) {
         targetServerInfo = getServerByName(extra.server);
       } else if (getGroupLookupName(group)) {
-        const groupTool = await resolveToolInGroup(group, toolName, appsRouteContext.enabled);
+        const groupTool = await resolveToolInGroup(group, toolName, false);
         if (groupTool) {
           targetServerInfo = groupTool.serverInfo;
           targetToolName = groupTool.toolName;
@@ -2743,7 +2774,7 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
 
       // Check if the tool exists on the server
       const tool =
-        targetTool ?? findToolOnServer(targetServerInfo, targetToolName, appsRouteContext.enabled);
+        targetTool ?? findToolOnServer(targetServerInfo, targetToolName, singleServerAppsRoute);
       if (!tool) {
         throw new Error(`Tool '${toolName}' not found on server '${targetServerInfo.name}'`);
       }
@@ -2910,11 +2941,18 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
 
     // Regular tool handling
     const lookupGroup = getGroupLookupName(group);
+    // A single connected server on an Apps-enabled route is addressed
+    // directly, using its raw (unqualified) tool name, same as before. A
+    // multi-server Apps-enabled route resolves via the qualified-name
+    // group lookup below, same as an ordinary (non-Apps) group route,
+    // just without stripping Apps metadata or hiding app-only tools
+    // (assertToolAvailableForRoute below still gates on appsRouteContext.enabled).
+    const singleServerAppsRoute = !!appsRouteContext.serverInfo;
     const groupTool =
-      !appsRouteContext.enabled && lookupGroup
-        ? await resolveToolInGroup(lookupGroup, request.params.name, appsRouteContext.enabled)
+      !singleServerAppsRoute && lookupGroup
+        ? await resolveToolInGroup(lookupGroup, request.params.name, false)
         : undefined;
-    const serverInfo = appsRouteContext.enabled
+    const serverInfo = singleServerAppsRoute
       ? appsRouteContext.serverInfo
       : (groupTool?.serverInfo ??
         (lookupGroup ? undefined : getServerByTool(request.params.name)));
@@ -2922,7 +2960,7 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
     const tool =
       groupTool?.tool ??
       (serverInfo
-        ? findToolOnServer(serverInfo, routeToolName, appsRouteContext.enabled)
+        ? findToolOnServer(serverInfo, routeToolName, singleServerAppsRoute)
         : undefined);
     if (!serverInfo || !tool) {
       throw new Error(`Server not found: ${request.params.name}`);
@@ -3415,24 +3453,53 @@ export const handleReadResourceRequest = async (request: any, extra: any) => {
       }
     }
 
-    if (!server && appsRouteContext.enabled && uri.startsWith('ui://')) {
-      server = appsRouteContext.serverInfo;
-    }
+    let result: any;
 
-    if (!server?.client) {
+    if (server?.client) {
+      result = await server.client.readResource({ uri });
+      if (!result || !Array.isArray(result.contents)) {
+        throw new Error(`Failed to read resource: ${uri}`);
+      }
+    } else if (appsRouteContext.enabled && uri.startsWith('ui://')) {
+      // Not pre-registered in resources/list — common for MCP Apps servers
+      // that generate ui:// resources dynamically at tool-call time. A
+      // single-server route goes straight to that server. A multi-server
+      // route has no way to know which upstream owns the URI up front, so
+      // probe each connected candidate in turn and use the first one that
+      // answers.
+      const candidates = appsRouteContext.serverInfo
+        ? [appsRouteContext.serverInfo]
+        : (appsRouteContext.serverInfos ?? []);
+
+      for (const candidate of candidates) {
+        if (!candidate.client) {
+          continue;
+        }
+        try {
+          const candidateResult = await candidate.client.readResource({ uri });
+          if (candidateResult && Array.isArray(candidateResult.contents)) {
+            result = candidateResult;
+            break;
+          }
+        } catch {
+          // This candidate doesn't own the resource; try the next one.
+        }
+      }
+
+      if (!result) {
+        throw new Error(`Resource not found: ${uri}`);
+      }
+    } else {
       throw new Error(`Resource not found: ${uri}`);
-    }
-
-    const result = await server.client.readResource({ uri });
-    if (!result || !Array.isArray(result.contents)) {
-      throw new Error(`Failed to read resource: ${uri}`);
     }
 
     return appsRouteContext.enabled
       ? result
       : {
           ...result,
-          contents: result.contents.map((content) => stripMcpAppsMetadata(content)),
+          contents: result.contents.map((content: { _meta?: Record<string, unknown> }) =>
+            stripMcpAppsMetadata(content),
+          ),
         };
   } catch (error) {
     console.error('Error handling ReadResourceRequest', summarizeErrorForLogging(error));

--- a/tests/services/mcpService-apps.test.ts
+++ b/tests/services/mcpService-apps.test.ts
@@ -1,4 +1,4 @@
-const mockClient = {
+const createMockClient = () => ({
   connect: jest.fn().mockResolvedValue(undefined),
   close: jest.fn(),
   getServerCapabilities: jest.fn(() => ({ tools: {}, resources: {}, prompts: {} })),
@@ -9,10 +9,23 @@ const mockClient = {
   listResources: jest.fn(),
   readResource: jest.fn(),
   callTool: jest.fn(),
-};
+});
+
+const mockClient = createMockClient();
+
+// Most tests only ever deal with one upstream server, so every constructed
+// Client shares the single `mockClient` above by default. A handful of new
+// multi-server-group tests need each upstream to behave independently (e.g.
+// one server owns a ui:// resource and the other doesn't); those tests
+// register a dedicated mock here, keyed by server name, which takes
+// precedence over the shared default.
+const mockClientsByServer = new Map<string, ReturnType<typeof createMockClient>>();
 
 jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
-  Client: jest.fn().mockImplementation(() => mockClient),
+  Client: jest.fn().mockImplementation((clientInfo: { name: string }) => {
+    const serverName = clientInfo.name.replace(/^mcp-client-/, '');
+    return mockClientsByServer.get(serverName) ?? mockClient;
+  }),
 }));
 
 jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
@@ -43,6 +56,15 @@ jest.mock('../../src/services/groupService.js', () => ({
   getServersInGroup: jest.fn(),
   getServerConfigInGroup: jest.fn(),
   getServerConfigsInGroup: mockGetServerConfigsInGroup,
+  // Real implementation: getFilteredServerInfosForGroup uses this to turn a
+  // group's stored server list (strings or per-server config objects) into
+  // normalized IGroupServerConfig entries.
+  normalizeGroupServers: (servers: Array<string | { name: string }>) =>
+    servers.map((server) =>
+      typeof server === 'string'
+        ? { name: server, tools: 'all', prompts: 'all', resources: 'all' }
+        : { tools: 'all', prompts: 'all', resources: 'all', ...server },
+    ),
 }));
 
 jest.mock('../../src/services/sseService.js', () => ({
@@ -100,6 +122,7 @@ jest.mock('../../src/services/proxy.js', () => ({
 const mockFindAll = jest.fn();
 const mockFindById = jest.fn();
 const mockFindBuiltinResourceByUri = jest.fn();
+const mockGroupFindByName = jest.fn(async (_name: string) => null as any);
 
 jest.mock('../../src/dao/index.js', () => ({
   getServerDao: jest.fn(() => ({
@@ -107,7 +130,7 @@ jest.mock('../../src/dao/index.js', () => ({
     findById: mockFindById,
   })),
   getGroupDao: jest.fn(() => ({
-    findByName: jest.fn(async () => null),
+    findByName: mockGroupFindByName,
     findById: jest.fn(async () => null),
   })),
   getSystemConfigDao: jest.fn(() => ({
@@ -193,9 +216,11 @@ describe('mcpService MCP Apps transparent proxy', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     cleanupAllServers();
+    mockClientsByServer.clear();
     mockFindAll.mockResolvedValue([makeServerConfig('apps-server')]);
     mockFindById.mockImplementation(async (name: string) => makeServerConfig(name));
     mockGetServerConfigsInGroup.mockResolvedValue([]);
+    mockGroupFindByName.mockImplementation(async () => null);
     mockFindBuiltinResourceByUri.mockResolvedValue(undefined);
     mockClient.listTools.mockResolvedValue({ tools: appsTools });
     mockClient.listPrompts.mockResolvedValue({ prompts: [] });
@@ -345,25 +370,149 @@ describe('mcpService MCP Apps transparent proxy', () => {
     expect(result.contents[0].text).toContain('Failed to read resource');
   });
 
-  it('blocks unlisted ui resources on aggregate routes', async () => {
-    mockFindAll.mockResolvedValue([
-      makeServerConfig('apps-server'),
-      makeServerConfig('other-server'),
-    ]);
-    mockGetServerConfigsInGroup.mockImplementation(async (group: string) =>
-      group === 'pair' ? [{ name: 'apps-server' }, { name: 'other-server' }] : [],
-    );
-    await initUpstreamServers();
-    await flushPromises();
-    await markSessionAsAppsCapable('aggregate-session', 'pair');
+  describe('multi-server Apps-enabled groups', () => {
+    // 'pair' is a real two-server group (apps-server + other-server), resolved
+    // through the group DAO the same way mcpService looks it up in production.
+    // Previously an Apps-enabled route required the group to resolve to
+    // exactly one connected server; groups with more than one server were
+    // silently treated as an ordinary (non-Apps) route. These tests cover the
+    // relaxed behavior: multiple connected servers keep Apps metadata and
+    // app-only tools, addressed by qualified name instead of a bare one.
+    const setUpPairGroup = () => {
+      mockFindAll.mockResolvedValue([
+        makeServerConfig('apps-server'),
+        makeServerConfig('other-server'),
+      ]);
+      mockGroupFindByName.mockImplementation(async (name: string) =>
+        name === 'pair' ? { servers: ['apps-server', 'other-server'] } : null,
+      );
+    };
 
-    const result = await handleReadResourceRequest(
-      { params: { uri: 'ui://apps/dashboard.html' } },
-      { sessionId: 'aggregate-session' },
-    );
+    it('keeps qualified tool names and full Apps metadata on a multi-server Apps route', async () => {
+      setUpPairGroup();
+      await initUpstreamServers();
+      await flushPromises();
+      await markSessionAsAppsCapable('aggregate-session', 'pair');
 
-    expect(result.contents[0].text).toContain('Resource not found');
-    expect(mockClient.readResource).not.toHaveBeenCalled();
+      const result = await handleListToolsRequest({}, { sessionId: 'aggregate-session' });
+
+      const dashboardTool = result.tools.find(
+        (tool: any) => tool.name === 'apps-server::open-dashboard',
+      );
+      const appOnlyTool = result.tools.find(
+        (tool: any) => tool.name === 'apps-server::poll-dashboard',
+      );
+      expect(dashboardTool._meta).toEqual(appsTools[0]._meta);
+      // App-only tools (visibility excludes 'model') stay visible here, unlike
+      // on an ordinary group route where they're hidden entirely.
+      expect(appOnlyTool).toBeDefined();
+    });
+
+    it('routes a qualified app-only tool call to the right server on a multi-server Apps route', async () => {
+      setUpPairGroup();
+      await initUpstreamServers();
+      await flushPromises();
+      await markSessionAsAppsCapable('aggregate-session', 'pair');
+
+      const result = await handleCallToolRequest(
+        { params: { name: 'apps-server::poll-dashboard', arguments: {} } },
+        { sessionId: 'aggregate-session' },
+      );
+
+      expect(result.isError).toBe(false);
+      expect(mockClient.callTool).toHaveBeenCalledWith(
+        { name: 'poll-dashboard', arguments: {} },
+        undefined,
+        expect.anything(),
+      );
+    });
+
+    it('reads an unlisted ui:// resource by probing each connected server', async () => {
+      setUpPairGroup();
+      await initUpstreamServers();
+      await flushPromises();
+      await markSessionAsAppsCapable('aggregate-session', 'pair');
+
+      const result = await handleReadResourceRequest(
+        { params: { uri: 'ui://apps/dashboard.html' } },
+        { sessionId: 'aggregate-session' },
+      );
+
+      expect(result.contents[0]._meta).toEqual({
+        ui: { csp: { connectDomains: [] } },
+        trace: 'keep-me',
+      });
+    });
+
+    it('falls through to the next candidate when a server does not own the resource', async () => {
+      setUpPairGroup();
+      // apps-server (the shared default mock client, probed first since it's
+      // first in the group's server list) does not own this resource.
+      mockClient.readResource.mockRejectedValue(new Error('not found on this server'));
+
+      // other-server does own it.
+      const otherServerClient = createMockClient();
+      otherServerClient.listTools.mockResolvedValue({ tools: [] });
+      otherServerClient.listPrompts.mockResolvedValue({ prompts: [] });
+      otherServerClient.listResources.mockResolvedValue({ resources: [] });
+      otherServerClient.readResource.mockResolvedValue({
+        contents: [
+          {
+            uri: 'ui://apps/dashboard.html',
+            mimeType: 'text/html;profile=mcp-app',
+            text: '<html>from other-server</html>',
+            _meta: { ui: { csp: { connectDomains: [] } }, trace: 'keep-me' },
+          },
+        ],
+      });
+      mockClientsByServer.set('other-server', otherServerClient);
+
+      await initUpstreamServers();
+      await flushPromises();
+      await markSessionAsAppsCapable('aggregate-session', 'pair');
+
+      const result = await handleReadResourceRequest(
+        { params: { uri: 'ui://apps/dashboard.html' } },
+        { sessionId: 'aggregate-session' },
+      );
+
+      expect(mockClient.readResource).toHaveBeenCalledWith({ uri: 'ui://apps/dashboard.html' });
+      expect(otherServerClient.readResource).toHaveBeenCalledWith({
+        uri: 'ui://apps/dashboard.html',
+      });
+      expect(result.contents[0]._meta).toEqual({
+        ui: { csp: { connectDomains: [] } },
+        trace: 'keep-me',
+      });
+    });
+
+    it('reports resource not found when no connected server owns an unlisted ui:// resource', async () => {
+      setUpPairGroup();
+      const appsServerClient = createMockClient();
+      appsServerClient.listTools.mockResolvedValue({ tools: appsTools });
+      appsServerClient.listPrompts.mockResolvedValue({ prompts: [] });
+      appsServerClient.listResources.mockResolvedValue({ resources: [] });
+      appsServerClient.readResource.mockRejectedValue(new Error('nope'));
+      mockClientsByServer.set('apps-server', appsServerClient);
+
+      const otherServerClient = createMockClient();
+      otherServerClient.listTools.mockResolvedValue({ tools: [] });
+      otherServerClient.listPrompts.mockResolvedValue({ prompts: [] });
+      otherServerClient.listResources.mockResolvedValue({ resources: [] });
+      otherServerClient.readResource.mockRejectedValue(new Error('nope'));
+      mockClientsByServer.set('other-server', otherServerClient);
+
+      await initUpstreamServers();
+      await flushPromises();
+      await markSessionAsAppsCapable('aggregate-session', 'pair');
+
+      const result = await handleReadResourceRequest(
+        { params: { uri: 'ui://apps/missing.html' } },
+        { sessionId: 'aggregate-session' },
+      );
+
+      expect(result.contents[0].text).toContain('Resource not found');
+    });
   });
 
   it('does not read a listed resource through a different single-server route', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #875. MCP Apps passthrough currently requires a route to resolve to exactly one connected upstream server (`getMcpAppsRouteContext`), which disables it entirely for any group that bundles more than one Apps-capable server. This PR relaxes that to support multiple connected servers per Apps-eligible route:

- A route resolving to a **single** connected server keeps today's behavior exactly: raw (unqualified) tool names, direct resource reads.
- A route resolving to **more than one** connected server now stays Apps-enabled (Apps metadata surfaced, app-only tools listed and callable) but addresses tools by their qualified name (`server::tool`) instead of the bare name, since more than one upstream could otherwise expose a tool with the same bare name.
- Unlisted `ui://` resource reads (for servers that generate them dynamically instead of listing them) on a multi-server route probe each connected candidate in turn and return the first successful response, since there's no prefix on the URI to indicate ownership up front.

This came out of running MCP Apps servers behind mcphub in a homelab setup where several Apps-capable servers are intentionally grouped together (dashboard/widget-style tools alongside plain utility servers) — under the current restriction, Apps passthrough is silently disabled for the whole group the moment a second Apps server joins it.

## Changes

- `src/services/mcpService.ts`: `McpAppsRouteContext` gains an optional `serverInfos` (plural) alongside the existing `serverInfo`, populated when more than one connected server is in scope. `projectToolForDownstream`, the `call_tool` meta-tool handler, the regular tool-call handler, and `handleReadResourceRequest`'s unlisted-`ui://` fallback all branch on single- vs multi-server the same way.
- `docs/features/mcp-apps.mdx`: updated to describe the multi-server behavior (tool-name qualification, resource-read probing).
- `tests/services/mcpService-apps.test.ts`: added a `multi-server Apps-enabled groups` suite (5 new tests) covering qualified tool listing/metadata, qualified app-only tool calls, listed-resource reads, unlisted-`ui://` probing with fallthrough to the next candidate, and the not-found case when no candidate owns the resource. Also fixed the group-DAO test mock (`getGroupDao().findByName`) to actually resolve a real multi-server group — the prior `blocks unlisted ui resources on aggregate routes` test mocked `groupService.getServerConfigsInGroup`, which isn't what `getFilteredServerInfosForGroup` calls, so it was unintentionally exercising the empty-group path rather than a true 2-server group.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/services/mcpService.ts tests/services/mcpService-apps.test.ts` — clean
- [x] `npx jest` — 139 suites / 925 tests pass, including 15 in `mcpService-apps.test.ts` (10 pre-existing + 5 new)
- [x] Confirmed single-server Apps routes are unaffected (all pre-existing tests pass unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)