### PR TITLE
fix: include upstream stderr in connection errors

### DIFF
--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -19,6 +19,7 @@ import { Request, Response } from 'express';
 import {
   getServerByName,
   getServerByOAuthState,
+  connectClientWithDiagnostics,
   createTransportFromConfig,
   updateServerToolsCache,
 } from '../services/mcpService.js';
@@ -354,7 +355,11 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
               serverName: serverInfo.name,
             });
             try {
-              await serverInfo.client.connect(serverInfo.transport, serverInfo.options);
+              await connectClientWithDiagnostics(
+                serverInfo.client,
+                serverInfo.transport,
+                serverInfo.options,
+              );
               console.log('Client connected successfully after OAuth callback', {
                 serverName: serverInfo.name,
               });

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -23,7 +23,8 @@ import {
   StreamableHTTPClientTransport,
   StreamableHTTPClientTransportOptions,
 } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { normalizeHeaders } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { normalizeHeaders, type Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { createFetchWithProxy, getProxyConfigFromEnv } from './proxy.js';
 import { assertSafeUrl, createRedirectValidatingFetch } from '../utils/ssrf.js';
 import { getUserDao } from '../dao/index.js';
@@ -74,6 +75,7 @@ import {
   sanitizeStringForLogging,
   summarizeErrorForLogging,
 } from '../utils/serialization.js';
+import { addStdioErrorContext, observeStdioStderr } from '../utils/stdioDiagnostics.js';
 import {
   MCP_APPS_CAPABILITIES,
   filterModelVisibleTools,
@@ -476,7 +478,7 @@ const getOrCreateIsolatedClient = async (
     const client = createUpstreamMcpClient(serverInfo.name, () => serverInfo);
 
     try {
-      await client.connect(transport, serverInfo.options || {});
+      await connectClientWithDiagnostics(client, transport, serverInfo.options || {});
     } catch (connectError) {
       // Connect failed — close the client/transport and kill any spawned
       // process tree so a failed handshake doesn't leak resources.
@@ -705,6 +707,18 @@ const sessionIsolatedClients = new Map<string, Map<string, { client: Client; tra
 
 // Locks to prevent concurrent creation of the same isolated client
 const isolatedClientCreationLocks = new Map<string, Promise<any>>();
+
+export const connectClientWithDiagnostics = async (
+  client: Client,
+  transport: Transport,
+  options?: RequestOptions,
+): Promise<void> => {
+  try {
+    await client.connect(transport, options);
+  } catch (error) {
+    throw addStdioErrorContext(error, transport);
+  }
+};
 
 // Track servers pending a cache-refresh reinstall.
 // Consumed once by createTransportFromConfig on the next reconnect.
@@ -1323,9 +1337,14 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
       env: env,
       stderr: 'pipe',
     });
-    transport.stderr?.on('data', (data) => {
-      console.log(`[${name}] [child] ${data}`);
-    });
+    if (transport.stderr) {
+      observeStdioStderr(transport, transport.stderr, (message) => {
+        console.log('Upstream server stderr', {
+          serverName: name,
+          message,
+        });
+      });
+    }
   } else {
     throw new Error(`Unable to create transport for server: ${name}`);
   }
@@ -1383,7 +1402,7 @@ const callToolWithReconnect = async (
           const newClient = createUpstreamMcpClient(serverInfo.name, () => serverInfo);
 
           // Reconnect with new transport
-          await newClient.connect(newTransport, serverInfo.options || {});
+          await connectClientWithDiagnostics(newClient, newTransport, serverInfo.options || {});
 
           if (isolated) {
             // Isolated path: close only this session's stale connection and
@@ -1707,8 +1726,7 @@ export const initializeClientsFromSettings = async (
       }
       nextServerInfos.push(serverInfo);
 
-      client
-        .connect(transport, initRequestOptions || requestOptions)
+      connectClientWithDiagnostics(client, transport, initRequestOptions || requestOptions)
         .then(() => {
           console.log(`Successfully connected client for server: ${name}`);
           const serverVersion = client.getServerVersion?.();

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -147,7 +147,7 @@ const summarizeSerializedErrorForLogging = (
 ): Record<string, unknown> => {
   const summary: Record<string, unknown> = {};
 
-  ['name', 'message', 'stack', 'requestId'].forEach((key) => {
+  ['name', 'message', 'stack', 'requestId', 'upstreamStderr'].forEach((key) => {
     if (typeof serialized[key] === 'string') {
       summary[key] = sanitizeStringForLogging(serialized[key]);
     }
@@ -197,6 +197,9 @@ export const summarizeErrorForLogging = (error: unknown): Record<string, unknown
     if (typeof record.requestId === 'string') {
       summary.requestId = sanitizeStringForLogging(record.requestId);
     }
+    if (typeof record.upstreamStderr === 'string') {
+      summary.upstreamStderr = sanitizeStringForLogging(record.upstreamStderr);
+    }
 
     if (Object.keys(summary).length > 0) {
       return summary;
@@ -242,6 +245,9 @@ export const formatErrorForLogging = (error: unknown): string => {
   }
   if (typeof summary.requestId === 'string') {
     parts.push(`requestId=${summary.requestId}`);
+  }
+  if (typeof summary.upstreamStderr === 'string') {
+    parts.push(`Upstream stderr:\n${summary.upstreamStderr}`);
   }
 
   return parts.join(' | ') || 'Unknown error';

--- a/src/utils/stdioDiagnostics.ts
+++ b/src/utils/stdioDiagnostics.ts
@@ -1,0 +1,82 @@
+import { sanitizeStringForLogging } from './serialization.js';
+
+const STDERR_TAIL_LIMIT = 32_768;
+
+type StderrStream = {
+  on(event: 'data', listener: (data: Buffer | string) => void): unknown;
+  on(event: 'end', listener: () => void): unknown;
+};
+
+type StdioDiagnosticState = {
+  rawTail: string;
+  pendingLine: string;
+};
+
+type ErrorWithUpstreamStderr = Error & {
+  cause?: unknown;
+  upstreamStderr?: string;
+};
+
+const diagnostics = new WeakMap<object, StdioDiagnosticState>();
+
+const keepTail = (value: string): string => value.slice(-STDERR_TAIL_LIMIT);
+
+export const observeStdioStderr = (
+  transport: object,
+  stderr: StderrStream,
+  logLine: (line: string) => void,
+): void => {
+  const state: StdioDiagnosticState = {
+    rawTail: '',
+    pendingLine: '',
+  };
+  diagnostics.set(transport, state);
+
+  const flushCompleteLines = (): void => {
+    const lines = state.pendingLine.split(/\r?\n/);
+    state.pendingLine = lines.pop() ?? '';
+    for (const line of lines) {
+      if (line.length > 0) {
+        logLine(sanitizeStringForLogging(line));
+      }
+    }
+  };
+
+  stderr.on('data', (data) => {
+    const chunk = data.toString();
+    state.rawTail = keepTail(state.rawTail + chunk);
+    state.pendingLine = keepTail(state.pendingLine + chunk);
+    flushCompleteLines();
+  });
+
+  stderr.on('end', () => {
+    if (state.pendingLine.length > 0) {
+      logLine(sanitizeStringForLogging(state.pendingLine));
+      state.pendingLine = '';
+    }
+  });
+};
+
+export const getStdioStderrTail = (transport: object): string | undefined => {
+  const tail = diagnostics.get(transport)?.rawTail.trim();
+  return tail ? sanitizeStringForLogging(tail) : undefined;
+};
+
+export const addStdioErrorContext = (error: unknown, transport: object): unknown => {
+  const upstreamStderr = getStdioStderrTail(transport);
+  if (!upstreamStderr) {
+    return error;
+  }
+
+  if (error instanceof Error && Object.isExtensible(error)) {
+    (error as ErrorWithUpstreamStderr).upstreamStderr = upstreamStderr;
+    return error;
+  }
+
+  const contextualError = new Error(
+    error instanceof Error ? error.message : String(error),
+  ) as ErrorWithUpstreamStderr;
+  contextualError.cause = error;
+  contextualError.upstreamStderr = upstreamStderr;
+  return contextualError;
+};

--- a/tests/services/mcpService-toggle.test.ts
+++ b/tests/services/mcpService-toggle.test.ts
@@ -4,6 +4,7 @@ const mockSaveToolsAsVectorEmbeddings = jest.fn().mockResolvedValue(undefined);
 const mockClientConnect = jest.fn().mockResolvedValue(undefined);
 const mockClientClose = jest.fn();
 const mockListTools = jest.fn().mockResolvedValue({ tools: [] });
+const mockStderrListeners = new Map<string, (data?: Buffer) => void>();
 
 jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: jest.fn().mockImplementation(() => ({
@@ -18,7 +19,9 @@ jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   StdioClientTransport: jest.fn().mockImplementation(() => ({
     close: jest.fn(),
     stderr: {
-      on: jest.fn(),
+      on: jest.fn((event: string, listener: (data?: Buffer) => void) => {
+        mockStderrListeners.set(event, listener);
+      }),
     },
   })),
 }));
@@ -187,6 +190,7 @@ describe('mcpService initializeClientsFromSettings OAuth authorization reuse', (
     setServerInfosForTest([]);
     mockServerDao.findAll.mockResolvedValue([]);
     mockClientConnect.mockResolvedValue(undefined);
+    mockStderrListeners.clear();
   });
 
   it('does not reconnect a server with an in-flight OAuth authorization during full reload', async () => {
@@ -238,6 +242,44 @@ describe('mcpService initializeClientsFromSettings OAuth authorization reuse', (
       },
     });
     expect(getServerByName('notion')?.oauth?.codeVerifier).toBe('verifier-1');
+  });
+
+  it('includes upstream stderr when a stdio server connection closes', async () => {
+    mockServerDao.findAll.mockResolvedValueOnce([
+      {
+        name: 'fetch',
+        enabled: true,
+        command: 'uvx',
+        args: ['mcp-server-fetch'],
+      },
+    ]);
+    mockClientConnect.mockImplementationOnce(async () => {
+      mockStderrListeners.get('data')?.(
+        Buffer.from('ImportError: token=secret cannot import name McpError\n'),
+      );
+      throw Object.assign(new Error('MCP error -32000: Connection closed'), { code: -32000 });
+    });
+
+    const servers = await initializeClientsFromSettings(true);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(servers[0]).toMatchObject({
+      status: 'disconnected',
+    });
+    expect(servers[0].error).toContain('MCP error -32000: Connection closed');
+    expect(servers[0].error).toContain(
+      'Upstream stderr:\nImportError: token=[REDACTED] cannot import name McpError',
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to connect client for server',
+      expect.objectContaining({
+        serverName: 'fetch',
+        error: expect.objectContaining({
+          code: -32000,
+          upstreamStderr: 'ImportError: token=[REDACTED] cannot import name McpError',
+        }),
+      }),
+    );
   });
 });
 

--- a/tests/utils/stdioDiagnostics.test.ts
+++ b/tests/utils/stdioDiagnostics.test.ts
@@ -1,0 +1,60 @@
+import { EventEmitter } from 'node:events';
+import {
+  addStdioErrorContext,
+  getStdioStderrTail,
+  observeStdioStderr,
+} from '../../src/utils/stdioDiagnostics.js';
+import { summarizeErrorForLogging } from '../../src/utils/serialization.js';
+
+class FakeStderr extends EventEmitter {}
+
+describe('stdio diagnostics', () => {
+  it('captures chunked stderr as sanitized lines and preserves the complete tail', () => {
+    const transport = {};
+    const stderr = new FakeStderr();
+    const logLine = jest.fn();
+
+    observeStdioStderr(transport, stderr, logLine);
+    stderr.emit('data', Buffer.from('Traceback (most recent call last):\nImport'));
+    stderr.emit('data', Buffer.from('Error: token=super-secret\n'));
+    stderr.emit('end');
+
+    expect(logLine).toHaveBeenNthCalledWith(1, 'Traceback (most recent call last):');
+    expect(logLine).toHaveBeenNthCalledWith(2, 'ImportError: token=[REDACTED]');
+    expect(getStdioStderrTail(transport)).toBe(
+      'Traceback (most recent call last):\nImportError: token=[REDACTED]',
+    );
+  });
+
+  it('keeps only the most recent stderr when output exceeds the diagnostic limit', () => {
+    const transport = {};
+    const stderr = new FakeStderr();
+
+    observeStdioStderr(transport, stderr, jest.fn());
+    stderr.emit('data', Buffer.from(`${'x'.repeat(40_000)}FINAL_ERROR`));
+
+    const tail = getStdioStderrTail(transport);
+    expect(tail?.length).toBeLessThanOrEqual(32_768);
+    expect(tail?.endsWith('FINAL_ERROR')).toBe(true);
+  });
+
+  it('adds captured stderr to connection errors so existing logging includes the cause', () => {
+    const transport = {};
+    const stderr = new FakeStderr();
+    const error = Object.assign(new Error('MCP error -32000: Connection closed'), {
+      code: -32000,
+    });
+
+    observeStdioStderr(transport, stderr, jest.fn());
+    stderr.emit('data', Buffer.from('ImportError: cannot import name McpError\n'));
+
+    const contextualError = addStdioErrorContext(error, transport);
+
+    expect(summarizeErrorForLogging(contextualError)).toEqual(
+      expect.objectContaining({
+        code: -32000,
+        upstreamStderr: 'ImportError: cannot import name McpError',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- capture and line-buffer stderr from stdio MCP server processes
- attach the sanitized stderr tail to MCP connection errors, preserving the original error code and message
- use the same diagnostic connection path for startup, reconnect, per-session, and OAuth reconnect flows
- expose the upstream stderr in structured logs and the server status error shown by the dashboard

## Root cause

When a stdio child exits during initialization, the MCP SDK reports the transport-level `-32000: Connection closed` error. MCPHub previously streamed child stderr separately, so the actual Python or Node failure could be split across log chunks and was not associated with the connection error or server status.

## Implementation

The new stdio diagnostic helper keeps a weakly referenced, sanitized 32 KiB stderr tail per transport. Complete stderr lines continue to be logged using a fixed structured log template. If connection fails, the captured tail is attached as `upstreamStderr`; existing error serialization then includes it in structured logs and formatted server errors. Non-stdio transports retain their existing behavior.

## Validation

- `pnpm lint`
- `pnpm test:ci` — 140 suites, 925 tests passed
- `pnpm build`
- `node scripts/verify-dist.js`
- `git diff --check`
- real `uvx mcp-server-fetch` failure using the built code: retained `MCP error -32000` and captured the complete Python `ImportError` traceback in `upstreamStderr`
