### PR TITLE
feat(auth): make Better Auth base URL configurable in settings

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -51,7 +51,7 @@ Provider client credentials remain environment-variable only.
 | Variable | Description |
 | --- | --- |
 | `BETTER_AUTH_ENABLED` | Master switch for Better Auth. Better Auth is still disabled automatically when MCPHub is not in database mode or when no provider has the required credentials. |
-| `BETTER_AUTH_URL` | Public base URL used to build Better Auth redirect URIs. This now takes precedence over `systemConfig.install.baseUrl`. Its origin is also auto-added to the trusted origin list. |
+| `BETTER_AUTH_URL` | Public base URL used to build Better Auth redirect URIs. Takes precedence over `systemConfig.auth.betterAuth.baseUrl` (configurable in Settings → Better Auth) and `systemConfig.install.baseUrl`. Its origin is also auto-added to the trusted origin list. |
 | `BETTER_AUTH_BASE_PATH` | Mount path for the Better Auth handler. Defaults to `/api/auth/better`. |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | Optional additional origins allowed to start Better Auth login flows. Accepts a comma-separated list, whitespace-separated list, or JSON array. When omitted, MCPHub still auto-trusts the origins from `BETTER_AUTH_URL` and `systemConfig.install.baseUrl`. |
 | `BETTER_AUTH_GOOGLE_ENABLED` | Enable or disable the Google provider after credentials are present. Defaults to `true`. |

--- a/docs/zh/configuration/environment-variables.mdx
+++ b/docs/zh/configuration/environment-variables.mdx
@@ -63,7 +63,7 @@ MCPHub 里的 Better Auth 目前依赖 PostgreSQL 会话存储，因此需要配
 | 变量 | 描述 |
 | --- | --- |
 | `BETTER_AUTH_ENABLED` | Better Auth 总开关。即使打开了它，如果 MCPHub 不在数据库模式下，或者没有任何提供商具备所需凭据，Better Auth 仍会自动禁用。 |
