### PR TITLE
fix: bound graceful shutdown for long-lived connections

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,9 @@ import { initOAuthServer } from './services/oauthServerService.js';
 import { safeStringify } from './utils/serialization.js';
 import { resolveTrustProxySetting } from './utils/proxyTrust.js';
 import http from 'http';
+import type { Socket } from 'net';
 import { mcpConnectionRateLimiter } from './utils/rateLimit.js';
+import { closeHttpServer } from './utils/serverShutdown.js';
 
 /**
  * Get the directory of the current module
@@ -45,6 +47,7 @@ function getCurrentFileDir(): string {
 export class AppServer {
   private app: express.Application;
   private server: http.Server | null = null;
+  private connections = new Set<Socket>();
   private port: number | string;
   private frontendPath: string | null = null;
   private basePath: string;
@@ -218,6 +221,10 @@ export class AppServer {
         );
       }
     });
+    this.server.on('connection', (socket) => {
+      this.connections.add(socket);
+      socket.once('close', () => this.connections.delete(socket));
+    });
   }
 
   /**
@@ -226,15 +233,10 @@ export class AppServer {
   async shutdown(): Promise<void> {
     console.log('[SHUTDOWN] Starting graceful shutdown...');
 
-    // Close HTTP server first (stop accepting new connections)
-    if (this.server) {
-      await new Promise<void>((resolve) => {
-        this.server!.close(() => {
-          console.log('[SHUTDOWN] HTTP server closed');
-          resolve();
-        });
-      });
-    }
+    // Stop accepting new connections while existing requests finish within the grace period.
+    const httpShutdown = this.server
+      ? closeHttpServer(this.server, this.connections)
+      : Promise.resolve();
 
     // Close all MCP clients
     try {
@@ -243,6 +245,9 @@ export class AppServer {
     } catch (error) {
       console.error('[SHUTDOWN] Error closing MCP clients', safeStringify({ error }));
     }
+
+    await httpShutdown;
+    this.server = null;
 
     // Close database connection if in database mode
     const useDatabase =

--- a/src/utils/serverShutdown.test.ts
+++ b/src/utils/serverShutdown.test.ts
@@ -1,0 +1,55 @@
+import http from 'http';
+import type { AddressInfo } from 'net';
+import type { Socket } from 'net';
+import { closeHttpServer } from './serverShutdown.js';
+
+const listen = (server: http.Server): Promise<number> => {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+};
+
+describe('closeHttpServer', () => {
+  it('closes normally without waiting for the grace period', async () => {
+    const connections = new Set<Socket>();
+    const server = http.createServer((_request, response) => response.end('ok'));
+    server.on('connection', (socket) => {
+      connections.add(socket);
+      socket.once('close', () => connections.delete(socket));
+    });
+
+    await listen(server);
+
+    await expect(closeHttpServer(server, connections, 50)).resolves.toBeUndefined();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('destroys a long-lived connection when the grace period expires', async () => {
+    const connections = new Set<Socket>();
+    let destroySpy: jest.SpyInstance | undefined;
+    const server = http.createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write('data: connected\n\n');
+    });
+    server.on('connection', (socket) => {
+      connections.add(socket);
+      destroySpy = jest.spyOn(socket, 'destroy');
+      socket.once('close', () => connections.delete(socket));
+    });
+
+    const port = await listen(server);
+    await new Promise<http.IncomingMessage>((resolve) => {
+      http.get(`http://127.0.0.1:${port}`, resolve);
+    });
+
+    await expect(closeHttpServer(server, connections, 20)).resolves.toBeUndefined();
+
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[SHUTDOWN] Grace period expired; force closing HTTP connections',
+      expect.objectContaining({ connections: 1, gracePeriodMs: 20 }),
+    );
+  });
+});

--- a/src/utils/serverShutdown.ts
+++ b/src/utils/serverShutdown.ts
@@ -1,0 +1,39 @@
+import type { Socket } from 'net';
+import type http from 'http';
+
+export const SHUTDOWN_GRACE_PERIOD_MS = 10_000;
+
+export const closeHttpServer = (
+  server: http.Server,
+  connections: ReadonlySet<Socket>,
+  gracePeriodMs = SHUTDOWN_GRACE_PERIOD_MS,
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const forceCloseTimer = setTimeout(() => {
+      if (connections.size === 0) {
+        return;
+      }
+
+      console.warn('[SHUTDOWN] Grace period expired; force closing HTTP connections', {
+        connections: connections.size,
+        gracePeriodMs,
+      });
+
+      for (const socket of connections) {
+        socket.destroy();
+      }
+    }, gracePeriodMs);
+
+    server.close((error) => {
+      clearTimeout(forceCloseTimer);
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      console.log('[SHUTDOWN] HTTP server closed');
+      resolve();
+    });
+  });
+};


### PR DESCRIPTION
## Summary

`server.close()` waited indefinitely for long-lived HTTP and SSE connections, which could leave the process alive after a restart.

- Track active HTTP sockets when the application server starts.
- Stop accepting new connections and clean up MCP clients immediately during shutdown.
- Allow existing HTTP connections 10 seconds to finish, then destroy remaining sockets and log the forced cleanup.
- Add regression coverage for both normal shutdown and a long-lived SSE connection.

Closes #1030

## Validation

- `pnpm exec jest src/utils/serverShutdown.test.ts --runInBand`
- `pnpm backend:build`
- `pnpm lint`
- `pnpm exec prettier --check src/server.ts src/utils/serverShutdown.ts src/utils/serverShutdown.test.ts`

The full Jest suite exceeded the local environment's 60-second command window before producing a result; the focused regression tests passed.