### PR TITLE
fix(oauth): restore 401 auto-discovery for URL-only Streamable HTTP servers

### DIFF
--- a/src/services/mcpOAuthProvider.ts
+++ b/src/services/mcpOAuthProvider.ts
@@ -534,6 +534,15 @@ const prepopulateScopesIfMissing = async (
   }
 };
 
+const hasAuthorizationHeader = (
+  headers?: Record<string, string>,
+): boolean => {
+  if (!headers) {
+    return false;
+  }
+  return Object.keys(headers).some((key) => key.toLowerCase() === 'authorization');
+};
+
 /**
  * Create an OAuth provider for a server if OAuth is configured
  *
@@ -547,9 +556,12 @@ export const createOAuthProvider = async (
 ): Promise<OAuthClientProvider | undefined> => {
   const oauth = serverConfig.oauth;
 
-  // Only create a provider when OAuth is actually configured. Static
-  // Authorization headers or API key auth must not be detached for remote MCP
-  // servers that have no OAuth state.
+  // Create a provider when OAuth is explicitly configured, OR when the server
+  // has no static Authorization header. The SDK's StreamableHTTPClientTransport
+  // only intercepts a 401 OAuth challenge when an authProvider is attached, so a
+  // URL-only remote server needs a provider up front for 401-driven auto-discovery
+  // to run. A server whose auth is a static Authorization header / API key is left
+  // alone so that header is preserved verbatim (see #1013, #1045).
   const hasOAuthConfig = Boolean(
     oauth &&
       (oauth.clientId ||
@@ -562,7 +574,7 @@ export const createOAuthProvider = async (
         oauth.dynamicRegistration?.registrationEndpoint),
   );
 
-  if (!hasOAuthConfig) {
+  if (!hasOAuthConfig && hasAuthorizationHeader(serverConfig.headers)) {
     return undefined;
   }
 

--- a/tests/services/mcpOAuthProvider.test.ts
+++ b/tests/services/mcpOAuthProvider.test.ts
@@ -23,7 +23,7 @@ jest.mock('../../src/services/mcpService.js', () => ({
 }));
 
 import { getSystemConfigDao } from '../../src/dao/index.js';
-import { MCPHubOAuthProvider } from '../../src/services/mcpOAuthProvider.js';
+import { MCPHubOAuthProvider, createOAuthProvider } from '../../src/services/mcpOAuthProvider.js';
 
 describe('MCPHubOAuthProvider redirect URI resolution', () => {
   const originalEnv = process.env;
@@ -96,5 +96,74 @@ describe('MCPHubOAuthProvider redirect URI resolution', () => {
       'https://backup.example.com/oauth/callback',
       'https://base.example.com/oauth/callback',
     ]);
+  });
+});
+
+describe('createOAuthProvider - 401 auto-discovery guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSystemConfigDao as jest.Mock).mockReturnValue({
+      get: jest.fn().mockResolvedValue({}),
+    });
+  });
+
+  it('creates a provider for a URL-only server so 401 auto-discovery can run', async () => {
+    const provider = await createOAuthProvider('notion', {
+      type: 'streamable-http',
+      url: 'https://mcp.notion.com/mcp',
+    } as any);
+
+    expect(provider).toBeInstanceOf(MCPHubOAuthProvider);
+  });
+
+  it('creates a provider for a URL-only server with non-Authorization headers', async () => {
+    const provider = await createOAuthProvider('notion', {
+      type: 'streamable-http',
+      url: 'https://mcp.notion.com/mcp',
+      headers: { 'X-Custom': 'value' },
+    } as any);
+
+    expect(provider).toBeInstanceOf(MCPHubOAuthProvider);
+  });
+
+  it('returns undefined when only a static Authorization header is configured', async () => {
+    const provider = await createOAuthProvider('static', {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer api-token' },
+    } as any);
+
+    expect(provider).toBeUndefined();
+  });
+
+  it('returns undefined for a static auth header with non-canonical casing', async () => {
+    const provider = await createOAuthProvider('static', {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      headers: { authorization: 'Bearer api-token' },
+    } as any);
+
+    expect(provider).toBeUndefined();
+  });
+
+  it('creates a provider when OAuth is explicitly configured', async () => {
+    const provider = await createOAuthProvider('oauth', {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      oauth: { clientId: 'abc' },
+    } as any);
+
+    expect(provider).toBeInstanceOf(MCPHubOAuthProvider);
+  });
+
+  it('creates a provider when OAuth is configured alongside a static Authorization header', async () => {
+    const provider = await createOAuthProvider('oauth', {
+      type: 'streamable-http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer stale-token' },
+      oauth: { clientId: 'abc' },
+    } as any);
+
+    expect(provider).toBeInstanceOf(MCPHubOAuthProvider);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the regression reported in #1045: since `1.0.27`, a URL-only Streamable HTTP server (e.g. `https://mcp.notion.com/mcp`) no longer entered OAuth auto-discovery on a `401` and failed with a generic `Streamable HTTP error`.
- Root cause: the `hasOAuthConfig` guard added in #1013 made `createOAuthProvider()` return `undefined` for URL-only servers, so no `authProvider` was attached to the transport. The MCP SDK (`@modelcontextprotocol/sdk@1.29.0`) only intercepts a `401` OAuth challenge when an `authProvider` is present (`streamableHttp.js`: `if (response.status === 401 && this._authProvider)`); otherwise it throws the generic error.
- Fix: create a provider whenever OAuth is explicitly configured **or** no static `Authorization` header is present. A server whose auth is a static `Authorization` header / API key is still left alone (no provider, header preserved), so #1013's behavior is intact.

## Behavior matrix

| OAuth configured | Static `Authorization` header | Before | After |
|---|---|---|---|
| yes | yes | provider created, header stripped | provider created, header stripped (unchanged) |
| yes | no  | provider created | provider created (unchanged) |
| no  | yes | **no provider** | no provider (unchanged — #1013 preserved) |
| no  | no  | **no provider → 401 discovery broken** | **provider created → 401 discovery restored** |

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:ci` — 1002 tests pass (145 suites)
- [x] `pnpm build`
- [x] Added regression tests in `tests/services/mcpOAuthProvider.test.ts` covering all four rows of the matrix above, plus case-insensitive `authorization` header handling.
- [x] Existing `tests/services/mcpService-oauth-static-auth-header.test.ts` (#1013's tests) still pass.

Closes #1045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)