-| `BETTER_AUTH_URL` | 用于生成 Better Auth 回调 URL 的公网访问地址。现在它会优先于 `systemConfig.install.baseUrl` 生效，其来源也会自动加入可信来源列表。 |
+| `BETTER_AUTH_URL` | 用于生成 Better Auth 回调 URL 的公网访问地址。优先级高于 `systemConfig.auth.betterAuth.baseUrl`（可在 设置 → Better Auth 中配置）和 `systemConfig.install.baseUrl`，其来源也会自动加入可信来源列表。 |
 | `BETTER_AUTH_BASE_PATH` | Better Auth 处理器挂载路径，默认 `/api/auth/better`。 |
 | `BETTER_AUTH_TRUSTED_ORIGINS` | 允许发起 Better Auth 登录流程的额外来源。支持逗号分隔、空白分隔或 JSON 数组。未设置时，MCPHub 仍会自动信任 `BETTER_AUTH_URL` 和 `systemConfig.install.baseUrl` 的来源。 |
 | `BETTER_AUTH_GOOGLE_ENABLED` | 在提供了凭据后启用或禁用 Google 登录，默认 `true`。 |

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -93,6 +93,7 @@ interface BetterAuthOidcConfig {
 
 interface BetterAuthConfig {
   enabled: boolean;
+  baseUrl: string;
   basePath: string;
   trustedOrigins: string[];
   providers: {
@@ -211,6 +212,7 @@ const DEFAULT_OIDC_SCOPES = ['openid', 'profile', 'email'];
 
 const getDefaultBetterAuthConfig = (): BetterAuthConfig => ({
   enabled: true,
+  baseUrl: '',
   basePath: '/api/auth/better',
   trustedOrigins: [],
   providers: {
@@ -249,6 +251,7 @@ const normalizeBetterAuthConfig = (
 
   return {
     enabled: config?.enabled ?? defaults.enabled,
+    baseUrl: config?.baseUrl?.trim() || defaults.baseUrl,
     basePath: config?.basePath?.trim() || defaults.basePath,
     trustedOrigins: normalizeStringArray(config?.trustedOrigins, defaults.trustedOrigins),
     providers: {
@@ -277,6 +280,7 @@ const mergeBetterAuthConfig = (
   const nextConfig: Partial<BetterAuthConfig> = {
     ...current,
     ...updates,
+    baseUrl: updates.baseUrl ?? current.baseUrl,
     trustedOrigins: updates.trustedOrigins ?? current.trustedOrigins,
     providers: {
       ...current.providers,

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -483,6 +483,7 @@ const SettingsPage: React.FC = () => {
   });
 
   const [tempBetterAuthConfig, setTempBetterAuthConfig] = useState<{
+    baseUrl: string;
     basePath: string;
     trustedOrigins: string;
     oidcProviderId: string;
@@ -490,6 +491,7 @@ const SettingsPage: React.FC = () => {
     oidcScopes: string;
     oidcPrompt: string;
   }>({
+    baseUrl: '',
     basePath: '/api/auth/better',
     trustedOrigins: '',
     oidcProviderId: 'oidc',
@@ -632,6 +634,7 @@ const SettingsPage: React.FC = () => {
   useEffect(() => {
     if (betterAuthConfig) {
       setTempBetterAuthConfig({
+        baseUrl: betterAuthConfig.baseUrl || '',
         basePath: betterAuthConfig.basePath || '/api/auth/better',
         trustedOrigins: betterAuthConfig.trustedOrigins?.join(', ') || '',
         oidcProviderId: betterAuthConfig.providers.oidc.providerId || 'oidc',
@@ -900,6 +903,7 @@ const SettingsPage: React.FC = () => {
 
   const handleBetterAuthTextChange = (
     key:
+      | 'baseUrl'
       | 'basePath'
       | 'trustedOrigins'
       | 'oidcProviderId'
@@ -922,6 +926,7 @@ const SettingsPage: React.FC = () => {
 
   const handleSaveBetterAuthConfig = async () => {
     const updates: Parameters<typeof updateBetterAuthConfigBatch>[0] = {};
+    const normalizedBaseUrl = tempBetterAuthConfig.baseUrl.trim();
     const normalizedBasePath = tempBetterAuthConfig.basePath.trim() || '/api/auth/better';
     const normalizedTrustedOrigins = parseCommaSeparated(tempBetterAuthConfig.trustedOrigins) || [];
     const normalizedProviderId = tempBetterAuthConfig.oidcProviderId.trim() || 'oidc';
@@ -929,6 +934,10 @@ const SettingsPage: React.FC = () => {
     const normalizedScopes =
       parseCommaSeparated(tempBetterAuthConfig.oidcScopes) || [...DEFAULT_OIDC_SCOPES];
     const normalizedPrompt = tempBetterAuthConfig.oidcPrompt.trim();
+
+    if (normalizedBaseUrl !== (betterAuthConfig.baseUrl || '')) {
+      updates.baseUrl = normalizedBaseUrl;
+    }
 
     if (normalizedBasePath !== betterAuthConfig.basePath) {
       updates.basePath = normalizedBasePath;
@@ -3019,6 +3028,26 @@ const SettingsPage: React.FC = () => {
                   disabled={loading}
                   checked={betterAuthConfig.enabled}
                   onCheckedChange={(checked) => handleBetterAuthToggle({ enabled: checked })}
+                />
+              </div>
+
+              <div className="p-3 bg-gray-50 dark:bg-gray-800 rounded-md">
+                <div className="mb-2">
+                  <h3 className="font-medium text-gray-700">
+                    {t('settings.betterAuthBaseUrl') || 'Base URL'}
+                  </h3>
+                  <p className="text-sm text-gray-500">
+                    {t('settings.betterAuthBaseUrlDescription') ||
+                      'Public base URL used to build Better Auth redirect URIs. Falls back to the install base URL when empty; the BETTER_AUTH_URL environment variable takes precedence.'}
+                  </p>
+                </div>
+                <input
+                  type="text"
+                  value={tempBetterAuthConfig.baseUrl}
+                  onChange={(e) => handleBetterAuthTextChange('baseUrl', e.target.value)}
+                  placeholder="https://mcphub.example.com"
+                  className="flex-1 mt-1 block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm form-input"
+                  disabled={loading}
                 />
               </div>
 

--- a/frontend/src/services/configService.ts
+++ b/frontend/src/services/configService.ts
@@ -65,6 +65,7 @@ export interface SystemConfig {
 
 interface BetterAuthConfig {
   enabled?: boolean;
+  baseUrl?: string;
   basePath?: string;
   trustedOrigins?: string[];
   providers?: {

--- a/locales/en.json
+++ b/locales/en.json
@@ -733,6 +733,8 @@
     "betterAuthEnvNote": "Client IDs and secrets still come from environment variables. Changing Better Auth settings may require an application restart, and the install base URL origin is trusted automatically.",
     "enableBetterAuth": "Enable Better Auth",
     "enableBetterAuthDescription": "Enable social and OIDC login when the required environment variables are configured.",
+    "betterAuthBaseUrl": "Base URL",
+    "betterAuthBaseUrlDescription": "Public base URL used to build Better Auth redirect URIs. Falls back to the install base URL when empty; the BETTER_AUTH_URL environment variable takes precedence.",
     "betterAuthBasePath": "Auth base path",
     "betterAuthBasePathDescription": "Relative API path used by the Better Auth routes.",
     "betterAuthTrustedOrigins": "Trusted origins",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -724,6 +724,8 @@
     "betterAuthEnvNote": "Les identifiants et secrets client proviennent toujours des variables d'environnement. Modifier les paramètres Better Auth peut nécessiter un redémarrage de l'application, et l'origine de l'URL de base d'installation est ajoutée automatiquement aux origines approuvées.",
     "enableBetterAuth": "Activer Better Auth",
     "enableBetterAuthDescription": "Activez la connexion sociale et OIDC lorsque les variables d'environnement requises sont configurées.",
+    "betterAuthBaseUrl": "URL de base",
+    "betterAuthBaseUrlDescription": "URL de base publique utilisée pour construire les URI de redirection Better Auth. Si vide, l'URL de base d'installation est utilisée ; la variable d'environnement BETTER_AUTH_URL est prioritaire.",
     "betterAuthBasePath": "Chemin de base d'authentification",
     "betterAuthBasePathDescription": "Chemin API relatif utilisé par les routes Better Auth.",
     "betterAuthTrustedOrigins": "Origines approuvées",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -723,6 +723,8 @@
     "betterAuthEnvNote": "İstemci kimlikleri ve gizli anahtarlar hâlâ ortam değişkenlerinden gelir. Better Auth ayarlarını değiştirmek uygulamanın yeniden başlatılmasını gerektirebilir; kurulum temel URL kaynağı da güvenilen kaynaklara otomatik olarak eklenir.",
     "enableBetterAuth": "Better Auth'u etkinleştir",
     "enableBetterAuthDescription": "Gerekli ortam değişkenleri yapılandırıldığında sosyal giriş ve OIDC girişini etkinleştirin.",
+    "betterAuthBaseUrl": "Temel URL",
+    "betterAuthBaseUrlDescription": "Better Auth yönlendirme URI'lerini oluşturmak için kullanılan genel temel URL. Boş bırakılırsa kurulum temel URL'si kullanılır; BETTER_AUTH_URL ortam değişkeni önceliklidir.",
     "betterAuthBasePath": "Kimlik doğrulama temel yolu",
     "betterAuthBasePathDescription": "Better Auth rotaları tarafından kullanılan göreli API yolu.",
     "betterAuthTrustedOrigins": "Güvenilen kaynaklar",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -735,6 +735,8 @@
     "betterAuthEnvNote": "客户端 ID 和密钥仍然来自环境变量。修改 Better Auth 设置后可能需要重启应用；同时，安装配置中的基础地址来源会自动加入受信任来源。",
     "enableBetterAuth": "启用 Better Auth",
     "enableBetterAuthDescription": "当所需环境变量配置完成后，启用社交登录和 OIDC 登录。",
+    "betterAuthBaseUrl": "基础地址",
+    "betterAuthBaseUrlDescription": "用于生成 Better Auth 回调 URL 的公网访问地址。留空时回退到安装配置中的基础地址；BETTER_AUTH_URL 环境变量优先级更高。",
     "betterAuthBasePath": "认证基础路径",
     "betterAuthBasePathDescription": "Better Auth 路由使用的相对 API 路径。",
     "betterAuthTrustedOrigins": "受信任来源",

--- a/src/betterAuth.ts
+++ b/src/betterAuth.ts
@@ -3,8 +3,10 @@ import { genericOAuth } from 'better-auth/plugins';
 import { PostgresDialect } from 'kysely';
 import { Pool } from 'pg';
 import defaultConfig, { loadSettings } from './config/index.js';
-import { resolveBetterAuthRuntimeConfig } from './services/betterAuthConfig.js';
-import { resolveInstallBaseUrl } from './utils/installBaseUrl.js';
+import {
+  resolveBetterAuthBaseUrl,
+  resolveBetterAuthRuntimeConfig,
+} from './services/betterAuthConfig.js';
 import { getCachedSystemConfig, isDatabaseModeEnabled } from './utils/systemConfigCache.js';
 
 const resolveSystemConfig = () => {
@@ -86,11 +88,9 @@ const resolveBaseURL = (baseUrl: string, basePath: string): string => {
   }
 };
 
-const systemInstallBaseUrl = resolveInstallBaseUrl(systemConfig);
+const betterAuthBaseUrl = resolveBetterAuthBaseUrl(systemConfig);
 const baseURL = resolveBaseURL(
-  process.env.BETTER_AUTH_URL ||
-    systemInstallBaseUrl ||
-    `http://localhost:${defaultConfig.port}${defaultConfig.basePath}`,
+  betterAuthBaseUrl || `http://localhost:${defaultConfig.port}${defaultConfig.basePath}`,
   runtimeConfig.basePath,
 );
 

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -1512,6 +1512,7 @@ export const updateSystemConfig = async (req: Request, res: Response): Promise<v
     const hasBetterAuthUpdate =
       auth?.betterAuth &&
       (typeof auth.betterAuth.enabled === 'boolean' ||
+        typeof auth.betterAuth.baseUrl === 'string' ||
         typeof auth.betterAuth.basePath === 'string' ||
         Array.isArray(auth.betterAuth.trustedOrigins) ||
         (auth.betterAuth.providers &&
@@ -1987,6 +1988,10 @@ export const updateSystemConfig = async (req: Request, res: Response): Promise<v
 
       if (typeof auth.betterAuth.enabled === 'boolean') {
         target.enabled = auth.betterAuth.enabled;
+      }
+
+      if (typeof auth.betterAuth.baseUrl === 'string') {
+        target.baseUrl = auth.betterAuth.baseUrl.trim();
       }
 
       if (typeof auth.betterAuth.basePath === 'string') {

--- a/src/services/betterAuthConfig.ts
+++ b/src/services/betterAuthConfig.ts
@@ -145,6 +145,13 @@ const normalizePrompt = (
   return normalizedValue as BetterAuthOidcProviderConfig['prompt'];
 };
 
+export const resolveBetterAuthBaseUrl = (
+  systemConfig?: SystemConfig | null,
+): string | undefined =>
+  normalizeOptionalString(process.env.BETTER_AUTH_URL) ||
+  normalizeOptionalString(systemConfig?.auth?.betterAuth?.baseUrl) ||
+  resolveInstallBaseUrl(systemConfig);
+
 const resolveBooleanSetting = (
   envValue: string | undefined,
   settingsValue: unknown,
@@ -236,6 +243,7 @@ export const resolveBetterAuthRuntimeConfig = (
       [
         ...trustedOriginSettings,
         process.env.BETTER_AUTH_URL,
+        betterAuthSettings.baseUrl,
         resolveInstallBaseUrl(systemConfig),
       ]
         .map((value) => normalizeTrustedOrigin(value))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -206,6 +206,7 @@ export interface BetterAuthOidcProviderConfig extends BetterAuthProviderToggle {
 
 export interface BetterAuthConfig {
   enabled?: boolean; // Enable/disable Better Auth integration
+  baseUrl?: string; // Public base URL used to build Better Auth redirect URIs
   basePath?: string; // Base path to mount Better Auth handler
   trustedOrigins?: string[]; // Explicitly trusted origins for social/OIDC login requests
   disableAutoCreate?: boolean; // When true, SSO login will not auto-create new users

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -426,6 +426,7 @@ describe('serverController - updateSystemConfig', () => {
       auth: {
         betterAuth: {
           enabled: true,
+          baseUrl: ' https://mcp.example.com ',
           basePath: '/custom-auth',
           trustedOrigins: ['https://mcp.example.com', '  '],
           providers: {
@@ -468,6 +469,7 @@ describe('serverController - updateSystemConfig', () => {
         auth: {
           betterAuth: {
             enabled: true,
+            baseUrl: 'https://mcp.example.com',
             basePath: '/custom-auth',
             trustedOrigins: ['https://mcp.example.com'],
             providers: {
@@ -500,6 +502,43 @@ describe('serverController - updateSystemConfig', () => {
               enabled: true,
               basePath: '/custom-auth',
             }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('persists a baseUrl-only Better Auth update', async () => {
+    mockRequest.body = {
+      auth: {
+        betterAuth: {
+          baseUrl: ' https://mcp.example.com ',
+        },
+      },
+    };
+
+    mockSystemConfigDao.get.mockResolvedValue({
+      routing: {
+        enableGlobalRoute: true,
+        enableGroupNameRoute: true,
+        enableBearerAuth: true,
+        bearerAuthKey: '',
+        bearerAuthHeaderName: 'Authorization',
+        jsonBodyLimit: '1mb',
+        skipAuth: false,
+      },
+      auth: {},
+    });
+
+    await updateSystemConfig(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).not.toHaveBeenCalledWith(400);
+
+    expect(mockSystemConfigDao.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          betterAuth: expect.objectContaining({
+            baseUrl: 'https://mcp.example.com',
           }),
         }),
       }),

--- a/tests/services/betterAuth.bootstrap.test.ts
+++ b/tests/services/betterAuth.bootstrap.test.ts
@@ -4,6 +4,7 @@ const poolMock = jest.fn();
 const postgresDialectMock = jest.fn();
 const loadSettingsMock = jest.fn();
 const resolveBetterAuthRuntimeConfigMock = jest.fn();
+const resolveBetterAuthBaseUrlMock = jest.fn();
 
 const runtimeConfig = {
   enabled: true,
@@ -71,6 +72,7 @@ jest.mock('../../src/services/betterAuthConfig.js', () => ({
   betterAuthRuntimeConfig: disabledRuntimeConfig,
   getBetterAuthRuntimeConfig: jest.fn(() => runtimeConfig),
   resolveBetterAuthRuntimeConfig: resolveBetterAuthRuntimeConfigMock,
+  resolveBetterAuthBaseUrl: resolveBetterAuthBaseUrlMock,
 }));
 
 describe('betterAuth bootstrap', () => {
@@ -91,6 +93,7 @@ describe('betterAuth bootstrap', () => {
     process.env.OIDC_CLIENT_ID = 'oidc-client-id';
     process.env.OIDC_CLIENT_SECRET = 'oidc-client-secret';
     process.env.USE_DB = 'true';
+    resolveBetterAuthBaseUrlMock.mockReturnValue('http://localhost:5173');
   });
 
   it('registers the generic OAuth plugin when the OIDC provider is enabled', async () => {
@@ -151,12 +154,37 @@ describe('betterAuth bootstrap', () => {
         },
       },
     });
+    resolveBetterAuthBaseUrlMock.mockReturnValue('http://localhost:5173');
 
     await import('../../src/betterAuth.js');
 
     expect(betterAuthMock).toHaveBeenCalledWith(
       expect.objectContaining({
         baseURL: 'http://localhost:5173/api/auth/better',
+      }),
+    );
+  });
+
+  it('uses betterAuth.baseUrl when BETTER_AUTH_URL is not set', async () => {
+    resolveBetterAuthBaseUrlMock.mockReturnValue('https://settings.example.com/mcphub');
+
+    await import('../../src/betterAuth.js');
+
+    expect(betterAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'https://settings.example.com/mcphub/api/auth/better',
+      }),
+    );
+  });
+
+  it('falls back to the default localhost URL when no base URL is configured', async () => {
+    resolveBetterAuthBaseUrlMock.mockReturnValue(undefined);
+
+    await import('../../src/betterAuth.js');
+
+    expect(betterAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseURL: 'http://localhost:3000/api/auth/better',
       }),
     );
   });

--- a/tests/services/betterAuthConfig.test.ts
+++ b/tests/services/betterAuthConfig.test.ts
@@ -218,6 +218,60 @@ describe('betterAuthConfig', () => {
     ]);
   });
 
+  it('uses betterAuth.baseUrl as a trusted origin and prefers it over install.baseUrl', async () => {
+    process.env.OIDC_CLIENT_ID = 'oidc-client-id';
+    process.env.OIDC_CLIENT_SECRET = 'oidc-client-secret';
+
+    const systemConfig = {
+      install: {
+        baseUrl: 'https://install.example.com/mcphub',
+      },
+      auth: {
+        betterAuth: {
+          enabled: true,
+          baseUrl: 'https://settings.example.com/mcphub',
+          providers: {
+            oidc: {
+              enabled: true,
+              discoveryUrl: 'https://auth.example.com/.well-known/openid-configuration',
+            },
+          },
+        },
+      },
+    };
+
+    getSystemConfigMock.mockResolvedValue(systemConfig);
+
+    const { getBetterAuthRuntimeConfig, resolveBetterAuthBaseUrl } = await import(
+      '../../src/services/betterAuthConfig.js'
+    );
+
+    expect((await getBetterAuthRuntimeConfig()).trustedOrigins).toEqual([
+      'https://settings.example.com',
+      'https://install.example.com',
+    ]);
+    expect(resolveBetterAuthBaseUrl(systemConfig)).toBe('https://settings.example.com/mcphub');
+  });
+
+  it('prefers BETTER_AUTH_URL over betterAuth.baseUrl for the resolved base URL', async () => {
+    process.env.BETTER_AUTH_URL = 'https://env-public.example.com/mcphub';
+
+    const systemConfig = {
+      install: {
+        baseUrl: 'https://install.example.com/mcphub',
+      },
+      auth: {
+        betterAuth: {
+          baseUrl: 'https://settings.example.com/mcphub',
+        },
+      },
+    };
+
+    const { resolveBetterAuthBaseUrl } = await import('../../src/services/betterAuthConfig.js');
+
+    expect(resolveBetterAuthBaseUrl(systemConfig)).toBe('https://env-public.example.com/mcphub');
+  });
+
   it('prefers Better Auth environment variables over stored settings for runtime config', async () => {
     process.env.BETTER_AUTH_ENABLED = 'true';
     process.env.BETTER_AUTH_BASE_PATH = 'env-auth';


### PR DESCRIPTION
## Summary

Closes #1051

Adds a **Base URL** field to Settings → Better Auth so the public base URL used to build Better Auth redirect URIs can be managed from the dashboard instead of only via the `BETTER_AUTH_URL` environment variable.

## Behavior change

Resolution order for the Better Auth base URL (highest priority first):

1. `BETTER_AUTH_URL` environment variable
2. `systemConfig.auth.betterAuth.baseUrl` (**new**, editable in the dashboard)
3. `systemConfig.install.baseUrl`
4. `http://localhost:{port}{basePath}` fallback

The configured origin is also auto-added to the trusted origins list, same as the existing env var / install base URL behavior. As with other Better Auth settings, changing this value requires an application restart to rebuild the auth instance.

## Implementation notes

- Extracted a shared `resolveBetterAuthBaseUrl()` in [src/services/betterAuthConfig.ts](src/services/betterAuthConfig.ts) used both by the auth bootstrap ([src/betterAuth.ts](src/betterAuth.ts)) and the trusted-origins resolution, keeping the precedence rules in one place.
- The new field lives inside the existing `auth` simple-json column, so no entity/migration changes are needed (dual-datasource checklist verified).
- i18n keys added to all four locales (en/zh/fr/tr); docs updated (en + zh).

## Testing

- Added unit tests covering: settings-based base URL as trusted origin, env-over-settings precedence, and the localhost fallback (`tests/services/betterAuthConfig.test.ts`, `tests/services/betterAuth.bootstrap.test.ts`).
- Pre-commit gate: `pnpm lint` ✅, `pnpm test:ci` (147 suites / 1027 tests) ✅, `pnpm build` ✅
- Manual check: verified the new input appears in Settings → Better Auth and persists via `PUT /api/system-config`.