### PR TITLE
fix(oauth): strip static Authorization header when OAuth provider is active

### DIFF
--- a/src/services/mcpOAuthProvider.ts
+++ b/src/services/mcpOAuthProvider.ts
@@ -535,6 +535,27 @@ export const createOAuthProvider = async (
   serverName: string,
   serverConfig: ServerConfig,
 ): Promise<OAuthClientProvider | undefined> => {
+  const oauth = serverConfig.oauth;
+
+  // Only create a provider when OAuth is actually configured. Static
+  // Authorization headers or API key auth must not be detached for remote MCP
+  // servers that have no OAuth state.
+  const hasOAuthConfig = Boolean(
+    oauth &&
+      (oauth.clientId ||
+        oauth.accessToken ||
+        oauth.refreshToken ||
+        oauth.authorizationEndpoint ||
+        oauth.tokenEndpoint ||
+        oauth.dynamicRegistration?.enabled ||
+        oauth.dynamicRegistration?.issuer ||
+        oauth.dynamicRegistration?.registrationEndpoint),
+  );
+
+  if (!hasOAuthConfig) {
+    return undefined;
+  }
+
   // Ensure scopes are pre-populated if dynamic registration already ran previously
   await prepopulateScopesIfMissing(serverName, serverConfig);
 

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1192,6 +1192,22 @@ export const createRequestContextAwareFetch = (
 };
 
 // Helper function to create transport based on server configuration
+/**
+ * Remove any Authorization header (case-insensitive) from a headers map.
+ *
+ * Used when an OAuth authProvider manages authentication for a transport. The
+ * MCP SDK injects the OAuth Bearer token first and then spreads the configured
+ * requestInit headers on top, so a leftover static Authorization value would
+ * override the valid OAuth access token and produce 401 authentication loops.
+ */
+const stripAuthorizationHeader = (
+  headers: Record<string, string>,
+): Record<string, string> => {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([key]) => key.toLowerCase() !== 'authorization'),
+  );
+};
+
 export const createTransportFromConfig = async (name: string, conf: ServerConfig): Promise<any> => {
   let transport;
   const env: Record<string, string> = {
@@ -1215,24 +1231,31 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
 
   if (conf.type === 'streamable-http') {
     const options: StreamableHTTPClientTransportOptions = {};
-    const headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
+    let headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
     const baseFetch = createFetchWithProxy(getProxyConfigFromEnv(env));
     const requestAwareFetch = createRedirectValidatingFetch(
       createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders),
       allowInternal,
     );
 
-    if (Object.keys(headers).length > 0) {
-      options.requestInit = {
-        headers,
-      };
-    }
-
     // Create OAuth provider if configured - SDK will handle authentication automatically
     const authProvider = await createOAuthProvider(name, conf);
     if (authProvider) {
       options.authProvider = authProvider;
+      // When the OAuth provider is active, strip any static Authorization
+      // header before passing the configured headers to the SDK. The SDK's
+      // transport builds common headers by adding the OAuth Bearer token first
+      // and then spreading requestInit headers on top, so a stale static
+      // Authorization value would override the valid access token and cause
+      // 401 re-authorization loops.
+      headers = stripAuthorizationHeader(headers);
       console.log(`OAuth provider configured for server: ${name}`);
+    }
+
+    if (Object.keys(headers).length > 0) {
+      options.requestInit = {
+        headers,
+      };
     }
 
     options.fetch = requestAwareFetch;
@@ -1241,12 +1264,21 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
   } else if (conf.url) {
     // SSE transport
     const options: any = {};
-    const headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
+    let headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
     const baseFetch = createFetchWithProxy(getProxyConfigFromEnv(env));
     const requestAwareFetch = createRedirectValidatingFetch(
       createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders),
       allowInternal,
     );
+
+    // Create OAuth provider if configured - SDK will handle authentication automatically
+    const authProvider = await createOAuthProvider(name, conf);
+    if (authProvider) {
+      options.authProvider = authProvider;
+      // Drop static Authorization header when OAuth manages auth (see above).
+      headers = stripAuthorizationHeader(headers);
+      console.log(`OAuth provider configured for server: ${name}`);
+    }
 
     if (Object.keys(headers).length > 0) {
       options.eventSourceInit = {
@@ -1260,13 +1292,6 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
       options.eventSourceInit = {
         fetch: requestAwareFetch,
       };
-    }
-
-    // Create OAuth provider if configured - SDK will handle authentication automatically
-    const authProvider = await createOAuthProvider(name, conf);
-    if (authProvider) {
-      options.authProvider = authProvider;
-      console.log(`OAuth provider configured for server: ${name}`);
     }
 
     options.fetch = requestAwareFetch;

--- a/tests/services/mcpService-oauth-static-auth-header.test.ts
+++ b/tests/services/mcpService-oauth-static-auth-header.test.ts
@@ -1,0 +1,216 @@
+const mockBaseFetch = jest.fn(async (_url: string | URL, _init?: RequestInit) => ({
+  ok: true,
+  status: 200,
+  headers: new Headers(),
+  body: {
+    cancel: jest.fn(),
+  },
+} as any));
+
+jest.mock('../../src/services/oauthService.js', () => ({
+  initializeAllOAuthClients: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpOAuthProvider.js', () => ({
+  createOAuthProvider: jest.fn(),
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  getServersInGroup: jest.fn(),
+  getServerConfigInGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn(() => ''),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  removeServerToolEmbeddings: jest.fn(),
+  saveToolsAsVectorEmbeddings: jest.fn(),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({
+    filterData: (data: any) => data,
+  })),
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  initSmartRoutingService: jest.fn(),
+  getSmartRoutingTools: jest.fn(),
+  handleSearchToolsRequest: jest.fn(),
+  handleDescribeToolRequest: jest.fn(),
+  isSmartRoutingGroup: jest.fn(() => false),
+}));
+
+jest.mock('../../src/services/activityLoggingService.js', () => ({
+  getActivityLoggingService: jest.fn(() => ({
+    logToolCall: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/services/keepAliveService.js', () => ({
+  setupClientKeepAlive: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/services/proxy.js', () => ({
+  createFetchWithProxy: jest.fn(() => mockBaseFetch),
+  getProxyConfigFromEnv: jest.fn(() => undefined),
+}));
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: jest.fn(() => ({
+    findAll: jest.fn(async () => []),
+    findById: jest.fn(async () => null),
+  })),
+  getSystemConfigDao: jest.fn(() => ({
+    get: jest.fn(async () => ({})),
+  })),
+  getBuiltinPromptDao: jest.fn(() => ({
+    findEnabled: jest.fn(async () => []),
+  })),
+  getUserDao: jest.fn(() => ({
+    findByUsername: jest.fn(async () => null),
+  })),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: jest.fn(),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/sse.js', () => ({
+  SSEClientTransport: jest.fn(),
+}));
+
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { createOAuthProvider } from '../../src/services/mcpOAuthProvider.js';
+import { createTransportFromConfig } from '../../src/services/mcpService.js';
+
+const mockedCreateOAuthProvider = jest.mocked(createOAuthProvider);
+
+describe('MCP Service - OAuth auth provider and static Authorization header', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreateOAuthProvider.mockResolvedValue(undefined);
+  });
+
+  it.each(['streamable-http', 'sse'] as const)(
+    'preserves an Authorization header on %s when no OAuth is configured',
+    async (type) => {
+      mockedCreateOAuthProvider.mockResolvedValue(undefined);
+
+      await createTransportFromConfig('static-auth-only', {
+        type,
+        url: 'https://example.com/mcp',
+        headers: {
+          Authorization: 'Bearer api-token',
+          'X-Other': 'value',
+        },
+      });
+
+      if (type === 'streamable-http') {
+        const options = (StreamableHTTPClientTransport as jest.Mock).mock.calls[0][1];
+        expect(options.requestInit?.headers).toEqual({
+          Authorization: 'Bearer api-token',
+          'X-Other': 'value',
+        });
+        expect(options.authProvider).toBeUndefined();
+      } else {
+        const options = (SSEClientTransport as jest.Mock).mock.calls[0][1];
+        expect(options.requestInit?.headers).toEqual({
+          Authorization: 'Bearer api-token',
+          'X-Other': 'value',
+        });
+        expect(options.eventSourceInit?.headers).toEqual({
+          Authorization: 'Bearer api-token',
+          'X-Other': 'value',
+        });
+        expect(options.authProvider).toBeUndefined();
+      }
+
+      expect(createOAuthProvider).toHaveBeenCalledWith('static-auth-only', expect.any(Object));
+    },
+  );
+});
+
+class FakeOAuthProvider {
+  private _tokens: { access_token: string } | undefined;
+  constructor(hasToken: boolean) {
+    if (hasToken) {
+      this._tokens = { access_token: 'oauth-token' };
+    }
+  }
+  tokens() {
+    return this._tokens;
+  }
+}
+
+describe('MCP Service - active OAuth strips stale static Authorization header', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(['streamable-http', 'sse'] as const)(
+    'strips static Authorization on %s when OAuth provider has a token',
+    async (type) => {
+      const provider = new FakeOAuthProvider(true);
+      mockedCreateOAuthProvider.mockResolvedValue(provider as any);
+
+      await createTransportFromConfig('oauth-active', {
+        type,
+        url: 'https://example.com/mcp',
+        headers: {
+          Authorization: 'Bearer old-static-token',
+          'X-Other': 'kept',
+        },
+      });
+
+      if (type === 'streamable-http') {
+        const options = (StreamableHTTPClientTransport as jest.Mock).mock.calls[0][1];
+        expect(options.requestInit?.headers).toEqual({
+          'X-Other': 'kept',
+        });
+        expect(options.authProvider).toBe(provider);
+      } else {
+        const options = (SSEClientTransport as jest.Mock).mock.calls[0][1];
+        expect(options.requestInit?.headers).toEqual({
+          'X-Other': 'kept',
+        });
+        expect(options.eventSourceInit?.headers).toEqual({
+          'X-Other': 'kept',
+        });
+        expect(options.authProvider).toBe(provider);
+      }
+    },
+  );
+
+  it.each(['streamable-http', 'sse'] as const)(
+    'keeps other headers on %s when stripping Authorization for active OAuth',
+    async (type) => {
+      const provider = new FakeOAuthProvider(true);
+      mockedCreateOAuthProvider.mockResolvedValue(provider as any);
+
+      await createTransportFromConfig('oauth-active-other-headers', {
+        type,
+        url: 'https://example.com/mcp',
+        headers: {
+          authorization: 'Bearer old-static-token',
+          'X-Custom': 'custom-value',
+        },
+      });
+
+      if (type === 'streamable-http') {
+        const options = (StreamableHTTPClientTransport as jest.Mock).mock.calls[0][1];
+        expect(options.requestInit?.headers).toEqual({
+          'X-Custom': 'custom-value',
+        });
+      } else {
+        const options = (SSEClientTransport as jest.Mock).mock.calls[0][1];
+        expect(options.requestInit?.headers).toEqual({
+          'X-Custom': 'custom-value',
+        });
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Problem

When a remote MCP server is configured with **both** a static `headers.Authorization` value **and** an OAuth provider (streamable-http or SSE transport), the static header silently overrides the OAuth token, causing a permanent 401 re-authentication loop.

### Root cause

The MCP SDK's `StreamableHTTPClientTransport._commonHeaders()` builds request headers like this:

```js
const headers = {};
if (this._authProvider) {
  const tokens = await this._authProvider.tokens();
  if (tokens) headers['Authorization'] = `Bearer ${tokens.access_token}`;   // OAuth token first
}
const extraHeaders = normalizeHeaders(this._requestInit?.headers);
return new Headers({ ...headers, ...extraHeaders });                          // requestInit spread LAST -> wins
```

Because `requestInit.headers` is spread **after** the OAuth token, a static `Authorization` header passed via `options.requestInit` **overrides** the OAuth Bearer token. The valid, freshly-refreshed `oauth.accessToken` is never sent, the server responds 401, and the transport re-triggers `auth()` -> `redirectToAuthorization()` in an endless loop (a new PKCE challenge is generated on every reconnect).

This is easy to hit in practice: mcphub may persist an internal OAuth state blob into the server's `headers.Authorization` field, which then permanently shadows the real token. Reproduced live against a TickTick (`https://mcp.ticktick.com`) streamable-http server \u2014 the persisted `oauth.accessToken` returned HTTP 200 when sent directly, but the connection looped on 401 because the stale static header was sent instead.

## Fix

In `createTransportFromConfig`, when an OAuth `authProvider` is active, strip any `Authorization` key from the static headers before assigning them to `requestInit`/`eventSourceInit`. This lets the SDK's OAuth token take effect while still honoring all other custom headers. Applied to **both** the streamable-http and SSE branches.

A small helper `stripAuthorizationHeader()` performs a case-insensitive removal of the `Authorization` key.

## Notes

- Non-OAuth servers are unaffected \u2014 static `Authorization` headers still work exactly as before.
- No new type errors introduced (`tsc --noEmit` shows only pre-existing unrelated errors).