### PR TITLE
feat(openapi): persist Set-Cookie across calls per downstream session

### DIFF
--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -144,6 +144,7 @@ const ServerForm = ({
             passthroughHeaders: initialData.config.openapi.passthroughHeaders
               ? initialData.config.openapi.passthroughHeaders.join(', ')
               : '',
+            cookieSession: initialData.config.openapi.cookieSession === true,
           }
         : {
             inputMode: 'url',
@@ -152,6 +153,7 @@ const ServerForm = ({
             version: '3.1.0',
             securityType: 'none',
             passthroughHeaders: '',
+            cookieSession: false,
           },
   });
 
@@ -830,6 +832,41 @@ const ServerForm = ({
                   />
                   <p className="text-xs text-gray-500 mt-1">
                     {t('server.openapi.passthroughHeadersHelp')}
+                  </p>
+                </div>
+
+                {/* Cookie Session Handling */}
+                <div className="mb-4">
+                  <div className="flex items-center mb-1">
+                    <input
+                      type="checkbox"
+                      id="openapiCookieSession"
+                      checked={formData.openapi?.cookieSession || false}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          openapi: {
+                            ...prev.openapi,
+                            passthroughHeaders: prev.openapi?.passthroughHeaders || '',
+                            url: prev.openapi?.url || '',
+                            cookieSession: e.target.checked,
+                          },
+                        }))
+                      }
+                      className="mr-2"
+                    />
+                    <label
+                      htmlFor="openapiCookieSession"
+                      className="text-gray-700 dark:text-gray-300 text-sm font-medium"
+                    >
+                      {t('server.openapi.cookieSession', 'Cookie Session Handling')}
+                    </label>
+                  </div>
+                  <p className="text-xs text-gray-500 ml-6">
+                    {t(
+                      'server.openapi.cookieSessionHelp',
+                      'Capture Set-Cookie from upstream login responses and replay them on later calls within the same downstream session. Isolated per MCP session; not persisted.',
+                    )}
                   </p>
                 </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -262,6 +262,7 @@ export interface ServerConfig {
     version?: string; // OpenAPI version (default: '3.1.0')
     security?: OpenAPISecurityConfig; // Security configuration for API calls
     passthroughHeaders?: string[]; // Header names to pass through from tool call requests to upstream OpenAPI endpoints
+    cookieSession?: boolean; // Opt-in: capture upstream Set-Cookie and replay on later calls, isolated per downstream MCP session
   };
 }
 
@@ -402,6 +403,7 @@ export interface ServerFormData {
     openIdConnectToken?: string;
     // Passthrough headers
     passthroughHeaders?: string; // Comma-separated list of header names
+    cookieSession?: boolean; // Opt-in dynamic cookie session handling
   };
 }
 

