### PR TITLE
fix: apply resource description/enabled overrides in dashboard list

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -2028,6 +2028,15 @@ export const getServersInfo = async (
           };
         });
 
+        const resourcesWithEnabled = resources.map((resource) => {
+          const resourceConfig = serverConfig?.resources?.[resource.uri];
+          return {
+            ...resource,
+            description: resolveDescriptionOverride(resource.description, resourceConfig),
+            enabled: resourceConfig?.enabled !== false,
+          };
+        });
+
         return {
           name,
           version,
@@ -2038,7 +2047,7 @@ export const getServersInfo = async (
           error,
           tools: toolsWithEnabled,
           prompts: promptsWithEnabled,
-          resources,
+          resources: resourcesWithEnabled,
           createTime,
           enabled,
           oauth:

--- a/tests/services/mcpService-server-metadata.test.ts
+++ b/tests/services/mcpService-server-metadata.test.ts
@@ -1,7 +1,7 @@
 const mockClient = {
   connect: jest.fn().mockResolvedValue(undefined),
   close: jest.fn(),
-  getServerCapabilities: jest.fn(() => ({ tools: {} })),
+  getServerCapabilities: jest.fn(() => ({ tools: {}, prompts: {}, resources: {} })),
   getServerVersion: jest.fn(() => ({ name: 'upstream-weather', version: '1.2.3' })),
   getInstructions: jest.fn(() => 'Use the weather tools for forecast lookups.'),
   listTools: jest.fn().mockResolvedValue({ tools: [] }),
@@ -257,6 +257,83 @@ describe('mcpService initialize metadata', () => {
         oauth: {
           connected: true,
         },
+      }),
+    ]);
+  });
+
+  it('exposes resource description and enabled overrides for dashboard consumers', async () => {
+    mockFindAll.mockResolvedValue([
+      {
+        name: 'zabbix',
+        type: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+        enabled: true,
+        resources: {
+          'resource://hosts': {
+            enabled: true,
+            description: 'Custom hosts description',
+          },
+          'resource://disabled': {
+            enabled: false,
+            description: 'Disabled resource',
+          },
+          'resource://no-override': {
+            enabled: true,
+            description: undefined,
+          },
+        },
+      },
+    ]);
+    mockClient.listResources.mockResolvedValueOnce({
+      resources: [
+        {
+          uri: 'resource://hosts',
+          name: 'resource_hosts',
+          description: 'Upstream hosts description',
+          mimeType: 'text/plain',
+        },
+        {
+          uri: 'resource://disabled',
+          name: 'resource_disabled',
+          description: 'Upstream disabled description',
+          mimeType: 'text/plain',
+        },
+        {
+          uri: 'resource://no-override',
+          name: 'resource_no_override',
+          description: 'Upstream no-override description',
+          mimeType: 'text/plain',
+        },
+      ],
+    });
+
+    await initUpstreamServers();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const result = await getServersInfo();
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: 'zabbix',
+        resources: expect.arrayContaining([
+          expect.objectContaining({
+            uri: 'resource://hosts',
+            description: 'Custom hosts description',
+            enabled: true,
+          }),
+          expect.objectContaining({
+            uri: 'resource://disabled',
+            description: 'Disabled resource',
+            enabled: false,
+          }),
+          expect.objectContaining({
+            uri: 'resource://no-override',
+            description: 'Upstream no-override description',
+            enabled: true,
+          }),
+        ]),
       }),
     ]);
   });


### PR DESCRIPTION
## Summary
- The dashboard Resources section showed stale upstream descriptions and did not reflect toggled enable/disable states, while the Tools and Prompts sections behaved correctly. Fixes #1031.
- `getServersInfo` (the dashboard list) applied custom description/enabled overrides from `serverConfig` for tools and prompts, but passed `resources` through unchanged. The MCP `resources/list` endpoint already applied the overrides at request time, which is why the endpoint returned correct data while the dashboard cache did not.
- Apply the same override resolution to resources (keyed by `uri`, matching `handleListResourcesRequest` and `serverController`), consistent with the existing tools/prompts pattern.

## Why not fix the cache
The issue suggested fixing `updateServerResourcesCache`. I left the cache storing raw upstream data on purpose: the cache is populated at connect time, and baking overrides into it would go stale when a user edits a description or toggles a resource (those updates write to `serverConfig` in the DAO, not the cache). Tools and prompts already apply overrides in the list function rather than the cache for exactly this reason, so resources now match that pattern.

## Test plan
- [x] Added `exposes resource description and enabled overrides for dashboard consumers` covering custom description, disabled override, and no-override fallback cases.
- [x] `npx jest tests/services/mcpService` — 127 tests pass.
- [x] Full suite `npx jest` — 990 tests pass.
- [x] `tsc --noEmit` and `eslint` clean.
- [ ] Manual: edit a resource description and toggle a resource off in Server detail → Resources, navigate away and back; values now persist in the UI (matching Tools/Prompts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)