### PR TITLE
feat: on-demand stdio server spawning to reduce memory usage

### DIFF
--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -618,6 +618,7 @@ const ServerCard = ({
             <ServerStatusDot
               status={server.status}
               enabled={server.enabled}
+              startOnDemand={server.config?.startOnDemand === true}
               onAuthClick={handleOAuth}
               className="hub-server-card-status"
             />

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -107,6 +107,9 @@ const ServerForm = ({
     },
     // Per-session client isolation initialization
     perSessionClient: initialData?.config?.perSessionClient === true,
+    // On-demand spawning initialization
+    startOnDemand: initialData?.config?.startOnDemand === true,
+    idleTimeoutMs: initialData?.config?.idleTimeoutMs ?? 300000,
     // OpenAPI configuration initialization
     openapi:
       initialData && initialData.config && initialData.config.openapi
@@ -1423,6 +1426,62 @@ const ServerForm = ({
                 'Create a dedicated upstream connection per session instead of sharing one across all sessions. Enable for stateful servers like Playwright. Increases upstream connections with concurrent sessions.',
               )}
             </p>
+          </div>
+        )}
+
+        {/* On-demand spawning - stdio only */}
+        {serverType === 'stdio' && (
+          <div className="mb-4">
+            <div className="flex items-center mb-1">
+              <input
+                type="checkbox"
+                id="startOnDemand"
+                checked={formData.startOnDemand || false}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    startOnDemand: e.target.checked,
+                  }))
+                }
+                className="mr-2"
+              />
+              <label htmlFor="startOnDemand" className="text-gray-700 dark:text-gray-300 text-sm font-medium">
+                {t('server.startOnDemand', 'Start On Demand')}
+              </label>
+            </div>
+            <p className="text-xs text-gray-500 ml-6">
+              {t(
+                'server.startOnDemandDescription',
+                'Skip startup connect and spawn this server only when a tool call arrives. The process is shut down automatically after the idle timeout, then restarted on the next call. Reduces persistent memory usage for rarely-used servers.',
+              )}
+            </p>
+            {formData.startOnDemand && (
+              <div className="ml-6 mt-2">
+                <label htmlFor="idleTimeoutMs" className="block text-xs text-gray-600 dark:text-gray-400 mb-1">
+                  {t('server.idleTimeoutMs', 'Idle shutdown timeout (ms)')}
+                </label>
+                <input
+                  type="number"
+                  id="idleTimeoutMs"
+                  min={10000}
+                  step={1000}
+                  value={formData.idleTimeoutMs ?? 300000}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      idleTimeoutMs: Number(e.target.value),
+                    }))
+                  }
+                  className="hub-input w-40 text-sm"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  {t(
+                    'server.idleTimeoutMsDescription',
+                    'Shut down the process after this many milliseconds with no tool calls. Default: 300000 (5 minutes).',
+                  )}
+                </p>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/ui/StatusDot.tsx
+++ b/frontend/src/components/ui/StatusDot.tsx
@@ -41,6 +41,7 @@ export const StatusDot: React.FC<StatusDotProps> = ({ kind, label, className, on
 interface ServerStatusDotProps {
   status: ServerStatus;
   enabled?: boolean;
+  startOnDemand?: boolean;
   onAuthClick?: (e: React.MouseEvent) => void;
   className?: string;
 }
@@ -48,12 +49,29 @@ interface ServerStatusDotProps {
 export const ServerStatusDot: React.FC<ServerStatusDotProps> = ({
   status,
   enabled,
+  startOnDemand,
   onAuthClick,
   className,
 }) => {
   const { t } = useTranslation();
   if (enabled === false) {
     return <StatusDot kind="muted" label={t('server.disable') || 'Disabled'} className={className} />;
+  }
+  // On-demand servers that are disconnected are "sleeping", not offline
+  if (startOnDemand && status === 'disconnected') {
+    return (
+      <StatusDot
+        kind="muted"
+        label={
+          <>
+            <span aria-hidden>💤</span>
+            <span>{t('status.sleeping', 'Sleeping')}</span>
+          </>
+        }
+        title={t('status.sleepingDescription', 'On-demand server — will start automatically when a tool is called')}
+        className={className}
+      />
+    );
   }
   const kind = STATUS_TO_KIND[status] ?? 'muted';
   const isOAuth = status === 'oauth_required';

--- a/frontend/src/utils/serverFormPayload.ts
+++ b/frontend/src/utils/serverFormPayload.ts
@@ -170,6 +170,8 @@ export const buildServerPayload = ({
     options,
     visibility: formData.visibility ?? 'private',
     perSessionClient: formData.perSessionClient === true ? true : undefined,
+    startOnDemand: formData.startOnDemand === true ? true : undefined,
+    idleTimeoutMs: formData.startOnDemand === true ? (formData.idleTimeoutMs ?? 300000) : undefined,
   };
 
   if (serverType === 'openapi') {

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1507,6 +1507,31 @@ export const initializeClientsFromSettings = async (
         continue;
       }
 
+      // On-demand servers: skip startup connect; spawn lazily on first tool call.
+      // Preserve existing runtime state (tools/prompts populated from a previous
+      // connection) so the tool list stays visible to agents even while sleeping.
+      if (expandedConf.startOnDemand === true) {
+        const existingOnDemand = existingServerInfos.find((s) => s.name === name);
+        nextServerInfos.push({
+          // Carry over cached tools/prompts/resources if the server was previously connected
+          ...(existingOnDemand ?? {
+            name,
+            status: 'disconnected' as const,
+            error: null,
+            tools: [],
+            prompts: [],
+            resources: [],
+            createTime: Date.now(),
+          }),
+          owner: expandedConf.owner,
+          visibility: expandedConf.visibility,
+          enabled: true,
+          config: expandedConf,
+        });
+        console.log(`Skipping startup connect for on-demand server: ${name}`);
+        continue;
+      }
+
       // Reuse this server's existing runtime state instead of reconnecting when:
       // - a targeted reload/reconnect (serverName) was requested for a
       //   *different* server — preserve its current state regardless of
@@ -2250,6 +2275,81 @@ function closeServer(name: string) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// On-demand spawning helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Shuts down an on-demand stdio server without removing it from serverInfos.
+ * The tool/prompt/resource lists are preserved so agents can still see what
+ * the server offers and trigger a cold-start on the next tool call.
+ */
+const shutdownOnDemandServer = (serverInfo: ServerInfo): void => {
+  if (serverInfo.idleTimeoutId) {
+    clearTimeout(serverInfo.idleTimeoutId);
+    serverInfo.idleTimeoutId = undefined;
+  }
+
+  // Close runtime (kills process) but intentionally keep tools/prompts/resources
+  closeServerRuntime(serverInfo);
+
+  serverInfo.status = 'disconnected';
+  console.log(
+    `[${serverInfo.name}] On-demand server shut down after idle; ` +
+      `${serverInfo.tools.length} tools cached for next wake-up`,
+  );
+};
+
+/**
+ * Resets (or starts) the idle-shutdown timer for an on-demand server.
+ * Call this after every successful tool invocation.
+ */
+const scheduleIdleShutdown = (serverInfo: ServerInfo): void => {
+  if (!serverInfo.config?.startOnDemand) return;
+
+  if (serverInfo.idleTimeoutId) {
+    clearTimeout(serverInfo.idleTimeoutId);
+  }
+
+  const idleMs = serverInfo.config.idleTimeoutMs ?? 300_000; // default 5 minutes
+  serverInfo.idleTimeoutId = setTimeout(() => {
+    if (serverInfo.status === 'connected') {
+      shutdownOnDemandServer(serverInfo);
+    }
+  }, idleMs);
+};
+
+/**
+ * Ensures an on-demand server is connected before a tool call proceeds.
+ * Uses a singleton promise so concurrent callers wait for the same spawn
+ * instead of triggering duplicate process launches.
+ */
+const ensureServerReady = async (serverInfo: ServerInfo): Promise<void> => {
+  if (serverInfo.status === 'connected') return;
+
+  // Another call is already spawning — wait for it
+  if (serverInfo.spawningPromise) {
+    await serverInfo.spawningPromise;
+    return;
+  }
+
+  console.log(`[${serverInfo.name}] Cold-starting on-demand server…`);
+  const spawnStart = Date.now();
+
+  const spawnPromise = reconnectServer(serverInfo.name).then(() => {
+    console.log(
+      `[${serverInfo.name}] On-demand server ready in ${Date.now() - spawnStart}ms`,
+    );
+  });
+
+  serverInfo.spawningPromise = spawnPromise;
+  try {
+    await spawnPromise;
+  } finally {
+    serverInfo.spawningPromise = undefined;
+  }
+};
+
 export const resetServerOAuthConnection = (name: string): boolean => {
   const serverInfo = serverInfos.find((serverInfo) => serverInfo.name === name);
   if (!serverInfo) {
@@ -2728,11 +2828,13 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
           targetTool = groupTool.tool;
         }
       } else {
-        // Find the first server that has this tool
+        // Find the first server that has this tool.
+        // On-demand servers may be sleeping (disconnected) but still advertise
+        // their cached tool list — include them as candidates.
         targetServerInfo = serverInfos.find(
           (serverInfo) =>
-            serverInfo.status === 'connected' &&
             serverInfo.enabled !== false &&
+            (serverInfo.status === 'connected' || serverInfo.config?.startOnDemand === true) &&
             serverInfo.tools.some((tool) => tool.name === toolName),
         );
       }
@@ -2740,6 +2842,22 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
       if (!targetServerInfo) {
         throw new Error(`No available servers found with tool: ${toolName}`);
       }
+
+      // If the target is an on-demand server that is not yet running, wake it up now.
+      // Concurrent callers are serialised via ensureServerReady's singleton promise.
+      if (targetServerInfo.config?.startOnDemand && targetServerInfo.status !== 'connected') {
+        await ensureServerReady(targetServerInfo);
+        // Re-read status from the mutated serverInfo after async spawn
+        const freshStatus = (targetServerInfo as ServerInfo).status;
+        if (freshStatus !== 'connected') {
+          throw new Error(
+            `Failed to start on-demand server '${targetServerInfo.name}' — check server logs`,
+          );
+        }
+      }
+
+      // Record activity timestamp for on-demand servers
+      targetServerInfo.lastUsedAt = Date.now();
 
       // Check if the tool exists on the server
       const tool =
@@ -2883,6 +3001,9 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
         toolName: cleanToolName,
         result: summarizeToolResultForLogging(result),
       });
+
+      // Reset idle-shutdown timer for on-demand servers after each successful call
+      scheduleIdleShutdown(targetServerInfo);
 
       // Log successful activity
       const duration = Date.now() - startTime;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -465,6 +465,12 @@ export interface ServerConfig {
     };
   };
   perSessionClient?: boolean; // When true, creates a dedicated upstream client per downstream session (session isolation for stateful servers like Playwright)
+  // On-demand spawning: start the stdio process only when a tool call arrives,
+  // and shut it down automatically after a period of inactivity.
+  // This reduces persistent memory usage for rarely-used servers.
+  // Only effective for stdio-type servers; HTTP/SSE servers are unaffected.
+  startOnDemand?: boolean; // When true, skip startup connect and spawn lazily on first tool call
+  idleTimeoutMs?: number; // Milliseconds of inactivity before shutting down (default: 300_000 = 5 min)
   // OpenAPI specific configuration
   openapi?: {
     url?: string; // OpenAPI specification URL
@@ -528,6 +534,10 @@ export interface ServerInfo {
   enabled?: boolean; // Flag to indicate if the server is enabled
   keepAliveIntervalId?: NodeJS.Timeout; // Timer ID for keep-alive ping interval
   config?: ServerConfig; // Reference to the original server configuration for OpenAPI passthrough headers
+  // On-demand spawning runtime state
+  spawningPromise?: Promise<void>; // Singleton promise: concurrent callers await this instead of double-spawning
+  idleTimeoutId?: NodeJS.Timeout; // Timer ID for idle-shutdown (cleared/reset on each tool call)
+  lastUsedAt?: number; // Timestamp of last tool call (ms since epoch)
   oauth?: {
     // OAuth authorization state
     authorizationUrl?: string; // OAuth authorization URL for user to visit


### PR DESCRIPTION
## Summary

Implements the feature requested in #1011: a `startOnDemand` config option for stdio MCP servers that skips the startup connect and instead spawns the child process **only when a tool call arrives**. The process shuts down automatically after an idle timeout and restarts transparently on the next call.

### Problem

Every enabled stdio server spawns a persistent Node.js process at startup and stays alive indefinitely, consuming RAM even when unused. On a typical setup this adds up to 400-500 MB of persistent memory for servers that may only be called a few times a day.

### Solution

```json
{
  "mcpServers": {
    "jira-cli-mcp": {
      "type": "stdio",
      "command": "/opt/homebrew/bin/jira-cli-mcp",
      "startOnDemand": true,
      "idleTimeoutMs": 300000
    }
  }
}
```

- **Cold start**: when a tool call arrives for a sleeping server, MCPHub spawns it, waits for connection, then serves the call — typically 200–500 ms
- **Warm**: subsequent calls within the idle window hit the live process with zero overhead
- **Idle shutdown**: after `idleTimeoutMs` ms (default 5 min) of no calls, the process is killed and RAM is freed
- **Tools stay visible**: cached tool/prompt lists are preserved across shutdowns so agents always see what the server offers and can trigger a wake-up

## Changes

### Backend (`src/`)

**`types/index.ts`**
- `ServerConfig`: add `startOnDemand?: boolean`, `idleTimeoutMs?: number`
- `ServerInfo`: add `spawningPromise?: Promise<void>`, `idleTimeoutId?: NodeJS.Timeout`, `lastUsedAt?: number`

**`services/mcpService.ts`**
- `shutdownOnDemandServer` — closes client/transport (kills process tree) while keeping cached tools/prompts/resources intact
- `scheduleIdleShutdown` — resets per-server idle timer after each successful tool call
- `ensureServerReady` — singleton-promise lazy spawn; concurrent callers await the same promise instead of double-spawning
- `initializeClientsFromSettings` — skip startup connect for on-demand servers; preserve existing runtime state (cached tools) across full reloads
- `handleCallToolRequest` — include sleeping on-demand servers as tool-call candidates; call `ensureServerReady` before invocation; call `scheduleIdleShutdown` after each successful call

### Frontend (`frontend/src/`)

- **`ServerForm.tsx`**: "Start On Demand" checkbox (stdio only) + "Idle shutdown timeout" number input revealed when enabled
- **`serverFormPayload.ts`**: emit `startOnDemand` / `idleTimeoutMs` into the config payload
- **`StatusDot.tsx`**: show 💤 **Sleeping** badge for on-demand servers that are currently idle (disconnected but not disabled), with a tooltip explaining they will wake on the next call
- **`ServerCard.tsx`**: pass `startOnDemand` prop to `ServerStatusDot`

## Behaviour under concurrency

If two tool calls arrive simultaneously during a cold start, `ensureServerReady` stores the spawn as a `Promise` on `serverInfo.spawningPromise`. The second caller awaits the same promise — only one process is ever launched regardless of concurrency.

## Trade-offs

| | Always-on (current) | On-demand (this PR) |
|---|---|---|
| Persistent RAM | Full process size | ~0 MB while idle |
| First-call latency | 0 ms | +200–500 ms (Node.js startup) |
| Tool visibility | Connected only | Always (cached) |
| Opt-in | — | `startOnDemand: true` |

Existing behaviour is unchanged — `startOnDemand` defaults to `false`.

Closes #1011