--- a/frontend/src/utils/serverFormPayload.ts
+++ b/frontend/src/utils/serverFormPayload.ts
@@ -93,6 +93,7 @@ const buildOpenApiConfig = (formData: ServerFormData): NonNullable<ServerConfig[
   const openapi: NonNullable<ServerConfig['openapi']> = {
     version: formData.openapi?.version || '3.1.0',
     passthroughHeaders: parseCommaSeparatedList(formData.openapi?.passthroughHeaders),
+    cookieSession: formData.openapi?.cookieSession === true ? true : undefined,
   };
   const oauth2TokenUrl = formData.openapi?.oauth2TokenUrl?.trim();
   const oauth2ClientId = formData.openapi?.oauth2ClientId?.trim();

--- a/locales/en.json
+++ b/locales/en.json
@@ -233,7 +233,9 @@
       "apiKeyInQuery": "Query",
       "apiKeyInCookie": "Cookie",
       "passthroughHeaders": "Passthrough Headers",
-      "passthroughHeadersHelp": "Comma-separated list of header names to pass through from incoming MCP requests to upstream server requests (e.g., Authorization, X-API-Key)"
+      "passthroughHeadersHelp": "Comma-separated list of header names to pass through from incoming MCP requests to upstream server requests (e.g., Authorization, X-API-Key)",
+      "cookieSession": "Cookie Session Handling",
+      "cookieSessionHelp": "Capture Set-Cookie from upstream login responses and replay them on later calls within the same downstream session. Isolated per MCP session; not persisted."
     },
     "oauth": {
       "sectionTitle": "OAuth Configuration",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -225,7 +225,9 @@
       "apiKeyInQuery": "Requête",
       "apiKeyInCookie": "Cookie",
       "passthroughHeaders": "En-têtes de transmission",
-      "passthroughHeadersHelp": "Liste séparée par des virgules des noms d’en-têtes à transmettre des requêtes MCP entrantes vers les requêtes du serveur en amont (par ex. : Authorization, X-API-Key)"
+      "passthroughHeadersHelp": "Liste séparée par des virgules des noms d’en-têtes à transmettre des requêtes MCP entrantes vers les requêtes du serveur en amont (par ex. : Authorization, X-API-Key)",
+      "cookieSession": "Gestion de session Cookie",
+      "cookieSessionHelp": "Capture les Set-Cookie des réponses de connexion en amont et les renvoie lors des appels ultérieurs dans la même session aval. Isolé par session MCP ; non persistant."
     },
     "oauth": {
       "sectionTitle": "Configuration OAuth",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -225,7 +225,9 @@
       "apiKeyInQuery": "Sorgu",
       "apiKeyInCookie": "Çerez",
       "passthroughHeaders": "Geçiş Başlıkları",
-      "passthroughHeadersHelp": "Gelen MCP isteklerinden yukarı akış sunucu isteklerine geçirilecek başlık adlarının virgülle ayrılmış listesi (örn. Authorization, X-API-Key)"
+      "passthroughHeadersHelp": "Gelen MCP isteklerinden yukarı akış sunucu isteklerine geçirilecek başlık adlarının virgülle ayrılmış listesi (örn. Authorization, X-API-Key)",
+      "cookieSession": "Cookie Oturum Yönetimi",
+      "cookieSessionHelp": "Yukarı akış oturum açma yanıtlarındaki Set-Cookie değerini yakalar ve aynı aşağı akış oturumundaki sonraki çağrılarda yeniden gönderir. MCP oturumu başına izole edilir; kalıcı değildir."
     },
     "oauth": {
       "sectionTitle": "OAuth Yapılandırması",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -233,7 +233,9 @@
       "apiKeyInQuery": "查询",
       "apiKeyInCookie": "Cookie",
       "passthroughHeaders": "透传请求头",
-      "passthroughHeadersHelp": "要从传入的 MCP 请求透传到上游服务器请求的请求头名称列表，用逗号分隔（如：Authorization, X-API-Key）"
+      "passthroughHeadersHelp": "要从传入的 MCP 请求透传到上游服务器请求的请求头名称列表，用逗号分隔（如：Authorization, X-API-Key）",
+      "cookieSession": "Cookie 会话处理",
+      "cookieSessionHelp": "捕获上游登录响应中的 Set-Cookie，并在同一下游会话的后续调用中自动携带。按 MCP 会话隔离，不持久化存储。"
     },
     "oauth": {
       "sectionTitle": "OAuth 配置",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "postgres": "^3.4.7",
     "redis": "^5.12.1",
     "reflect-metadata": "^0.2.2",
+    "tough-cookie": "^6.0.2",
     "tree-kill": "^1.2.2",
     "typeorm": "^0.3.26",
     "undici": "^7.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
+      tough-cookie:
+        specifier: ^6.0.2
+        version: 6.0.2
       tree-kill:
         specifier: ^1.2.2
         version: 1.2.2
@@ -1450,66 +1453,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1586,36 +1602,42 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.32':
     resolution: {integrity: sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-ppc64-gnu@1.15.32':
     resolution: {integrity: sha512-KGkTMyz/Tbn3PBNu0AVZ4GTDFKnICrYcTiNPZq8DrvK42pnFsf3GNDrIG9E5AtQlTmC0YigkWKmu0eMcfTrmgA==}
     engines: {node: '>=10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-s390x-gnu@1.15.32':
     resolution: {integrity: sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==}
     engines: {node: '>=10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.15.32':
     resolution: {integrity: sha512-ERsjfGcj6CBmj3vJnGDO8m8rTvw6RqMcWo1dogOtNx3/+/0+NNpJiXDobJrr1GwInI/BHAEkvSFIH6d2LqPcUQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.32':
     resolution: {integrity: sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.32':
     resolution: {integrity: sha512-01yN0o9jvo8xBTP12aPK2wW8b41jmOlGbDDlAnoynotc4pO6xA0zby9f1z6j++qXDpGBttLySq1omgVrlQKYcw==}
@@ -1732,48 +1754,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
     resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -2122,41 +2152,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3718,48 +3756,56 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -4730,6 +4776,13 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -4744,6 +4797,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -9619,6 +9676,12 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   tmpl@1.0.5: {}
 
   to-buffer@1.2.2:
@@ -9632,6 +9695,10 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
 
   tree-kill@1.2.2: {}
 

--- a/src/clients/__tests__/openapi-cookie.test.ts
+++ b/src/clients/__tests__/openapi-cookie.test.ts
@@ -210,6 +210,70 @@ describe('OpenAPIClient - cookie session handling', () => {
     const protectedCall = lastCallTo(client.httpClient.request, '/protected');
     expect(protectedCall[0].headers?.Cookie).toBeUndefined();
   });
+
+  it('captures Set-Cookie from a non-2xx error response', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        // Simulate a non-2xx response (e.g. a redirect treated as an error)
+        // carrying Set-Cookie. Axios surfaces this as a rejected promise.
+        throw {
+          isAxiosError: true,
+          response: {
+            status: 400,
+            statusText: 'Bad Request',
+            data: {},
+            headers: { 'set-cookie': ['accesstoken=abc; Path=/; HttpOnly'] },
+          },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await expect(client.callTool('login', {}, undefined, false, 'sess-1')).rejects.toThrow(
+      'API call failed: 400',
+    );
+    await client.callTool('getProtected', {}, undefined, false, 'sess-1');
+
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    expect(protectedCall[0].headers?.Cookie).toBe('accesstoken=abc');
+  });
+
+  it('preserves a caller-configured Cookie header, merging with jar cookies', async () => {
+    const cookieHeaderTool: TestTool = {
+      name: 'getProtected',
+      description: 'protected',
+      inputSchema: {
+        type: 'object',
+        properties: { Cookie: { type: 'string' } },
+        required: [],
+      },
+      operationId: 'getProtected',
+      method: 'get',
+      path: '/protected',
+      parameters: [{ name: 'Cookie', in: 'header', required: false, schema: { type: 'string' } }],
+    };
+    const client = makeClient({ cookieSession: true }, [loginTool, cookieHeaderTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=abc; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    // Caller supplies a Cookie header param alongside the session jar cookie.
+    await client.callTool('getProtected', { Cookie: 'pref=dark' }, undefined, false, 'sess-1');
+
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    const cookie = protectedCall[0].headers?.Cookie;
+    // Both cookies present; jar value wins for a duplicate name.
+    expect(cookie).toContain('pref=dark');
+    expect(cookie).toContain('accesstoken=abc');
+  });
 });
 
 describe('OpenAPIClient - static apiKey.in:cookie', () => {

--- a/src/clients/__tests__/openapi-cookie.test.ts
+++ b/src/clients/__tests__/openapi-cookie.test.ts
@@ -1,0 +1,277 @@
+import { OpenAPIClient } from '../openapi.js';
+import type { ServerConfig } from '../../types/index.js';
+
+type TestTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  operationId: string;
+  method: string;
+  path: string;
+  parameters?: any[];
+};
+
+type TestClient = OpenAPIClient & {
+  baseUrl: string;
+  tools: TestTool[];
+  httpClient: {
+    request: jest.Mock;
+    defaults: { headers: { common: Record<string, string> } };
+  };
+};
+
+const BASE_URL = 'https://8.8.8.8';
+
+const loginTool: TestTool = {
+  name: 'login',
+  description: 'login',
+  inputSchema: { type: 'object', properties: {}, required: [] },
+  operationId: 'login',
+  method: 'post',
+  path: '/login',
+};
+
+const protectedTool: TestTool = {
+  name: 'getProtected',
+  description: 'protected',
+  inputSchema: { type: 'object', properties: {}, required: [] },
+  operationId: 'getProtected',
+  method: 'get',
+  path: '/protected',
+};
+
+const otherTool: TestTool = {
+  name: 'getOther',
+  description: 'other',
+  inputSchema: { type: 'object', properties: {}, required: [] },
+  operationId: 'getOther',
+  method: 'get',
+  path: '/other',
+};
+
+const subTool: TestTool = {
+  name: 'getSub',
+  description: 'sub',
+  inputSchema: { type: 'object', properties: {}, required: [] },
+  operationId: 'getSub',
+  method: 'get',
+  path: '/sub/data',
+};
+
+function makeClient(openapi: ServerConfig['openapi'], tools: TestTool[]): TestClient {
+  const config: ServerConfig = {
+    type: 'openapi',
+    openapi: {
+      schema: {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      },
+      ...openapi,
+    },
+  };
+  const client = new OpenAPIClient(config) as TestClient;
+  client.baseUrl = BASE_URL;
+  client.tools = tools;
+  client.httpClient = {
+    request: jest.fn(async () => ({ data: {}, headers: {} })),
+    defaults: { headers: { common: {} } },
+  };
+  return client;
+}
+
+// Find the last request mock call whose config matched the given url path.
+const lastCallTo = (mock: jest.Mock, url: string) => {
+  const calls = mock.mock.calls.filter((c) => c[0]?.url === url);
+  return calls[calls.length - 1];
+};
+
+describe('OpenAPIClient - cookie session handling', () => {
+  it('captures Set-Cookie from a login call and replays it on a later call', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=abc; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    await client.callTool('getProtected', {}, undefined, false, 'sess-1');
+
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    expect(protectedCall[0].headers?.Cookie).toBe('accesstoken=abc');
+  });
+
+  it('does not leak a session cookie into a different session', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=abc; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    await client.callTool('getProtected', {}, undefined, false, 'sess-2');
+
+    const sess2Call = lastCallTo(client.httpClient.request, '/protected');
+    expect(sess2Call[0].headers?.Cookie).toBeUndefined();
+  });
+
+  it('fail-safes (no capture, no inject) when no sessionId is present', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=abc; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, undefined);
+    await client.callTool('getProtected', {}, undefined, false, undefined);
+
+    const loginCall = lastCallTo(client.httpClient.request, '/login');
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    expect(loginCall[0].headers?.Cookie).toBeUndefined();
+    expect(protectedCall[0].headers?.Cookie).toBeUndefined();
+  });
+
+  it('captures multiple Set-Cookie headers from one response', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: {
+            'set-cookie': ['accesstoken=abc; Path=/', 'csrf=xyz; Path=/'],
+          },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    await client.callTool('getProtected', {}, undefined, false, 'sess-1');
+
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    const cookie = protectedCall[0].headers?.Cookie;
+    expect(cookie).toContain('accesstoken=abc');
+    expect(cookie).toContain('csrf=xyz');
+  });
+
+  it('scopes captured cookies by Path (does not send to non-matching paths)', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, otherTool, subTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=abc; Path=/sub'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    await client.callTool('getOther', {}, undefined, false, 'sess-1');
+    await client.callTool('getSub', {}, undefined, false, 'sess-1');
+
+    const otherCall = lastCallTo(client.httpClient.request, '/other');
+    const subCall = lastCallTo(client.httpClient.request, '/sub/data');
+    expect(otherCall[0].headers?.Cookie).toBeUndefined();
+    expect(subCall[0].headers?.Cookie).toBe('accesstoken=abc');
+  });
+
+  it('clearSessionCookies drops the jar so cookies are no longer sent', async () => {
+    const client = makeClient({ cookieSession: true }, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=abc; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    client.clearSessionCookies('sess-1');
+    await client.callTool('getProtected', {}, undefined, false, 'sess-1');
+
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    expect(protectedCall[0].headers?.Cookie).toBeUndefined();
+  });
+});
+
+describe('OpenAPIClient - static apiKey.in:cookie', () => {
+  const staticConfig: ServerConfig['openapi'] = {
+    schema: { openapi: '3.0.0', info: { title: 'Test API', version: '1.0.0' }, paths: {} },
+    security: {
+      type: 'apiKey',
+      apiKey: { name: 'accesstoken', in: 'cookie', value: 'static-val' },
+    },
+  };
+
+  it('sends the static cookie on every request without cookieSession enabled', async () => {
+    const client = makeClient(staticConfig, [protectedTool]);
+    await client.callTool('getProtected', {}, undefined, false, undefined);
+
+    const call = lastCallTo(client.httpClient.request, '/protected');
+    expect(call[0].headers?.Cookie).toBe('accesstoken=static-val');
+  });
+
+  it('does not capture Set-Cookie when cookieSession is not enabled', async () => {
+    const client = makeClient(staticConfig, [loginTool, protectedTool]);
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=dynamic; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    await client.callTool('login', {}, undefined, false, undefined);
+    await client.callTool('getProtected', {}, undefined, false, undefined);
+
+    // Static cookie is still sent; the dynamic Set-Cookie was not captured.
+    const protectedCall = lastCallTo(client.httpClient.request, '/protected');
+    expect(protectedCall[0].headers?.Cookie).toBe('accesstoken=static-val');
+  });
+
+  it('lets a dynamic Set-Cookie override the static cookie within a session', async () => {
+    const client = makeClient(
+      { ...staticConfig, cookieSession: true },
+      [loginTool, protectedTool],
+    );
+    client.httpClient.request.mockImplementation(async (cfg: any) => {
+      if (cfg.url === '/login') {
+        return {
+          data: { ok: true },
+          headers: { 'set-cookie': ['accesstoken=dynamic; Path=/; HttpOnly'] },
+        };
+      }
+      return { data: { ok: true }, headers: {} };
+    });
+
+    // Before login, the static cookie is sent (jar not yet created).
+    await client.callTool('getProtected', {}, undefined, false, 'sess-1');
+    const preLogin = lastCallTo(client.httpClient.request, '/protected');
+    expect(preLogin[0].headers?.Cookie).toBe('accesstoken=static-val');
+
+    await client.callTool('login', {}, undefined, false, 'sess-1');
+    await client.callTool('getProtected', {}, undefined, false, 'sess-1');
+    const postLogin = lastCallTo(client.httpClient.request, '/protected');
+    expect(postLogin[0].headers?.Cookie).toBe('accesstoken=dynamic');
+  });
+});

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -533,6 +533,7 @@ export class OpenAPIClient {
 
     let attemptedUpstreamRequest = false;
     let authorizationUsedForRequest: string | undefined;
+    let resolvedTarget: URL | null = null;
 
     try {
       await this.ensureOAuth2AccessToken();
@@ -601,7 +602,7 @@ export class OpenAPIClient {
       // internal/loopback/link-local address. The baseURL and tool path are
       // both attacker-influenced (via the OpenAPI spec), so validate the
       // final URL rather than trusting either alone.
-      let resolvedTarget: URL | null = null;
+      resolvedTarget = null;
       try {
         resolvedTarget = new URL(String(requestConfig.url ?? '/'), this.baseUrl || undefined);
       } catch {
@@ -636,6 +637,17 @@ export class OpenAPIClient {
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
+        // Capture Set-Cookie from non-2xx responses too. With maxRedirects: 0,
+        // a 3xx login redirect is surfaced as an error; 4xx logout responses
+        // may expire cookies. Capture before retry/rethrow so the jar stays
+        // current and the 401-retry path can re-inject updated cookies.
+        if (
+          this.isCookieSessionEnabled(sessionId) &&
+          resolvedTarget &&
+          error.response
+        ) {
+          this.captureResponseCookies(error.response, resolvedTarget.href, sessionId);
+        }
         if (
           attemptedUpstreamRequest &&
           error.response?.status === 401 &&
@@ -750,11 +762,37 @@ export class OpenAPIClient {
     }
 
     if (cookieString) {
+      const existingHeaders = requestConfig.headers as Record<string, string> | undefined;
+      const merged = OpenAPIClient.mergeCookieHeader(existingHeaders?.Cookie, cookieString);
       requestConfig.headers = {
-        ...(requestConfig.headers as Record<string, string>),
-        Cookie: cookieString,
+        ...existingHeaders,
+        Cookie: merged,
       };
     }
+  }
+
+  // Merge two Cookie header strings, with `additional` (jar/static) values
+  // winning for duplicate names so caller-configured cookies are preserved.
+  private static mergeCookieHeader(existing: string | undefined, additional: string): string {
+    const entries = new Map<string, string>();
+    const parse = (header: string) => {
+      for (const part of header.split(';')) {
+        const trimmed = part.trim();
+        if (!trimmed) {
+          continue;
+        }
+        const eq = trimmed.indexOf('=');
+        if (eq <= 0) {
+          continue;
+        }
+        entries.set(trimmed.slice(0, eq).trim(), trimmed.slice(eq + 1));
+      }
+    };
+    if (existing) {
+      parse(existing);
+    }
+    parse(additional);
+    return [...entries].map(([k, v]) => `${k}=${v}`).join('; ');
   }
 
   // Capture Set-Cookie headers from an upstream response into the session jar.

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { CookieJar } from 'tough-cookie';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import { OpenAPIV3 } from 'openapi-types';
 import { ServerConfig, OpenAPISecurityConfig } from '../types/index.js';
@@ -32,6 +33,15 @@ export class OpenAPIClient {
   private securityConfig?: OpenAPISecurityConfig;
   private readonly persistOAuth2Token?: OpenAPIClientOptions['persistOAuth2Token'];
   private oauth2TokenRequest?: Promise<string | undefined>;
+  // Per-session cookie jars for the dynamic Set-Cookie login flow. Keyed by
+  // downstream MCP sessionId so authenticated state never crosses users or
+  // sessions. In-memory only; never persisted.
+  private readonly cookieJars = new Map<string, CookieJar>();
+  private static readonly MAX_COOKIE_JARS = 1000;
+  // Static cookie from `apiKey.in: 'cookie'` config, merged into the Cookie
+  // header at call time. Seeded into each session jar so a dynamic Set-Cookie
+  // of the same name can override it.
+  private staticCookieHeader?: string;
   // Resolved in initialize(): admin-owned servers may target internal services
   // and skip the SSRF internal-IP blocklist.
   private allowInternalNetworks = false;
@@ -88,8 +98,9 @@ export class OpenAPIClient {
               config.params = { ...config.params, [name]: value };
               return config;
             });
+          } else if (location === 'cookie') {
+            this.staticCookieHeader = `${name}=${value}`;
           }
-          // Note: Cookie authentication would need additional setup
         }
         break;
 
@@ -513,6 +524,7 @@ export class OpenAPIClient {
     args: Record<string, unknown>,
     passthroughHeaders?: Record<string, string>,
     hasRetriedAfterUnauthorized = false,
+    sessionId?: string,
   ): Promise<unknown> {
     const tool = this.tools.find((t) => t.name === toolName);
     if (!tool) {
@@ -601,9 +613,26 @@ export class OpenAPIClient {
         });
       }
 
+      const cookieSessionEnabled = this.isCookieSessionEnabled(sessionId);
+      // Inject cookies when either the dynamic session store is active for this
+      // call or a static `apiKey.in: 'cookie'` is configured (static cookies
+      // apply to every request regardless of session).
+      if ((cookieSessionEnabled || this.staticCookieHeader) && resolvedTarget) {
+        this.applyRequestCookies(
+          requestConfig,
+          resolvedTarget.href,
+          cookieSessionEnabled ? sessionId : undefined,
+        );
+      }
+
       authorizationUsedForRequest = this.getDefaultAuthorizationHeader();
       attemptedUpstreamRequest = true;
       const response = await this.httpClient.request(requestConfig);
+
+      if (cookieSessionEnabled && resolvedTarget) {
+        this.captureResponseCookies(response, resolvedTarget.href, sessionId);
+      }
+
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error)) {
@@ -614,7 +643,7 @@ export class OpenAPIClient {
           authorizationUsedForRequest &&
           authorizationUsedForRequest !== this.getDefaultAuthorizationHeader()
         ) {
-          return this.callTool(toolName, args, passthroughHeaders, true);
+          return this.callTool(toolName, args, passthroughHeaders, true, sessionId);
         }
 
         if (
@@ -623,7 +652,7 @@ export class OpenAPIClient {
           !hasRetriedAfterUnauthorized &&
           (await this.invalidateRefreshableOAuth2Token())
         ) {
-          return this.callTool(toolName, args, passthroughHeaders, true);
+          return this.callTool(toolName, args, passthroughHeaders, true, sessionId);
         }
 
         const status = error.response?.status ?? 'unknown';
@@ -660,7 +689,102 @@ export class OpenAPIClient {
     return this.spec;
   }
 
+  private isCookieSessionEnabled(sessionId?: string): sessionId is string {
+    return !!this.config.openapi?.cookieSession && typeof sessionId === 'string' && sessionId.length > 0;
+  }
+
+  // Lazily create a per-session cookie jar, seeded with the static apiKey
+  // cookie (if any) so it applies to every request and can be overridden by a
+  // dynamic Set-Cookie of the same name.
+  private getCookieJar(sessionId: string): CookieJar {
+    let jar = this.cookieJars.get(sessionId);
+    if (jar) {
+      return jar;
+    }
+
+    // Backstop: evict the oldest jar before exceeding the cap. Session-end
+    // cleanup is the primary eviction path; this guards against leaks when a
+    // session is abandoned without an explicit close.
+    if (this.cookieJars.size >= OpenAPIClient.MAX_COOKIE_JARS) {
+      const oldest = this.cookieJars.keys().next().value;
+      if (oldest !== undefined) {
+        this.cookieJars.delete(oldest);
+      }
+    }
+
+    jar = new CookieJar();
+    if (this.staticCookieHeader && this.baseUrl) {
+      try {
+        jar.setCookieSync(`${this.staticCookieHeader}; Path=/`, this.baseUrl);
+      } catch {
+        // ignore malformed static cookie / unsuitable baseUrl
+      }
+    }
+    this.cookieJars.set(sessionId, jar);
+    return jar;
+  }
+
+  // Apply stored cookies to an outgoing request. When a session jar exists,
+  // use it (it already includes any seeded static cookie and captured dynamic
+  // cookies). Otherwise fall back to the static `apiKey.in: 'cookie'` value so
+  // static cookie auth works without opting into session handling.
+  private applyRequestCookies(
+    requestConfig: AxiosRequestConfig,
+    requestUrl: string,
+    sessionId?: string,
+  ): void {
+    let cookieString = '';
+    if (sessionId) {
+      const jar = this.cookieJars.get(sessionId);
+      if (jar) {
+        try {
+          cookieString = jar.getCookieStringSync(requestUrl);
+        } catch {
+          return;
+        }
+      } else if (this.staticCookieHeader) {
+        cookieString = this.staticCookieHeader;
+      }
+    } else if (this.staticCookieHeader) {
+      cookieString = this.staticCookieHeader;
+    }
+
+    if (cookieString) {
+      requestConfig.headers = {
+        ...(requestConfig.headers as Record<string, string>),
+        Cookie: cookieString,
+      };
+    }
+  }
+
+  // Capture Set-Cookie headers from an upstream response into the session jar.
+  private captureResponseCookies(
+    response: AxiosResponse,
+    requestUrl: string,
+    sessionId: string,
+  ): void {
+    const setCookie = response.headers?.['set-cookie'];
+    if (!setCookie) {
+      return;
+    }
+    const jar = this.getCookieJar(sessionId);
+    const headers = Array.isArray(setCookie) ? setCookie : [setCookie];
+    for (const header of headers) {
+      try {
+        jar.setCookieSync(header, requestUrl);
+      } catch {
+        // skip unparseable Set-Cookie rather than failing the tool call
+      }
+    }
+  }
+
+  // Drop the cookie jar for a session. Called from session-end cleanup.
+  clearSessionCookies(sessionId: string): void {
+    this.cookieJars.delete(sessionId);
+  }
+
   disconnect(): void {
     // No persistent connection to close for OpenAPI
+    this.cookieJars.clear();
   }
 }

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -413,6 +413,12 @@ const cleanupIsolatedSession = (sessionId: string): void => {
     }
     console.log(`Cleaned up isolated clients for session: ${sessionId}`);
   }
+
+  // Drop per-session OpenAPI cookie jars so authenticated state does not
+  // outlive the downstream session.
+  for (const serverInfo of serverInfos) {
+    serverInfo.openApiClient?.clearSessionCookies?.(sessionId);
+  }
 };
 
 /** Helper to write an isolated session upstream client into the tracking map. */
@@ -3016,6 +3022,16 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
   const bearerKeyContext = requestContextService.getBearerKeyContext();
   const sessionId = extra.sessionId || '';
 
+  // For OpenAPI cookie-session isolation, use a real per-caller session id.
+  // `extra.sessionId` falls back to the shared 'api-session' literal for direct
+  // API calls without x-session-id, which would leak cookies across callers, so
+  // exclude that value. Fail-safe (undefined) when no real session is present.
+  const cookieSessionId =
+    requestContextService.getSessionId() ||
+    (typeof extra?.sessionId === 'string' && extra.sessionId !== 'api-session'
+      ? extra.sessionId
+      : undefined);
+
   // Extract group and key info from request context (set by SSE/HTTP handlers)
   // Fallback to extra for backward compatibility (e.g., direct API calls)
   const group =
@@ -3179,7 +3195,13 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
         }
 
         await reserveHostedIfNeeded(targetServerInfo.name, cleanToolName);
-        const result = await openApiClient.callTool(cleanToolName, finalArgs, passthroughHeaders);
+        const result = await openApiClient.callTool(
+          cleanToolName,
+          finalArgs,
+          passthroughHeaders,
+          false,
+          cookieSessionId,
+        );
         await settleHostedIfNeeded({
           success: true,
           requestContent: finalArgs,
@@ -3375,7 +3397,13 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
 
       const finalArgs = request.params.arguments || {};
       await reserveHostedIfNeeded(serverInfo.name, cleanToolName);
-      const result = await openApiClient.callTool(cleanToolName, finalArgs, passthroughHeaders);
+      const result = await openApiClient.callTool(
+        cleanToolName,
+        finalArgs,
+        passthroughHeaders,
+        false,
+        cookieSessionId,
+      );
       await settleHostedIfNeeded({
         success: true,
         requestContent: finalArgs,

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -3023,14 +3023,21 @@ export const handleCallToolRequest = async (request: any, extra: any) => {
   const sessionId = extra.sessionId || '';
 
   // For OpenAPI cookie-session isolation, use a real per-caller session id.
-  // `extra.sessionId` falls back to the shared 'api-session' literal for direct
-  // API calls without x-session-id, which would leak cookies across callers, so
-  // exclude that value. Fail-safe (undefined) when no real session is present.
-  const cookieSessionId =
-    requestContextService.getSessionId() ||
-    (typeof extra?.sessionId === 'string' && extra.sessionId !== 'api-session'
-      ? extra.sessionId
-      : undefined);
+  // Direct API controllers fall back to shared synthetic ids ('api-session' /
+  // 'openapi-session') when x-session-id is absent, which would leak cookies
+  // across callers, so only accept an explicitly-provided session header or a
+  // non-synthetic extra.sessionId. Fail-safe (undefined) otherwise.
+  const isSyntheticSessionFallback = (id: string) =>
+    id === 'api-session' || id === 'openapi-session';
+  const explicitXSessionId = extra?.headers?.['x-session-id'];
+  const cookieSessionId = [
+    requestContextService.getSessionId(),
+    typeof explicitXSessionId === 'string' ? explicitXSessionId : undefined,
+    typeof extra?.sessionId === 'string' ? extra.sessionId : undefined,
+  ].find(
+    (id): id is string =>
+      typeof id === 'string' && id.length > 0 && !isSyntheticSessionFallback(id),
+  );
 
   // Extract group and key info from request context (set by SSE/HTTP handlers)
   // Fallback to extra for backward compatibility (e.g., direct API calls)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -478,6 +478,7 @@ export interface ServerConfig {
     version?: string; // OpenAPI version (default: '3.1.0')
     security?: OpenAPISecurityConfig; // Security configuration for API calls
     passthroughHeaders?: string[]; // Header names to pass through from tool call requests to upstream OpenAPI endpoints
+    cookieSession?: boolean; // Opt-in: capture upstream Set-Cookie and replay on later calls, isolated per downstream MCP session
   };
 }
 

--- a/src/utils/serverConfigPersistence.ts
+++ b/src/utils/serverConfigPersistence.ts
@@ -126,6 +126,10 @@ const normalizeOpenApi = (
     normalized.passthroughHeaders = passthroughHeaders;
   }
 
+  if (openapi.cookieSession === true) {
+    normalized.cookieSession = true;
+  }
+
   return Object.keys(normalized).length > 0 ? normalized : undefined;
 };
 


### PR DESCRIPTION
## Summary

- Add opt-in cookie-session handling for OpenAPI servers (`openapi.cookieSession`) so a login tool's `Set-Cookie` response is captured and replayed on later protected calls within the same downstream MCP session.
- Per-session `CookieJar` (via `tough-cookie`) is isolated from other users/sessions, kept in memory only, and never persisted. Session-end cleanup drops the jar; a size cap guards against leaks from abandoned sessions.
- Implement the previously dead `apiKey.in: 'cookie'` static path (sent on every request; a dynamic `Set-Cookie` of the same name can override it within a session).

Closes #1043.

## Why

The shared Axios client had no cookie jar, so a dynamic upstream login flow (login → `Set-Cookie` → protected call) could not complete without the caller manually supplying the cookie on every request. Because one `OpenAPIClient` is shared across all downstream users on a server, a naive global jar would also mix authenticated state between users — this change scopes cookie state per MCP session and fail-safes (no capture, no inject) when no real session id is present.

## Changes

- `src/clients/openapi.ts`: per-session `CookieJar` map, `apiKey.in: 'cookie'` branch in `setupSecurity`, `callTool` inject-before / capture-after with a new `sessionId` param (threaded through the 401-retry path), `clearSessionCookies`, `MAX_COOKIE_JARS` eviction, `disconnect()` clears jars.
- `src/services/mcpService.ts`: resolve `cookieSessionId` (excludes the shared `'api-session'` direct-API fallback) and pass to both `callTool` sites; extend `cleanupIsolatedSession` to clear OpenAPI cookie jars across all servers.
- `src/types/index.ts` + `src/utils/serverConfigPersistence.ts`: `openapi.cookieSession?: boolean` type and normalization allowlist entry.
- Dashboard: checkbox toggle in the OpenAPI server form + payload wiring + locale strings (en/zh/tr/fr).

## Security / isolation

- Cookie state keyed by MCP `sessionId`; cross-user and cross-session isolation enforced.
- No persistence — process restart clears all jars.
- Fail-safe: no real session id → no cookie capture or injection.
- `tough-cookie` provides RFC 6265 domain/path/expiry/Secure/HttpOnly scoping.

## Test plan

- [x] `src/clients/__tests__/openapi-cookie.test.ts` — 9 cases: capture/replay, cross-session isolation, fail-safe without sessionId, multiple `Set-Cookie`, `Path` scoping, `clearSessionCookies`, static `apiKey.in: 'cookie'`, dynamic-overrides-static.
- [x] Backend: full suite (1011 tests) green, `tsc --noEmit` clean.
- [x] Frontend: `npm run build` green.
- [ ] Manual: dashboard toggle round-trips through save/reload; live login → protected-call flow against a real cookie-auth upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)