### PR TITLE
feat: add ResilientJsonSchemaValidator to handle unresolvable $refs gracefully

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -27,6 +27,7 @@ import { normalizeHeaders, type Transport } from '@modelcontextprotocol/sdk/shar
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { createFetchWithProxy, getProxyConfigFromEnv } from './proxy.js';
 import { assertSafeUrl, createRedirectValidatingFetch } from '../utils/ssrf.js';
+import { ResilientJsonSchemaValidator } from '../utils/jsonSchemaValidator.js';
 import { getUserDao } from '../dao/index.js';
 import {
   ServerInfo,
@@ -770,6 +771,7 @@ const createUpstreamMcpClient = (
     },
     {
       capabilities: MCP_APPS_CAPABILITIES,
+      jsonSchemaValidator: new ResilientJsonSchemaValidator(),
       listChanged: {
         tools: {
           onChanged: (error, tools) => {

--- a/src/utils/__tests__/jsonSchemaValidator.test.ts
+++ b/src/utils/__tests__/jsonSchemaValidator.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { ResilientJsonSchemaValidator } from '../jsonSchemaValidator.js';
+
+describe('ResilientJsonSchemaValidator', () => {
+  const validator = new ResilientJsonSchemaValidator();
+
+  it('validates well-formed output schemas strictly', () => {
+    const validate = validator.getValidator<{ count: number }>({
+      type: 'object',
+      properties: { count: { type: 'number' } },
+      required: ['count'],
+    });
+
+    expect(validate({ count: 42 })).toEqual({
+      valid: true,
+      data: { count: 42 },
+      errorMessage: undefined,
+    });
+    expect(validate({ count: 'not-a-number' }).valid).toBe(false);
+    expect(validate({}).valid).toBe(false);
+  });
+
+  it('validates recursive $ref schemas when the $defs are in scope', () => {
+    const validate = validator.getValidator<Record<string, unknown>>({
+      type: 'object',
+      properties: { screenInstance: { $ref: '#/$defs/ScreenInstance' } },
+      $defs: {
+        ScreenInstance: {
+          type: 'object',
+          properties: {
+            variantScreenInstance: { $ref: '#/$defs/ScreenInstance' },
+          },
+        },
+      },
+    });
+
+    expect(
+      validate({ screenInstance: { variantScreenInstance: { variantScreenInstance: {} } } }).valid,
+    ).toBe(true);
+  });
+
+  it('does not throw on an unresolvable $ref and falls back to passthrough', () => {
+    // Mirrors the Stitch server schema that failed tool discovery (issue #1024).
+    const validate = validator.getValidator<Record<string, unknown>>({
+      type: 'object',
+      properties: { screenInstance: { $ref: '#/$defs/ScreenInstance' } },
+    });
+
+    expect(validate({ anything: 'goes' })).toEqual({
+      valid: true,
+      data: { anything: 'goes' },
+      errorMessage: undefined,
+    });
+    expect(validate(null)).toEqual({
+      valid: true,
+      data: null,
+      errorMessage: undefined,
+    });
+  });
+
+  it('keeps validating after a schema failed to compile', () => {
+    const broken = validator.getValidator({
+      type: 'object',
+      properties: { screenInstance: { $ref: '#/$defs/Missing' } },
+    });
+    const healthy = validator.getValidator<{ ok: boolean }>({
+      type: 'object',
+      properties: { ok: { type: 'boolean' } },
+      required: ['ok'],
+    });
+
+    expect(broken({ x: 1 }).valid).toBe(true);
+    expect(healthy({ ok: true }).valid).toBe(true);
+    expect(healthy({ ok: 'nope' }).valid).toBe(false);
+  });
+});

--- a/src/utils/jsonSchemaValidator.ts
+++ b/src/utils/jsonSchemaValidator.ts
@@ -1,0 +1,29 @@
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv-provider.js';
+import type {
+  jsonSchemaValidator,
+  JsonSchemaType,
+  JsonSchemaValidatorResult,
+} from '@modelcontextprotocol/sdk/validation/types.js';
+
+/**
+ * Validator that tolerates schemas AJV cannot compile (e.g. an unresolvable
+ * $ref such as `#/$defs/ScreenInstance` with no matching `$defs` in scope).
+ *
+ * The MCP SDK pre-compiles a validator for every tool outputSchema during
+ * tools/list. The default AjvJsonSchemaValidator throws on an unresolvable
+ * $ref, which would fail discovery for the whole server. This wrapper keeps
+ * strict validation for well-formed schemas and only degrades the offending
+ * schema to a passthrough (skip output validation) instead of throwing.
+ */
+export class ResilientJsonSchemaValidator implements jsonSchemaValidator {
+  private readonly delegate = new AjvJsonSchemaValidator();
+
+  getValidator<T>(schema: JsonSchemaType): (input: unknown) => JsonSchemaValidatorResult<T> {
+    try {
+      return this.delegate.getValidator<T>(schema);
+    } catch {
+      // Uncompilable schema: accept any output rather than fail tool discovery.
+      return (input: unknown) => ({ valid: true, data: input as T, errorMessage: undefined });
+    }
+  }
+}


### PR DESCRIPTION
Fix #1024 