### PR TITLE
fix: remove duplicated semver@7.8.5 entries from lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4487,16 +4487,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -9328,10 +9318,6 @@ snapshots:
   semver@7.7.3: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.5: {}
-
-  semver@7.8.5: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
## Summary
- `pnpm install --frozen-lockfile` was failing with `ERR_PNPM_BROKEN_LOCKFILE: duplicated mapping key` at the `semver@7.8.5` entries.
- The lockfile contained three identical `semver@7.8.5` mappings in both the `packages:` and `snapshots:` sections, making it invalid YAML.
- Removed the duplicate entries, keeping the single canonical entry per section.

## Test plan
- [x] Verified no duplicate keys remain in `packages:` and `snapshots:` sections
- [x] `pnpm install --frozen-lockfile` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)