### PR TITLE
chore: align license metadata with Apache-2.0

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -4,7 +4,7 @@
     "title": "OpenAPI Plant Store",
     "description": "A sample API that uses a plant store as an example to demonstrate features in the OpenAPI specification",
     "license": {
-      "name": "MIT"
+      "name": "Apache-2.0"
     },
     "version": "1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "model context protocol"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
     "@google/genai": "^1.44.0",


### PR DESCRIPTION
## Summary

The repository license is Apache-2.0 (per the root LICENSE file and README), but two metadata files declared conflicting licenses, causing inconsistent results for users and license-scanning tools.

- package.json: `ISC` → `Apache-2.0`
- docs/api-reference/openapi.json: `MIT` → `Apache-2.0`

No code changes.

Fixes #1050

## Testing

- Metadata-only change; verified LICENSE file (Apache 2.0) and README declaration remain the single source of truth.