### PR TITLE
fix(ui): clearer server-import validation and OAuth clientId/redirect-uri guidance

### DIFF
--- a/frontend/src/components/JSONImportForm.tsx
+++ b/frontend/src/components/JSONImportForm.tsx
@@ -69,7 +69,17 @@ All servers will be imported in a single efficient batch operation.`;
     const parsed = parseAndValidateJson(jsonInput);
     if (!parsed) return;
 
-    setPreviewServers(normalizeImportedServers(parsed));
+    const { servers, issues } = normalizeImportedServers(parsed);
+
+    if (issues.length > 0) {
+      const details = issues.map((issue) => `${issue.name}: ${issue.message}`).join('\n');
+      setError(t('jsonImport.validationErrors') + '\n' + details);
+      if (servers.length === 0) {
+        return;
+      }
+    }
+
+    setPreviewServers(servers);
   };
 
   const handleImport = async () => {

--- a/frontend/src/components/ServerCard.tsx
+++ b/frontend/src/components/ServerCard.tsx
@@ -345,6 +345,13 @@ const ServerCard = ({
       const top = window.screen.height / 2 - h / 2;
       window.open(server.oauth.authorizationUrl, 'OAuth Authorization', `width=${w},height=${h},left=${left},top=${top}`);
       showToast(t('status.oauthWindowOpened'), 'info');
+      // When a static clientId is configured, the provider's OAuth client is registered
+      // with its own redirect-URI allow-list, which often excludes this hub's callback and
+      // makes the provider reject the authorize request with "invalid redirect_uri". Warn the
+      // user and point them to removing clientId so MCPHub can dynamically register its own.
+      if (server.oauth.clientIdConfigured) {
+        showToast(t('status.oauthClientIdHint'), 'warning');
+      }
     }
   };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -314,6 +314,7 @@ export interface Server {
     authorizationUrl?: string;
     state?: string;
     connected?: boolean;
+    clientIdConfigured?: boolean; // A static oauth.clientId is set (dynamic registration suppressed)
   };
 }
 

--- a/frontend/src/utils/jsonImport.ts
+++ b/frontend/src/utils/jsonImport.ts
@@ -4,9 +4,74 @@ export interface ImportJsonFormat {
   mcpServers: Record<string, ServerConfig>;
 }
 
-export const normalizeImportedServers = (parsed: ImportJsonFormat) => {
-  return Object.entries(parsed.mcpServers).map(([name, config]) => {
+export interface NormalizedServer {
+  name: string;
+  config: Partial<ServerConfig>;
+}
+
+export interface ImportIssue {
+  name: string;
+  message: string;
+}
+
+export interface NormalizeResult {
+  servers: NormalizedServer[];
+  issues: ImportIssue[];
+}
+
+// Remote transport types that require a `url`.
+const REMOTE_TYPES = ['sse', 'streamable-http'];
+
+// Keys that mcphub understands on a server config. Anything else is either a
+// typo or copied from another tool's schema (e.g. an `auth` block), and would
+// otherwise be silently dropped during import — leaving the user confused when
+// the imported server does not behave as their JSON suggested.
+const KNOWN_KEYS = new Set<keyof ServerConfig | string>([
+  'type',
+  'url',
+  'command',
+  'args',
+  'env',
+  'headers',
+  'options',
+  'openapi',
+  'oauth',
+  'enabled',
+  'visibility',
+  'keepAliveInterval',
+  'enableKeepAlive',
+  'perSessionClient',
+  'tools',
+  'prompts',
+  'passthroughHeaders',
+  'proxy',
+]);
+
+/**
+ * Normalize imported server configs and collect human-readable issues.
+ *
+ * Previous behaviour silently coerced any unrecognized `type` (or a missing
+ * `type` on a remote server) into a `stdio` server, and dropped fields such as
+ * `oauth`. That produced opaque "Failed to import servers" errors downstream.
+ * We now validate up-front and name the exact server/field at fault.
+ */
+export const normalizeImportedServers = (parsed: ImportJsonFormat): NormalizeResult => {
+  const servers: NormalizedServer[] = [];
+  const issues: ImportIssue[] = [];
+
+  for (const [name, rawConfig] of Object.entries(parsed.mcpServers)) {
+    const config = (rawConfig ?? {}) as ServerConfig & Record<string, unknown>;
     const normalizedConfig: Partial<ServerConfig> = {};
+
+    // Surface unknown top-level keys (e.g. the `auth` block some tools use).
+    const unknownKeys = Object.keys(config).filter((key) => !KNOWN_KEYS.has(key));
+    if (unknownKeys.length > 0) {
+      issues.push({
+        name,
+        message: `unknown field(s) "${unknownKeys.join('", "')}" — not part of the mcphub server schema. For OAuth, use an "oauth" object (e.g. {"scopes":["email"]}).`,
+      });
+      continue;
+    }
 
     if (config.type === 'sse' || config.type === 'streamable-http') {
       normalizedConfig.type = config.type;
@@ -14,10 +79,29 @@ export const normalizeImportedServers = (parsed: ImportJsonFormat) => {
       if (config.headers) {
         normalizedConfig.headers = config.headers;
       }
+      if (config.oauth) {
+        normalizedConfig.oauth = config.oauth;
+      }
+      if (!config.url) {
+        issues.push({
+          name,
+          message: `"${config.type}" servers require a "url" field.`,
+        });
+        continue;
+      }
     } else if (config.type === 'openapi') {
       normalizedConfig.type = 'openapi';
       normalizedConfig.openapi = config.openapi;
-    } else {
+    } else if (config.type === undefined || config.type === 'stdio') {
+      // A url without a recognized remote type is a common mistake (e.g.
+      // "type":"http"). Only treat as stdio when there is no url.
+      if (config.url && !config.command) {
+        issues.push({
+          name,
+          message: `has a "url" but type "${config.type ?? 'stdio'}". Use "streamable-http" or "sse" for remote servers.`,
+        });
+        continue;
+      }
       normalizedConfig.type = 'stdio';
       normalizedConfig.command = config.command;
       normalizedConfig.args = config.args || [];
@@ -27,8 +111,27 @@ export const normalizeImportedServers = (parsed: ImportJsonFormat) => {
       if (config.options) {
         normalizedConfig.options = config.options;
       }
+      if (!config.command) {
+        issues.push({
+          name,
+          message: `stdio servers require a "command" field.`,
+        });
+        continue;
+      }
+    } else {
+      // Unknown/unsupported type such as "http".
+      const suggestion = REMOTE_TYPES.includes(String(config.type))
+        ? ''
+        : ` Did you mean "streamable-http"? Supported types: stdio, sse, streamable-http, openapi.`;
+      issues.push({
+        name,
+        message: `unsupported type "${config.type}".${suggestion}`,
+      });
+      continue;
     }
 
-    return { name, config: normalizedConfig };
-  });
+    servers.push({ name, config: normalizedConfig });
+  }
+
+  return { servers, issues };
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -251,7 +251,8 @@
     "connecting": "Connecting",
     "oauthRequired": "OAuth Required",
     "clickToAuthorize": "Click to authorize with OAuth",
-    "oauthWindowOpened": "OAuth authorization window opened. Please complete the authorization."
+    "oauthWindowOpened": "OAuth authorization window opened. Please complete the authorization.",
+    "oauthClientIdHint": "This server has a preconfigured OAuth client ID. If authorization fails with \"invalid redirect_uri\", remove the clientId so MCPHub can register its own OAuth client automatically."
   },
   "errors": {
     "general": "Something went wrong",
@@ -889,7 +890,8 @@
     "parseError": "Failed to parse JSON. Please check the format and try again.",
     "addFailed": "Failed to add server",
     "importFailed": "Failed to import servers",
-    "partialSuccess": "Imported {{count}} of {{total}} servers successfully. Some servers failed:"
+    "partialSuccess": "Imported {{count}} of {{total}} servers successfully. Some servers failed:",
+    "validationErrors": "Some servers could not be imported. Please fix the following and try again:"
   },
   "groupImport": {
     "button": "Import",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -243,7 +243,8 @@
     "connecting": "Connexion en cours",
     "oauthRequired": "OAuth requis",
     "clickToAuthorize": "Cliquez pour autoriser avec OAuth",
-    "oauthWindowOpened": "Fenêtre d'autorisation OAuth ouverte. Veuillez compléter l'autorisation."
+    "oauthWindowOpened": "Fenêtre d'autorisation OAuth ouverte. Veuillez compléter l'autorisation.",
+    "oauthClientIdHint": "Ce serveur possède un ID client OAuth préconfiguré. Si l'autorisation échoue avec « invalid redirect_uri », supprimez le clientId pour que MCPHub puisse enregistrer automatiquement son propre client OAuth."
   },
   "errors": {
     "general": "Une erreur est survenue",
@@ -880,7 +881,8 @@
     "parseError": "Échec de l'analyse du JSON. Veuillez vérifier le format et réessayer.",
     "addFailed": "Échec de l'ajout du serveur",
     "importFailed": "Échec de l'importation des serveurs",
-    "partialSuccess": "{{count}} serveur(s) sur {{total}} importé(s) avec succès. Certains serveurs ont échoué :"
+    "partialSuccess": "{{count}} serveur(s) sur {{total}} importé(s) avec succès. Certains serveurs ont échoué :",
+    "validationErrors": "Certains serveurs n'ont pas pu être importés. Veuillez corriger les points suivants et réessayer :"
   },
   "groupImport": {
     "button": "Importer",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -243,7 +243,8 @@
     "connecting": "Bağlanıyor",
     "oauthRequired": "OAuth Gerekli",
     "clickToAuthorize": "OAuth ile yetkilendirmek için tıklayın",
-    "oauthWindowOpened": "OAuth yetkilendirme penceresi açıldı. Lütfen yetkilendirmeyi tamamlayın."
+    "oauthWindowOpened": "OAuth yetkilendirme penceresi açıldı. Lütfen yetkilendirmeyi tamamlayın.",
+    "oauthClientIdHint": "Bu sunucuda önceden yapılandırılmış bir OAuth istemci kimliği var. Yetkilendirme \"invalid redirect_uri\" hatasıyla başarısız olursa, MCPHub'ın kendi OAuth istemcisini otomatik olarak kaydedebilmesi için clientId'yi kaldırın."
   },
   "errors": {
     "general": "Bir şeyler yanlış gitti",
@@ -879,7 +880,8 @@
     "parseError": "JSON ayrıştırılamadı. Lütfen formatı kontrol edip tekrar deneyin.",
     "addFailed": "Sunucu eklenemedi",
     "importFailed": "Sunucular içe aktarılamadı",
-    "partialSuccess": "{{total}} sunucudan {{count}} tanesi başarıyla içe aktarıldı. Bazı sunucular başarısız oldu:"
+    "partialSuccess": "{{total}} sunucudan {{count}} tanesi başarıyla içe aktarıldı. Bazı sunucular başarısız oldu:",
+    "validationErrors": "Bazı sunucular içe aktarılamadı. Lütfen aşağıdakileri düzeltip tekrar deneyin:"
   },
   "groupImport": {
     "button": "İçe Aktar",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -251,7 +251,8 @@
     "connecting": "连接中",
     "oauthRequired": "需要OAuth授权",
     "clickToAuthorize": "点击进行OAuth授权",
-    "oauthWindowOpened": "OAuth授权窗口已打开，请完成授权。"
+    "oauthWindowOpened": "OAuth授权窗口已打开，请完成授权。",
+    "oauthClientIdHint": "该服务器配置了预设的 OAuth 客户端 ID。如果授权因“invalid redirect_uri”失败，请删除 clientId，让 MCPHub 自动注册自己的 OAuth 客户端。"
   },
   "errors": {
     "general": "发生错误",
@@ -892,7 +893,8 @@
     "parseError": "解析 JSON 失败。请检查格式后重试。",
     "addFailed": "添加服务器失败",
     "importFailed": "导入服务器失败",
-    "partialSuccess": "成功导入 {{count}} / {{total}} 个服务器。部分服务器失败："
+    "partialSuccess": "成功导入 {{count}} / {{total}} 个服务器。部分服务器失败：",
+    "validationErrors": "部分服务器无法导入。请修正以下问题后重试："
   },
   "groupImport": {
     "button": "导入",

--- a/src/services/mcpOAuthProvider.ts
+++ b/src/services/mcpOAuthProvider.ts
@@ -355,6 +355,12 @@ export class MCPHubOAuthProvider implements OAuthClientProvider {
         authorizationUrl,
         state,
         codeVerifier: this._codeVerifier,
+        // Flag when a static clientId is configured (which suppresses dynamic client
+        // registration). Such a client is registered on the provider with its own
+        // redirect URI allow-list, which frequently does NOT include this hub's callback,
+        // producing an "invalid redirect_uri" 400 at the provider's authorize endpoint.
+        // The frontend uses this to hint the user to remove clientId and let MCPHub self-register.
+        clientIdConfigured: Boolean(this.serverConfig?.oauth?.clientId),
       };
       console.log('Stored OAuth authorization URL in server info', {
         serverName: this.serverName,

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1987,6 +1987,7 @@ export const getServersInfo = async (
                     ? {
                         authorizationUrl: oauth.authorizationUrl,
                         state: oauth.state,
+                        ...(oauth.clientIdConfigured ? { clientIdConfigured: true } : {}),
                         // Don't expose codeVerifier to frontend for security
                       }
                     : {}),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -544,6 +544,10 @@ export interface ServerInfo {
     state?: string; // OAuth state parameter for CSRF protection
     codeVerifier?: string; // PKCE code verifier
     connected?: boolean; // True when stored upstream OAuth tokens exist
+    clientIdConfigured?: boolean; // True when a static oauth.clientId is set (dynamic registration is suppressed).
+    // When set, a preconfigured client's redirect-URI allow-list may not include this hub's callback,
+    // causing the upstream authorize endpoint to reject with "invalid redirect_uri". Surfaced so the UI
+    // can hint the user to remove clientId and let MCPHub self-register (DCR).
   };
 }
 

--- a/tests/frontend/jsonImport.test.ts
+++ b/tests/frontend/jsonImport.test.ts
@@ -2,7 +2,7 @@ import { normalizeImportedServers } from '../../frontend/src/utils/jsonImport';
 
 describe('normalizeImportedServers', () => {
   it('preserves stdio timeout options during JSON import', () => {
-    const servers = normalizeImportedServers({
+    const { servers, issues } = normalizeImportedServers({
       mcpServers: {
         'my-server': {
           command: 'npx',
@@ -16,6 +16,7 @@ describe('normalizeImportedServers', () => {
       },
     });
 
+    expect(issues).toEqual([]);
     expect(servers).toEqual([
       {
         name: 'my-server',


### PR DESCRIPTION
## Summary

Two independent UX fixes for confusing server-onboarding failures I hit while adding remote (streamable-http) OAuth servers to a self-hosted hub.

### 1. Opaque server-import failures

`normalizeImportedServers()` previously coerced any unrecognized `type` (e.g. `"http"`) or a missing `type` into a **stdio** server, and silently dropped the `oauth` field. So a pasted config like:

```json
{ "mcpServers": { "Foo": { "type": "http", "url": "https://…", "auth": { "CLIENT_ID": "…" } } } }
```

became a broken stdio entry and the whole import failed with a generic **"Failed to import servers"** — with no indication of which field was wrong.

Now `normalizeImportedServers()` returns `{ servers, issues }`:
- Unknown top-level keys (e.g. `auth`) are named in the error.
- An unsupported `type` is reported with `Did you mean "streamable-http"?`.
- The `oauth` object is preserved (previously dropped).
- The import preview surfaces these per-server issues instead of failing blindly.

### 2. OAuth `clientId` / `invalid redirect_uri` guidance

A statically configured `oauth.clientId` suppresses dynamic client registration — `clientInformation()` returns the stored id, so the SDK never performs DCR. When that preconfigured client's redirect allow-list excludes this hub's callback, the upstream auth server rejects authorization with **400 `invalid_redirect_uri`** and the user is stuck in an `oauth_required` loop with no explanation.

(Real-world repro: pasting a provider's per-app client ID from their docs — e.g. a "Claude Desktop" client — into a self-hosted MCPHub whose callback isn't on that client's allow-list.)

The server status now carries `clientIdConfigured`, and the dashboard shows a hint when opening OAuth for such a server: *if authorization fails with "invalid redirect_uri", remove the clientId so MCPHub can register its own OAuth client automatically.* Fixed-client providers are unaffected — this only adds a hint, it never changes the flow.

## Changes
- `frontend/src/utils/jsonImport.ts` — richer validation returning `{ servers, issues }`; preserve `oauth`.
- `frontend/src/components/JSONImportForm.tsx` — surface validation issues in preview.
- `src/services/mcpOAuthProvider.ts`, `src/services/mcpService.ts`, `src/types/index.ts`, `frontend/src/types/index.ts` — plumb `clientIdConfigured` to the frontend.
- `frontend/src/components/ServerCard.tsx` — show the DCR hint toast.
- `locales/{en,zh,fr,tr}.json` — two new keys.

## Testing
- Backend `tsc --noEmit`: no new errors (only the repo's pre-existing missing-dev-dep-type errors).
- `eslint` on all changed files: clean.
- `vite build` (frontend): passes.

This is separate from #1013 (static Authorization header override), which fixes a different code path.