### PR TITLE
fix(openapi): authenticate spec document download with configured credentials

### DIFF
--- a/docs/configuration/mcp-settings.mdx
+++ b/docs/configuration/mcp-settings.mdx
@@ -104,7 +104,7 @@ A server entry has the shape `"<server-name>": ServerConfig`. The relevant field
 | `openapi.url` | string | one of `url`/`schema` | URL of an OpenAPI document MCPHub will download. |
 | `openapi.schema` | object | one of `url`/`schema` | Inline OpenAPI document. |
 | `headers` | object | no | Static headers applied to outbound calls, including the spec download itself. |
-| `passthroughHeaders` | string[] | no | Headers to forward from the caller. |
+| `openapi.passthroughHeaders` | string[] | no | Headers to forward from the caller. |
 
 The authoritative definition of every field is the `ServerConfig` type in [src/types/index.ts](src/types/index.ts) — consult it if you need behavior not described here.
 

--- a/docs/configuration/mcp-settings.mdx
+++ b/docs/configuration/mcp-settings.mdx
@@ -103,10 +103,19 @@ A server entry has the shape `"<server-name>": ServerConfig`. The relevant field
 | ----- | ---- | -------- | ----------- |
 | `openapi.url` | string | one of `url`/`schema` | URL of an OpenAPI document MCPHub will download. |
 | `openapi.schema` | object | one of `url`/`schema` | Inline OpenAPI document. |
-| `headers` | object | no | Static headers applied to outbound calls. |
+| `headers` | object | no | Static headers applied to outbound calls, including the spec download itself. |
 | `passthroughHeaders` | string[] | no | Headers to forward from the caller. |
 
 The authoritative definition of every field is the `ServerConfig` type in [src/types/index.ts](src/types/index.ts) — consult it if you need behavior not described here.
+
+<Note>
+A protected `openapi.url` is downloaded through MCPHub's authenticated client, so the
+configured `headers` and OpenAPI `security` credentials (HTTP Basic/Bearer, API key,
+OAuth2 token) authenticate the fetch. Credentials are scoped to the document origin only —
+they are **not** forwarded to external `$ref` resolutions or cross-origin redirects. If a
+protected document references external `$ref`s that also require auth, inline the document
+via `openapi.schema` instead.
+</Note>
 
 ## Common MCP Server Examples
 

--- a/docs/zh/configuration/mcp-settings.mdx
+++ b/docs/zh/configuration/mcp-settings.mdx
@@ -94,7 +94,7 @@ MCPHub 使用几个配置文件：
 | `openapi.url` | string | `url`/`schema` 二选一 | MCPHub 将下载的 OpenAPI 文档 URL。 |
 | `openapi.schema` | object | `url`/`schema` 二选一 | 内联的 OpenAPI 文档。 |
 | `headers` | object | 否 | 应用于所有出站请求的静态请求头，包括文档下载本身。 |
-| `passthroughHeaders` | string[] | 否 | 从调用方转发到上游的请求头名称。 |
+| `openapi.passthroughHeaders` | string[] | 否 | 从调用方转发到上游的请求头名称。 |
 
 每个字段的权威定义见 [src/types/index.ts](src/types/index.ts) 中的 `ServerConfig` 类型；如需此处未描述的行为，请查阅该类型。
 

