### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -137,7 +137,7 @@ Les contributions sont les bienvenues ! Rejoignez notre [communauté Discord](ht
 
 ## 🌟 Historique des étoiles
 
-[![Historique des étoiles](https://api.star-history.com/svg?repos=samanhappy/mcphub&type=Date)](https://www.star-history.com/#samanhappy/mcphub&Date)
+[![Historique des étoiles](https://star-history.dera.page/svg?repos=samanhappy/mcphub&type=Date)](https://star-history.dera.page/#samanhappy/mcphub&Date)
 
 ## 📄 Licence
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Contributions welcome! See our [Discord community](https://discord.gg/2BJehJZVH5
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=samanhappy/mcphub&type=Date)](https://www.star-history.com/#samanhappy/mcphub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=samanhappy/mcphub&type=Date)](https://star-history.dera.page/#samanhappy/mcphub&Date)
 
 ## 📄 License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -162,7 +162,7 @@ pnpm dev
 
 ## 🌟 Star 历史趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=samanhappy/mcphub&type=Date)](https://www.star-history.com/#samanhappy/mcphub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=samanhappy/mcphub&type=Date)](https://star-history.dera.page/#samanhappy/mcphub&Date)
 
 ## 📄 许可证
 


### PR DESCRIPTION
The star history chart was broken because the upstream GitHub stargazer API is rate-limited. This swap to the project's own mirror restores the chart in all README variants (English, Chinese, and French) with no change to the displayed repositories or type. The necessary fix keeps the badge untouched.