--- a/docs/zh/configuration/mcp-settings.mdx
+++ b/docs/zh/configuration/mcp-settings.mdx
@@ -87,6 +87,21 @@ MCPHub 使用几个配置文件：
 | `stdio`        | string  | `pipe`          | stdio 配置         |
 | `perSessionClient` | boolean | `false`     | 为每个下游 MCP 会话创建独立的上游客户端，而不是在所有会话间共享同一个连接。适用于 Playwright 等有状态服务器。参见[会话级客户端隔离](#会话级客户端隔离有状态服务器)。 |
 
+### `type: "openapi"`
+
+| 字段 | 类型 | 必需 | 描述 |
+| ---- | ---- | ---- | ---- |
+| `openapi.url` | string | `url`/`schema` 二选一 | MCPHub 将下载的 OpenAPI 文档 URL。 |
+| `openapi.schema` | object | `url`/`schema` 二选一 | 内联的 OpenAPI 文档。 |
+| `headers` | object | 否 | 应用于所有出站请求的静态请求头，包括文档下载本身。 |
+| `passthroughHeaders` | string[] | 否 | 从调用方转发到上游的请求头名称。 |
+
+每个字段的权威定义见 [src/types/index.ts](src/types/index.ts) 中的 `ServerConfig` 类型；如需此处未描述的行为，请查阅该类型。
+
+<Note>
+受保护的 `openapi.url` 会通过 MCPHub 的已认证客户端下载，因此配置的 `headers` 与 OpenAPI `security` 凭证（HTTP Basic/Bearer、API Key、OAuth2 令牌）会用于该次拉取的认证。凭证仅作用于文档所在源，不会转发给外部 `$ref` 解析或跨源重定向。若受保护的文档引用了同样需要认证的外部 `$ref`，请改用 `openapi.schema` 内联文档。
+</Note>
+
 ## 常见 MCP 服务器示例
 
 ### Web 和 API 服务器

--- a/src/clients/__tests__/openapi-spec-auth.test.ts
+++ b/src/clients/__tests__/openapi-spec-auth.test.ts
@@ -1,0 +1,295 @@
+import axios from 'axios';
+import { OpenAPIClient } from '../openapi.js';
+import type { ServerConfig } from '../../types/index.js';
+import { UnsafeUrlError } from '../../utils/ssrf.js';
+
+// Shared mock so per-tests can toggle admin status. getUserDao() returns a new
+// object each call but always the same findByUsername reference.
+jest.mock('../../dao/index.js', () => {
+  const findByUsername = jest.fn();
+  return { getUserDao: () => ({ findByUsername }) };
+});
+
+import { getUserDao } from '../../dao/index.js';
+
+const findByUsername = (getUserDao() as { findByUsername: jest.Mock }).findByUsername;
+
+const SPEC_URL = 'http://8.8.8.8/v3/api-docs';
+const INTERNAL_SPEC_URL = 'http://127.0.0.1:8081/v3/api-docs';
+
+const minimalSpec = JSON.stringify({
+  openapi: '3.0.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {
+    '/things': {
+      get: {
+        operationId: 'get_things',
+        responses: { '200': { description: 'ok' } },
+      },
+    },
+  },
+});
+
+const yamlSpec = [
+  'openapi: 3.0.0',
+  'info:',
+  '  title: Test API',
+  '  version: 1.0.0',
+  'paths:',
+  '  /things:',
+  '    get:',
+  '      operationId: get_things',
+  "      responses:",
+  "        '200':",
+  '          description: ok',
+].join('\n');
+
+type TestClient = OpenAPIClient & {
+  httpClient: {
+    get: jest.Mock;
+    defaults: { adapter?: unknown; headers: { common: Record<string, string> } };
+  };
+};
+
+// Install a capturing adapter so we can assert on the fully-merged outgoing
+// request headers (defaults + per-request) without touching the network. axios
+// flattens defaults.headers.common / method buckets into config.headers before
+// the adapter runs, so this is the faithful place to verify auth is attached.
+function installCapturingAdapter(client: TestClient, body: unknown, captured: { v: unknown }) {
+  client.httpClient.defaults.adapter = (config: any) => {
+    captured.v = config;
+    return Promise.resolve({
+      data: body,
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    });
+  };
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findByUsername.mockReset();
+  findByUsername.mockResolvedValue(null);
+  // Safety net: any accidental external fetch (e.g. an unexpected $ref) hits a
+  // mock instead of the real network.
+  (globalThis as { fetch: unknown }).fetch = jest.fn();
+});
+
+afterEach(() => {
+  (globalThis as { fetch: unknown }).fetch = originalFetch;
+});
+
+describe('OpenAPIClient - authenticated spec document fetch (#1044)', () => {
+  it('applies configured HTTP Basic credentials to the document download', async () => {
+    const credentials = Buffer.from('user:pass').toString('base64');
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        url: SPEC_URL,
+        security: { type: 'http', http: { scheme: 'basic', credentials } },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    installCapturingAdapter(client, minimalSpec, captured);
+
+    await client.initialize();
+
+    const headers = (captured.v as { headers: { get: (n: string) => string } }).headers;
+    expect(headers.get('Authorization')).toBe(`Basic ${credentials}`);
+    expect((captured.v as { url: string }).url).toBe(SPEC_URL);
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
+
+  it('honors static config.headers on the document download', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      headers: { 'X-Custom': 'doc-fetch-value' },
+      openapi: { url: SPEC_URL },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    installCapturingAdapter(client, minimalSpec, captured);
+
+    await client.initialize();
+
+    const headers = (captured.v as { headers: { get: (n: string) => string } }).headers;
+    expect(headers.get('X-Custom')).toBe('doc-fetch-value');
+  });
+
+  it('fails with a sanitized message when credentials are incorrect', async () => {
+    const credentials = Buffer.from('admin:wrongpassword').toString('base64');
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        url: SPEC_URL,
+        security: { type: 'http', http: { scheme: 'basic', credentials } },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    client.httpClient.defaults.adapter = () =>
+      Promise.reject(
+        new axios.AxiosError(
+          'Request failed with status code 401',
+          'ERR_BAD_REQUEST',
+          {},
+          {},
+          { status: 401, statusText: 'Unauthorized', data: null, headers: {}, config: {} },
+        ),
+      );
+
+    await expect(client.initialize()).rejects.toThrow('Failed to load OpenAPI specification');
+    await expect(client.initialize()).rejects.not.toThrow('wrongpassword');
+    await expect(client.initialize()).rejects.not.toThrow(credentials);
+  });
+
+  it('parses a YAML spec document fetched with credentials', async () => {
+    const credentials = Buffer.from('user:pass').toString('base64');
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        url: SPEC_URL,
+        security: { type: 'http', http: { scheme: 'basic', credentials } },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    installCapturingAdapter(client, yamlSpec, captured);
+
+    await client.initialize();
+
+    expect((captured.v as { headers: { get: (n: string) => string } }).headers.get('Authorization')).toBe(
+      `Basic ${credentials}`,
+    );
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
+
+  it('leaves the inline schema branch unchanged (no document fetch)', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        schema: {
+          openapi: '3.0.0',
+          info: { title: 'Test API', version: '1.0.0' },
+          paths: {
+            '/things': {
+              get: {
+                operationId: 'get_things',
+                responses: { '200': { description: 'ok' } },
+              },
+            },
+          },
+        },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const getMock = jest.fn();
+    (client.httpClient as unknown as { get: jest.Mock }).get = getMock;
+
+    await client.initialize();
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
+
+  it('blocks an internal spec URL for non-admin owners (SSRF)', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      owner: 'regular',
+      openapi: { url: INTERNAL_SPEC_URL },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const getMock = jest.fn();
+    (client.httpClient as unknown as { get: jest.Mock }).get = getMock;
+
+    await expect(client.initialize()).rejects.toThrow(UnsafeUrlError);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('allows an internal spec URL for admin owners and authenticates the fetch', async () => {
+    findByUsername.mockResolvedValue({ isAdmin: true });
+    const credentials = Buffer.from('user:pass').toString('base64');
+    const config: ServerConfig = {
+      type: 'openapi',
+      owner: 'admin',
+      openapi: {
+        url: INTERNAL_SPEC_URL,
+        security: { type: 'http', http: { scheme: 'basic', credentials } },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    installCapturingAdapter(client, minimalSpec, captured);
+
+    await client.initialize();
+
+    expect((captured.v as { headers: { get: (n: string) => string } }).headers.get('Authorization')).toBe(
+      `Basic ${credentials}`,
+    );
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
+
+  it('does not forward credentials to a cross-origin external $ref', async () => {
+    const credentials = Buffer.from('user:pass').toString('base64');
+    const externalUrl = 'https://external.example.com/schema.json';
+    const docWithExternalRef = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/things': {
+          get: {
+            operationId: 'get_things',
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': { schema: { $ref: `${externalUrl}#/Thing` } },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const subSchema = JSON.stringify({ Thing: { type: 'object', properties: { id: { type: 'string' } } } });
+
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        url: SPEC_URL,
+        security: { type: 'http', http: { scheme: 'basic', credentials } },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    installCapturingAdapter(client, docWithExternalRef, captured);
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      status: 200,
+      headers: { get: () => null },
+      body: Buffer.from(subSchema),
+      arrayBuffer: async () => new TextEncoder().encode(subSchema),
+    });
+    (globalThis as { fetch: unknown }).fetch = fetchMock;
+
+    await client.initialize();
+
+    // Main document fetch (axios) carried the credentials...
+    expect((captured.v as { headers: { get: (n: string) => string } }).headers.get('Authorization')).toBe(
+      `Basic ${credentials}`,
+    );
+    // ...but the external $ref resolution (SwaggerParser's own resolver) did not.
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    const externalHeaders = (fetchMock.mock.calls[0][1] as { headers: Record<string, string> }).headers;
+    expect(externalHeaders).toEqual({});
+    expect(externalHeaders.Authorization).toBeUndefined();
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
+});

--- a/src/clients/__tests__/openapi-spec-auth.test.ts
+++ b/src/clients/__tests__/openapi-spec-auth.test.ts
@@ -292,4 +292,78 @@ describe('OpenAPIClient - authenticated spec document fetch (#1044)', () => {
     expect(externalHeaders.Authorization).toBeUndefined();
     expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
   });
+
+  it('applies a static apiKey cookie to the document download', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        url: SPEC_URL,
+        security: {
+          type: 'apiKey',
+          apiKey: { name: 'session', in: 'cookie', value: 'abc123' },
+        },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    installCapturingAdapter(client, minimalSpec, captured);
+
+    await client.initialize();
+
+    expect((captured.v as { headers: { get: (n: string) => string } }).headers.get('Cookie')).toBe(
+      'session=abc123',
+    );
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
+
+  it('fetches an OAuth2 client-credentials token before the document download', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        url: SPEC_URL,
+        security: {
+          type: 'oauth2',
+          oauth2: {
+            tokenUrl: 'https://auth.example.com/oauth/token',
+            clientId: 'test-client',
+            clientSecret: 'test-secret',
+            token: '',
+          },
+        },
+      },
+    };
+    const client = new OpenAPIClient(config) as TestClient;
+    const captured = { v: null as unknown };
+    // Both the token POST (httpClient.request) and the doc GET (httpClient.get)
+    // route through the configured adapter; differentiate by method.
+    let tokenFetchIndex: number | null = null;
+    let docFetchIndex: number | null = null;
+    let callCount = 0;
+    client.httpClient.defaults.adapter = (cfg: any) => {
+      callCount += 1;
+      if (cfg.method === 'post') {
+        tokenFetchIndex = callCount;
+        return Promise.resolve({
+          data: { access_token: 'fresh-token', expires_in: 3600 },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: cfg,
+        });
+      }
+      docFetchIndex = callCount;
+      captured.v = cfg;
+      return Promise.resolve({ data: minimalSpec, status: 200, statusText: 'OK', headers: {}, config: cfg });
+    };
+
+    await client.initialize();
+
+    expect(tokenFetchIndex).not.toBeNull();
+    expect(docFetchIndex).not.toBeNull();
+    expect(tokenFetchIndex!).toBeLessThan(docFetchIndex!);
+    expect(
+      (captured.v as { headers: { get: (n: string) => string } }).headers.get('Authorization'),
+    ).toBe('Bearer fresh-token');
+    expect(client.getTools().some((t) => t.name === 'get_things')).toBe(true);
+  });
 });

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -284,6 +284,11 @@ export class OpenAPIClient {
         : null;
       this.allowInternalNetworks = !!ownerUser?.isAdmin;
 
+      // Obtain/refresh the OAuth2 access token up front so it authenticates the
+      // document download (for url configs) and is ready for later API calls.
+      // No-op when no OAuth2 security is configured.
+      await this.ensureOAuth2AccessToken();
+
       // Parse and dereference the OpenAPI specification
       if (this.config.openapi?.url) {
         // Fetch the document through the authenticated httpClient (carries
@@ -295,10 +300,16 @@ export class OpenAPIClient {
         // therefore receives no auth by default.
         const specUrl = this.config.openapi.url;
         await assertSafeUrl(specUrl, { allowInternal: this.allowInternalNetworks });
-        const response = await this.httpClient.get(specUrl, {
+        const requestConfig: AxiosRequestConfig = {
           responseType: 'text',
           transformResponse: [(data: unknown) => data],
-        });
+        };
+        // The static apiKey.in:'cookie' value is otherwise only injected in
+        // callTool; apply it here too so cookie-protected spec URLs load.
+        if (this.staticCookieHeader) {
+          requestConfig.headers = { Cookie: this.staticCookieHeader };
+        }
+        const response = await this.httpClient.get(specUrl, requestConfig);
         const raw =
           typeof response.data === 'string' ? response.data : String(response.data);
         this.spec = (await SwaggerParser.dereference(
@@ -319,7 +330,6 @@ export class OpenAPIClient {
       this.updateBaseUrlFromServers();
 
       this.extractTools();
-      await this.ensureOAuth2AccessToken();
     } catch (error) {
       // Let SSRF rejections propagate as-is so callers can distinguish a blocked
       // target from a parse/auth failure (matches callTool's handling).

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -1,9 +1,10 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { CookieJar } from 'tough-cookie';
 import SwaggerParser from '@apidevtools/swagger-parser';
+import * as yaml from 'js-yaml';
 import { OpenAPIV3 } from 'openapi-types';
 import { ServerConfig, OpenAPISecurityConfig } from '../types/index.js';
-import { assertSafeUrl } from '../utils/ssrf.js';
+import { assertSafeUrl, UnsafeUrlError } from '../utils/ssrf.js';
 import { getUserDao } from '../dao/index.js';
 import { sanitizeStringForLogging, createSafeJSON } from '../utils/serialization.js';
 
@@ -274,10 +275,36 @@ export class OpenAPIClient {
 
   async initialize(): Promise<void> {
     try {
+      // Resolve whether this server's owner is an admin first; admin-owned
+      // servers may legitimately target internal services and skip the SSRF
+      // blocklist. Needed before the URL fetch so the spec-download guard is
+      // scoped the same way as callTool's.
+      const ownerUser = this.config.owner
+        ? await getUserDao().findByUsername(this.config.owner)
+        : null;
+      this.allowInternalNetworks = !!ownerUser?.isAdmin;
+
       // Parse and dereference the OpenAPI specification
       if (this.config.openapi?.url) {
+        // Fetch the document through the authenticated httpClient (carries
+        // config.headers + security credentials from setupSecurity, and uses
+        // maxRedirects: 0 so credentials are never forwarded across a
+        // cross-origin redirect). SwaggerParser's own resolver is bypassed for
+        // the main document so its (unauthenticated) headers never see the
+        // credentials; external $ref resolution still uses that resolver and
+        // therefore receives no auth by default.
+        const specUrl = this.config.openapi.url;
+        await assertSafeUrl(specUrl, { allowInternal: this.allowInternalNetworks });
+        const response = await this.httpClient.get(specUrl, {
+          responseType: 'text',
+          transformResponse: [(data: unknown) => data],
+        });
+        const raw =
+          typeof response.data === 'string' ? response.data : String(response.data);
         this.spec = (await SwaggerParser.dereference(
-          this.config.openapi.url,
+          specUrl,
+          this.parseSpecDocument(raw),
+          {},
         )) as OpenAPIV3.Document;
       } else if (this.config.openapi?.schema) {
         // For schema object, we need to pass it as a cloned object
@@ -291,18 +318,29 @@ export class OpenAPIClient {
       // Update baseUrl from OpenAPI servers field
       this.updateBaseUrlFromServers();
 
-      // Resolve whether this server's owner is an admin; admin-owned servers
-      // may legitimately target internal services and skip the SSRF blocklist.
-      const ownerUser = this.config.owner
-        ? await getUserDao().findByUsername(this.config.owner)
-        : null;
-      this.allowInternalNetworks = !!ownerUser?.isAdmin;
-
       this.extractTools();
       await this.ensureOAuth2AccessToken();
     } catch (error) {
+      // Let SSRF rejections propagate as-is so callers can distinguish a blocked
+      // target from a parse/auth failure (matches callTool's handling).
+      if (error instanceof UnsafeUrlError) {
+        throw error;
+      }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new Error(`Failed to load OpenAPI specification: ${errorMessage}`);
+      throw new Error(
+        `Failed to load OpenAPI specification: ${sanitizeStringForLogging(errorMessage)}`,
+      );
+    }
+  }
+
+  // Parse a fetched spec body into an object. JSON first (stricter errors for
+  // malformed JSON), YAML fallback so protected YAML documents work without
+  // relying on SwaggerParser's own fetch (which cannot carry our credentials).
+  private parseSpecDocument(raw: string): any {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return yaml.load(raw);
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix #1044: an OpenAPI spec URL protected by HTTP Basic auth (or Bearer/API key/`headers`) could not be loaded. The document was fetched via `SwaggerParser.dereference(url)`, which bypassed MCPHub's authenticated axios client, so configured credentials never reached the initial download.
- `initialize()` now fetches the document through the authenticated `httpClient` (carrying `config.headers` + `security` credentials, `maxRedirects: 0`), parses JSON-or-YAML, then hands the object to `SwaggerParser.dereference(specUrl, doc, {})` for `$ref` resolution.
- Credentials are scoped to the document origin only — they are **not** forwarded to external `$ref` resolutions or cross-origin redirects (the parser's own unauthenticated resolver handles externals).
- Adds an SSRF guard on the document fetch, consistent with `callTool` (admin-owned servers bypass via `allowInternalNetworks`). `UnsafeUrlError` propagates unwrapped; other errors are sanitized to avoid credential logging.
- YAML documents supported via `js-yaml` fallback (no regression vs. the parser's auto-detection). Inline `openapi.schema` path unchanged.

Distinct from #1043 (runtime Set-Cookie across tool calls, fixed in #1047): this issue occurs before tool generation, during the initial document fetch.

## Test plan

- [x] `pnpm test` — new `openapi-spec-auth.test.ts` (8 cases) + full openapi client suite (41 tests) pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean

New test cases cover issue #1044's suggested tests:
- [x] Basic credentials authenticate the document download (asserts merged Authorization header via capturing adapter)
- [x] static `config.headers` honored on the document fetch
- [x] incorrect credentials fail without leaking the credential value
- [x] YAML document parsed after authenticated fetch
- [x] inline `openapi.schema` branch unchanged (no document fetch)
- [x] SSRF blocks an internal spec URL for non-admin owners
- [x] admin owner bypasses SSRF and authenticates the fetch
- [x] credentials not forwarded to a cross-origin external `$ref` (axios doc fetch carries `Authorization`; the parser's `fetch` for the external `$ref` receives `headers: {}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)