### PR TITLE
fix(server): avoid unnecessary runtime reloads when editing a server

### DIFF
--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -356,35 +356,37 @@ const ServerForm = ({
             {t('server.sectionBasicInfo', 'Basic Info')}
           </h3>
 
-          <div className="mb-4">
-            <label className="block text-sm font-medium mb-1.5 text-[var(--hub-ink-2)]" htmlFor="name">
-              {t('server.name')}
-            </label>
-            <input
-              type="text"
-              name="name"
-              id="name"
-              value={formData.name}
-              onChange={handleInputChange}
-              className="w-full py-2 px-3 form-input"
-              placeholder="e.g.: time-mcp"
-              required
-            />
-          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+            <div className="md:col-span-1">
+              <label className="block text-sm font-medium mb-1.5 text-[var(--hub-ink-2)]" htmlFor="name">
+                {t('server.name')}
+              </label>
+              <input
+                type="text"
+                name="name"
+                id="name"
+                value={formData.name}
+                onChange={handleInputChange}
+                className="w-full py-2 px-3 form-input"
+                placeholder="e.g.: time-mcp"
+                required
+              />
+            </div>
 
-          <div className="mb-4">
-            <label className="block text-sm font-medium mb-1.5 text-[var(--hub-ink-2)]" htmlFor="description">
-              {t('server.description')}
-            </label>
-            <input
-              type="text"
-              name="description"
-              id="description"
-              value={formData.description || ''}
-              onChange={handleInputChange}
-              className="w-full py-2 px-3 form-input"
-              placeholder={t('server.descriptionPlaceholder')}
-            />
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium mb-1.5 text-[var(--hub-ink-2)]" htmlFor="description">
+                {t('server.description')}
+              </label>
+              <input
+                type="text"
+                name="description"
+                id="description"
+                value={formData.description || ''}
+                onChange={handleInputChange}
+                className="w-full py-2 px-3 form-input"
+                placeholder={t('server.descriptionPlaceholder')}
+              />
+            </div>
           </div>
         </div>
 
@@ -723,6 +725,59 @@ const ServerForm = ({
                   </div>
                 )}
 
+                {/* OpenID Connect Configuration */}
+                {formData.openapi?.securityType === 'openIdConnect' && (
+                  <div className="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded bg-gray-50 dark:bg-gray-800">
+                    <h4 className="text-sm font-medium mb-3 text-gray-700 dark:text-gray-300">
+                      {t('server.openapi.openIdConnectConfig')}
+                    </h4>
+                    <div className="grid grid-cols-1 gap-3">
+                      <div>
+                        <label className="block text-xs text-gray-600 mb-1">
+                          {t('server.openapi.openIdConnectUrl')}
+                        </label>
+                        <input
+                          type="url"
+                          value={formData.openapi?.openIdConnectUrl || ''}
+                          onChange={(e) =>
+                            setFormData((prev) => ({
+                              ...prev,
+                              openapi: {
+                                ...prev.openapi,
+                                openIdConnectUrl: e.target.value,
+                                url: prev.openapi?.url || '',
+                              },
+                            }))
+                          }
+                          className="w-full border rounded px-2 py-1 text-sm focus:outline-none form-input"
+                          placeholder="https://example.com/.well-known/openid_configuration"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-gray-600 mb-1">
+                          {t('server.openapi.openIdConnectToken')}
+                        </label>
+                        <input
+                          type="password"
+                          value={formData.openapi?.openIdConnectToken || ''}
+                          onChange={(e) =>
+                            setFormData((prev) => ({
+                              ...prev,
+                              openapi: {
+                                ...prev.openapi,
+                                openIdConnectToken: e.target.value,
+                                url: prev.openapi?.url || '',
+                              },
+                            }))
+                          }
+                          className="w-full border rounded px-2 py-1 text-sm focus:outline-none form-input"
+                          placeholder="id-token"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
                 {/* OAuth2 Configuration */}
                 {formData.openapi?.securityType === 'oauth2' && (
                   <div className="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded bg-gray-50 dark:bg-gray-800">
@@ -817,85 +872,6 @@ const ServerForm = ({
                     </div>
                   </div>
                 )}
-
-                {/* OpenID Connect Configuration */}
-                {formData.openapi?.securityType === 'openIdConnect' && (
-                  <div className="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded bg-gray-50 dark:bg-gray-800">
-                    <h4 className="text-sm font-medium mb-3 text-gray-700 dark:text-gray-300">
-                      {t('server.openapi.openIdConnectConfig')}
-                    </h4>
-                    <div className="grid grid-cols-1 gap-3">
-                      <div>
-                        <label className="block text-xs text-gray-600 mb-1">
-                          {t('server.openapi.openIdConnectUrl')}
-                        </label>
-                        <input
-                          type="url"
-                          value={formData.openapi?.openIdConnectUrl || ''}
-                          onChange={(e) =>
-                            setFormData((prev) => ({
-                              ...prev,
-                              openapi: {
-                                ...prev.openapi,
-                                openIdConnectUrl: e.target.value,
-                                url: prev.openapi?.url || '',
-                              },
-                            }))
-                          }
-                          className="w-full border rounded px-2 py-1 text-sm focus:outline-none form-input"
-                          placeholder="https://example.com/.well-known/openid_configuration"
-                        />
-                      </div>
-                      <div>
-                        <label className="block text-xs text-gray-600 mb-1">
-                          {t('server.openapi.openIdConnectToken')}
-                        </label>
-                        <input
-                          type="password"
-                          value={formData.openapi?.openIdConnectToken || ''}
-                          onChange={(e) =>
-                            setFormData((prev) => ({
-                              ...prev,
-                              openapi: {
-                                ...prev.openapi,
-                                openIdConnectToken: e.target.value,
-                                url: prev.openapi?.url || '',
-                              },
-                            }))
-                          }
-                          className="w-full border rounded px-2 py-1 text-sm focus:outline-none form-input"
-                          placeholder="id-token"
-                        />
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Passthrough Headers Configuration */}
-                <div className="mb-4">
-                  <label className="block text-sm font-medium mb-1.5 text-gray-700 dark:text-gray-300">
-                    {t('server.openapi.passthroughHeaders')}
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.openapi?.passthroughHeaders || ''}
-                    onChange={(e) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        openapi: {
-                          ...prev.openapi,
-                          passthroughHeaders: e.target.value,
-                          url: prev.openapi?.url || '',
-                        },
-                      }))
-                    }
-                    className="w-full py-2 px-3 form-input"
-                    placeholder="Authorization, X-API-Key, X-Custom-Header"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    {t('server.openapi.passthroughHeadersHelp')}
-                  </p>
-                </div>
 
                 {/* Cookie Session Handling */}
                 <div className="mb-4">
@@ -1041,27 +1017,6 @@ const ServerForm = ({
                 </div>
 
                 <div className="mb-4">
-                  <label className="block text-sm font-medium mb-1.5 text-gray-700 dark:text-gray-300">
-                    {t('server.openapi.passthroughHeaders')}
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.passthroughHeaders || ''}
-                    onChange={(e) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        passthroughHeaders: e.target.value,
-                      }))
-                    }
-                    className="w-full py-2 px-3 form-input"
-                    placeholder="Authorization, X-Custom-User-Id"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    {t('server.openapi.passthroughHeadersHelp')}
-                  </p>
-                </div>
-
-                <div className="mb-4">
                   <div className="flex justify-between items-center mb-2">
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                       {t('server.envVars')}
@@ -1102,54 +1057,6 @@ const ServerForm = ({
                       </button>
                     </div>
                   ))}
-                </div>
-
-                <div className="mb-4">
-                  <div
-                    className="flex items-center justify-between cursor-pointer bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 p-3 rounded border border-gray-200 dark:border-gray-700"
-                    onClick={() => setIsOAuthSectionExpanded(!isOAuthSectionExpanded)}
-                  >
-                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                      {t('server.oauth.sectionTitle')}
-                    </label>
-                    <span className="text-gray-500 text-sm">{isOAuthSectionExpanded ? '▼' : '▶'}</span>
-                  </div>
-
-                  {isOAuthSectionExpanded && (
-                    <div className="border border-gray-200 dark:border-gray-700 rounded-b p-4 bg-gray-50 dark:bg-gray-800 border-t-0">
-                      <p className="text-xs text-gray-500 mb-3">
-                        {t('server.oauth.sectionDescription')}
-                      </p>
-                      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                        <div>
-                          <label className="block text-xs text-gray-600 mb-1">
-                            {t('server.oauth.clientId')}
-                          </label>
-                          <input
-                            type="text"
-                            value={formData.oauth?.clientId || ''}
-                            onChange={(e) => handleOAuthChange('clientId', e.target.value)}
-                            className="w-full py-2 px-3 form-input"
-                            placeholder="client id"
-                            autoComplete="off"
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs text-gray-600 mb-1">
-                            {t('server.oauth.clientSecret')}
-                          </label>
-                          <input
-                            type="password"
-                            value={formData.oauth?.clientSecret || ''}
-                            onChange={(e) => handleOAuthChange('clientSecret', e.target.value)}
-                            className="w-full py-2 px-3 form-input"
-                            placeholder="client secret"
-                            autoComplete="off"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  )}
                 </div>
               </>
             ) : (
@@ -1336,6 +1243,100 @@ const ServerForm = ({
                   </div>
                 )}
               </div>
+
+              {/* Passthrough Headers Configuration */}
+              <div>
+                <label className="block text-sm font-medium mb-1.5 text-[var(--hub-ink-2)]">
+                  {t('server.openapi.passthroughHeaders')}
+                </label>
+                {serverType === 'openapi' ? (
+                  <>
+                    <input
+                      type="text"
+                      value={formData.openapi?.passthroughHeaders || ''}
+                      onChange={(e) =>
+                        setFormData((prev) => ({
+                          ...prev,
+                          openapi: {
+                            ...prev.openapi,
+                            passthroughHeaders: e.target.value,
+                            url: prev.openapi?.url || '',
+                          },
+                        }))
+                      }
+                      className="w-full py-2 px-3 form-input"
+                      placeholder="Authorization, X-API-Key, X-Custom-Header"
+                    />
+                  </>
+                ) : (
+                  <input
+                    type="text"
+                    value={formData.passthroughHeaders || ''}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        passthroughHeaders: e.target.value,
+                      }))
+                    }
+                    className="w-full py-2 px-3 form-input"
+                    placeholder="Authorization, X-Custom-User-Id"
+                  />
+                )}
+                <p className="text-xs text-gray-500 mt-1">
+                  {t('server.openapi.passthroughHeadersHelp')}
+                </p>
+              </div>
+
+              {/* OAuth Configuration - non-OpenAPI types */}
+              {serverType !== 'openapi' && (
+                <div>
+                  <div
+                    className="flex items-center justify-between cursor-pointer bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 p-3 rounded border border-gray-200 dark:border-gray-700"
+                    onClick={() => setIsOAuthSectionExpanded(!isOAuthSectionExpanded)}
+                  >
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      {t('server.oauth.sectionTitle')}
+                    </label>
+                    <span className="text-gray-500 text-sm">{isOAuthSectionExpanded ? '▼' : '▶'}</span>
+                  </div>
+
+                  {isOAuthSectionExpanded && (
+                    <div className="border border-gray-200 dark:border-gray-700 rounded-b p-4 bg-gray-50 dark:bg-gray-800 border-t-0">
+                      <p className="text-xs text-gray-500 mb-3">
+                        {t('server.oauth.sectionDescription')}
+                      </p>
+                      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                        <div>
+                          <label className="block text-xs text-gray-600 mb-1">
+                            {t('server.oauth.clientId')}
+                          </label>
+                          <input
+                            type="text"
+                            value={formData.oauth?.clientId || ''}
+                            onChange={(e) => handleOAuthChange('clientId', e.target.value)}
+                            className="w-full py-2 px-3 form-input"
+                            placeholder="client id"
+                            autoComplete="off"
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-xs text-gray-600 mb-1">
+                            {t('server.oauth.clientSecret')}
+                          </label>
+                          <input
+                            type="password"
+                            value={formData.oauth?.clientSecret || ''}
+                            onChange={(e) => handleOAuthChange('clientSecret', e.target.value)}
+                            className="w-full py-2 px-3 form-input"
+                            placeholder="client secret"
+                            autoComplete="off"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Request Options Configuration */}
               {serverType !== 'openapi' && (

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -109,6 +109,9 @@ const ServerForm = ({
     },
     // Per-session client isolation initialization
     perSessionClient: initialData?.config?.perSessionClient === true,
+    // Proxychains proxy config: round-trip the stored value so editing the
+    // server does not silently drop it (there is no in-form editor for it).
+    proxy: initialData?.config?.proxy,
     // On-demand spawning initialization
     startOnDemand: initialData?.config?.startOnDemand === true,
     idleTimeoutMs: initialData?.config?.idleTimeoutMs ?? 300000,

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -916,7 +916,7 @@ const ServerForm = ({
                     <button
                       type="button"
                       onClick={addHeaderVar}
-                      className="bg-gray-200 hover:bg-gray-300 text-gray-700 font-medium py-1 px-2 rounded text-sm flex items-center justify-center min-w-[30px] min-h-[30px] btn-primary"
+                      className="hub-btn primary !w-[30px] !h-[30px] !p-0 justify-center text-base font-bold"
                     >
                       +
                     </button>
@@ -981,7 +981,7 @@ const ServerForm = ({
                     <button
                       type="button"
                       onClick={addHeaderVar}
-                      className="bg-gray-200 hover:bg-gray-300 text-gray-700 font-medium py-1 px-2 rounded text-sm flex items-center justify-center min-w-[30px] min-h-[30px] btn-primary"
+                      className="hub-btn primary !w-[30px] !h-[30px] !p-0 justify-center text-base font-bold"
                     >
                       +
                     </button>
@@ -1024,7 +1024,7 @@ const ServerForm = ({
                     <button
                       type="button"
                       onClick={addEnvVar}
-                      className="bg-gray-200 hover:bg-gray-300 text-gray-700 font-medium py-1 px-2 rounded text-sm flex items-center justify-center min-w-[30px] min-h-[30px] btn-primary"
+                      className="hub-btn primary !w-[30px] !h-[30px] !p-0 justify-center text-base font-bold"
                     >
                       +
                     </button>
@@ -1099,7 +1099,7 @@ const ServerForm = ({
                     <button
                       type="button"
                       onClick={addEnvVar}
-                      className="bg-gray-200 hover:bg-gray-300 text-gray-700 font-medium py-1 px-2 rounded text-sm flex items-center justify-center min-w-[30px] min-h-[30px] btn-primary"
+                      className="hub-btn primary !w-[30px] !h-[30px] !p-0 justify-center text-base font-bold"
                     >
                       +
                     </button>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -11,6 +11,9 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   asChild?: boolean;
   loading?: boolean;
   children: React.ReactNode;
+  // Allow async handlers: Button detects a returned promise and shows the
+  // loading state for the duration of the call.
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
 }
 
 const variantStyles: Record<ButtonVariant, string> = {

--- a/frontend/src/contexts/EmbeddingSyncContext.tsx
+++ b/frontend/src/contexts/EmbeddingSyncContext.tsx
@@ -93,29 +93,34 @@ export const EmbeddingSyncProvider: React.FC<{ children: React.ReactNode }> = ({
           return;
         }
 
-        clearHideTimer(data.progress.serverName);
+        // Hold the narrowed reference: type-guard narrowing of a property access
+        // is not preserved inside the setTimeout closure below, so dereference
+        // once into a const and use that everywhere.
+        const progress = data.progress;
 
-        if (data.progress.status === 'error') {
-          removeSync(data.progress.serverName);
+        clearHideTimer(progress.serverName);
+
+        if (progress.status === 'error') {
+          removeSync(progress.serverName);
           return;
         }
 
         const nextState: EmbeddingSyncProgressState = {
-          serverName: data.progress.serverName,
-          current: data.progress.current,
-          total: data.progress.total,
-          status: data.progress.status,
+          serverName: progress.serverName,
+          current: progress.current,
+          total: progress.total,
+          status: progress.status,
         };
 
         upsertSync(nextState);
 
-        if (data.progress.status === 'completed') {
+        if (progress.status === 'completed') {
           const timer = setTimeout(() => {
-            removeSync(data.progress.serverName);
-            hideTimersRef.current.delete(data.progress.serverName);
+            removeSync(progress.serverName);
+            hideTimersRef.current.delete(progress.serverName);
           }, COMPLETION_VISIBILITY_MS);
 
-          hideTimersRef.current.set(data.progress.serverName, timer);
+          hideTimersRef.current.set(progress.serverName, timer);
         }
       } catch {
         // Ignore malformed stream messages.

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -209,6 +209,10 @@ export interface ServerConfig {
   enableKeepAlive?: boolean; // Enable remote health checks and automatic reconnect attempts
   keepAliveInterval?: number; // Health check and reconnect interval in milliseconds (default: 60000ms)
   perSessionClient?: boolean; // Create a dedicated upstream client per downstream session instead of sharing one connection (for stateful servers like Playwright)
+  // On-demand spawning: start the stdio process only when a tool call arrives,
+  // and shut it down automatically after a period of inactivity (stdio only).
+  startOnDemand?: boolean;
+  idleTimeoutMs?: number; // Milliseconds of inactivity before shutting down (default: 300_000)
   tools?: Record<string, { enabled: boolean; description?: string }>; // Tool-specific configurations with enable/disable state and custom descriptions
   prompts?: Record<string, { enabled: boolean; description?: string }>; // Prompt-specific configurations with enable/disable state and custom descriptions
   options?: {
@@ -363,12 +367,19 @@ export interface ServerFormData {
     resetTimeoutOnProgress?: boolean;
     maxTotalTimeout?: number;
   };
+  // Proxychains4 proxy configuration for STDIO servers (Linux/macOS only).
+  // Round-tripped from the stored config so an edit does not drop it.
+  proxy?: ProxychainsConfig;
   keepAlive?: {
     enabled?: boolean;
     interval?: number;
   };
   // Create a dedicated upstream client per downstream session (stateful servers)
   perSessionClient?: boolean;
+  // On-demand spawning (stdio only): start the process on first tool call and
+  // shut it down after a period of inactivity.
+  startOnDemand?: boolean;
+  idleTimeoutMs?: number;
   oauth?: {
     clientId?: string;
     clientSecret?: string;

--- a/frontend/src/utils/serverFormPayload.ts
+++ b/frontend/src/utils/serverFormPayload.ts
@@ -46,7 +46,12 @@ const normalizeSharedUsers = (usernames?: string[]): string[] => {
 const buildOptions = (options?: ServerFormData['options']) => {
   const nextOptions: NonNullable<ServerFormData['options']> = {};
 
-  if (options?.timeout && options.timeout !== 60000) {
+  // Always echo the timeout, even when it equals the 60000 default: dropping it
+  // makes the payload differ from a stored explicit `timeout: 60000` and trips
+  // the backend's "connection changed" fast-path check on unrelated edits. The
+  // backend comparison normalizes the default timeout, so an explicit 60000 and
+  // an absent one compare as equal.
+  if (typeof options?.timeout === 'number' && !Number.isNaN(options.timeout)) {
     nextOptions.timeout = options.timeout;
   }
 
@@ -185,6 +190,9 @@ export const buildServerPayload = ({
     perSessionClient: formData.perSessionClient === true ? true : undefined,
     startOnDemand: formData.startOnDemand === true ? true : undefined,
     idleTimeoutMs: formData.startOnDemand === true ? (formData.idleTimeoutMs ?? 300000) : undefined,
+    // Round-trip the stored proxychains config (no in-form editor) so an edit
+    // of any other field does not drop it and force an avoidable reload.
+    proxy: formData.proxy,
   };
 
   if (serverType === 'openapi') {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,9 +19,8 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
-    
+
     /* Paths */
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -15,6 +15,7 @@ import {
   addServer,
   addOrUpdateServer,
   removeServer,
+  closeServer,
   getServerByName,
   notifyToolChanged,
   broadcastToolListChanged,
@@ -187,43 +188,69 @@ const stripUndefinedDeep = (value: unknown): unknown => {
   return value;
 };
 
-const toComparableServerConfig = (config: ServerConfig | ServerRecord): unknown => {
-  const { name: _name, ...rest } = config as ServerConfig & {
-    name?: string;
-  };
+// Fields baked into the live MCP client/transport at connect time. Editing any
+// of these requires tearing down and re-establishing the runtime. Everything
+// else in ServerConfig (description, owner, visibility, sharedWithUsers,
+// `enabled`, and the tools/prompts/resources per-item overrides) is read-time
+// or access metadata that can be applied without a reconnect.
+const CONNECTION_RELEVANT_CONFIG_FIELDS = [
+  'type',
+  'url',
+  'command',
+  'args',
+  'env',
+  'headers',
+  'passthroughHeaders',
+  'options',
+  'oauth',
+  'openapi',
+  'perSessionClient',
+  'startOnDemand',
+  'idleTimeoutMs',
+  'enableKeepAlive',
+  'keepAliveInterval',
+  'proxy',
+] as const;
 
-  const normalized = normalizeServerConfigForPersistence(rest);
-  const {
-    visibility: _visibility,
-    sharedWithUsers: _sharedWithUsers,
-    ...comparableConfig
-  } = normalized;
+type ConnectionRelevantServerConfig = Pick<
+  ServerConfig,
+  (typeof CONNECTION_RELEVANT_CONFIG_FIELDS)[number]
+>;
 
-  return stripUndefinedDeep(comparableConfig);
+const toConnectionRelevantConfig = (
+  config: ServerConfig | ServerRecord,
+): ConnectionRelevantServerConfig => {
+  const normalized = normalizeServerConfigForPersistence(config) as Record<string, unknown>;
+  const picked: Record<string, unknown> = {};
+  for (const field of CONNECTION_RELEVANT_CONFIG_FIELDS) {
+    picked[field] = normalized[field];
+  }
+  const comparable = stripUndefinedDeep(picked) as Record<string, unknown>;
+  // Treat the default request timeout (60000, the dashboard form default) as
+  // equivalent to "not set": an explicit 60000 stored via API/file import and an
+  // absent timeout resolve to the same effective connect timeout. Without this, a
+  // stored explicit 60000 (or the dashboard echoing 60000 back) would look like a
+  // connection change on unrelated edits and reload the runtime for nothing.
+  const options = comparable.options as { timeout?: number } | undefined;
+  if (options && options.timeout === 60000) {
+    delete options.timeout;
+    if (Object.keys(options).length === 0) {
+      delete comparable.options;
+    }
+  }
+  return comparable as ConnectionRelevantServerConfig;
 };
 
-const isAccessOnlyServerUpdate = (
+// True when an edit touches at least one field the live connection depends on,
+// i.e. the runtime must be torn down and reconnected.
+const hasConnectionRelevantChange = (
   existingServer: ServerRecord,
   nextConfig: ServerConfig,
-): boolean => {
-  const currentAccess = {
-    visibility: existingServer.visibility ?? 'private',
-    sharedWithUsers: existingServer.sharedWithUsers ?? [],
-  };
-  const nextAccess = {
-    visibility: nextConfig.visibility ?? 'private',
-    sharedWithUsers: nextConfig.sharedWithUsers ?? [],
-  };
-
-  if (isDeepStrictEqual(currentAccess, nextAccess)) {
-    return false;
-  }
-
-  return isDeepStrictEqual(
-    toComparableServerConfig(existingServer),
-    toComparableServerConfig(nextConfig),
+): boolean =>
+  !isDeepStrictEqual(
+    toConnectionRelevantConfig(existingServer),
+    toConnectionRelevantConfig(nextConfig),
   );
-};
 
 export const getAllServers = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -944,6 +971,13 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
         return;
       }
 
+      // Close the runtime still keyed by the OLD name. addOrUpdateServer below
+      // closes by `finalName` (the new name), which finds nothing - the entry is
+      // still registered under the old name until initializeClientsFromSettings
+      // rebuilds serverInfos. Without this explicit close the old stdio child
+      // process tree is orphaned and leaks until the process restarts.
+      closeServer(name);
+
       // Update references in groups
       const groupDao = getGroupDao();
       await groupDao.updateServerName(name, newName);
@@ -968,7 +1002,11 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
     // Use the final server name (new name if renaming, otherwise original name)
     const finalName = isRenaming ? newName : name;
 
-    if (!isRenaming && isAccessOnlyServerUpdate(existingServer, normalizedConfig)) {
+    // Fast path: if no connection-relevant field changed, persist and update
+    // in-memory access metadata without tearing down the runtime. This covers
+    // visibility/sharedWithUsers edits, description-only edits, owner changes,
+    // and no-op edits alike - none of them need a reconnect.
+    if (!isRenaming && !hasConnectionRelevantChange(existingServer, normalizedConfig)) {
       const serverDao = getServerDao();
       const updatedServer = await serverDao.update(name, normalizedConfig);
 

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -2367,8 +2367,9 @@ const closeServerRuntime = (serverInfo: ServerInfo): void => {
   console.log('Closed MCP server client and transport');
 };
 
-// Close server client and transport
-function closeServer(name: string) {
+// Close server client and transport (keeps the entry in serverInfos; the next
+// initializeClientsFromSettings rebuild drops it if it is no longer configured).
+export function closeServer(name: string) {
   const serverInfo = serverInfos.find((serverInfo) => serverInfo.name === name);
   if (serverInfo) {
     closeServerRuntime(serverInfo);

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -54,6 +54,7 @@ const mockGetServerByName = jest.fn();
 const mockAddServer = jest.fn();
 const mockAddOrUpdateServer = jest.fn();
 const mockRemoveServer = jest.fn();
+const mockCloseServer = jest.fn();
 const mockToggleServerStatus = jest.fn();
 const mockReconnectServer = jest.fn();
 const mockUpdateServerInfoVisibility = jest.fn();
@@ -77,6 +78,7 @@ jest.mock('../../src/services/mcpService.js', () => ({
   addServer: mockAddServer,
   addOrUpdateServer: mockAddOrUpdateServer,
   removeServer: mockRemoveServer,
+  closeServer: jest.fn((...args: unknown[]) => mockCloseServer(...args)),
   getServerByName: jest.fn(() => mockGetServerByName()),
   notifyToolChanged: jest.fn(() => mockNotifyToolChanged()),
   broadcastToolListChanged: jest.fn(() => mockBroadcastToolListChanged()),
@@ -209,6 +211,14 @@ describe('serverController - stdio servers without arguments', () => {
     mockAddServer.mockResolvedValue({ success: true });
     mockAddOrUpdateServer.mockResolvedValue({ success: true });
     mockNotifyToolChanged.mockResolvedValue(undefined);
+    mockServerDao.update = jest.fn().mockResolvedValue({
+      name: 'no-args-server',
+      type: 'stdio',
+      command: '/usr/bin/some-tool',
+      args: [],
+      owner: 'admin',
+      visibility: 'private',
+    });
     mockServerDao.findById.mockResolvedValue({
       name: 'no-args-server',
       type: 'stdio',
@@ -277,14 +287,16 @@ describe('serverController - stdio servers without arguments', () => {
     await updateServer(request, response);
 
     expect(status).not.toHaveBeenCalledWith(400);
-    expect(mockAddOrUpdateServer).toHaveBeenCalledWith(
+    // The payload is identical to the stored connection config (a no-op edit),
+    // so it takes the fast path: persisted via DAO update, no runtime reload.
+    expect(mockServerDao.update).toHaveBeenCalledWith(
       'no-args-server',
       expect.objectContaining({
         type: 'stdio',
         command: '/usr/bin/some-tool',
       }),
-      true,
     );
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
     expect(json).toHaveBeenCalledWith({
       success: true,
       message: 'Server updated successfully',
@@ -835,6 +847,279 @@ describe('serverController - updateServer', () => {
     expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
   });
 
+  it('uses the access-only fast path when the payload omits enabled (real dashboard payload)', async () => {
+    // The dashboard's buildServerPayload never sends `enabled`, while servers
+    // created through the DAO are persisted with `enabled: true`. The comparable
+    // config must therefore ignore `enabled`, or every visibility-only edit
+    // would tear down and reconnect the server runtime for no reason.
+    mockRequest.body.config = {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      description: '',
+      visibility: 'public',
+      sharedWithUsers: undefined,
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      type: 'sse',
+      url: 'https://example.com/sse',
+      enabled: true,
+      owner: 'admin',
+      visibility: 'private',
+    });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).toHaveBeenCalled();
+    expect(mockUpdateServerInfoVisibility).toHaveBeenCalledWith('test-server', 'public', undefined);
+    expect(mockBroadcastToolListChanged).toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server updated successfully',
+    });
+  });
+
+  it('uses the access-only fast path for a sharedWithUsers-only edit (real dashboard payload)', async () => {
+    // Same asymmetry as above, but for the sharing allowlist on a group server:
+    // the stored record carries `enabled: true` and the existing allowlist, while
+    // the dashboard payload omits `enabled`. A pure allowlist edit must not
+    // tear down and reconnect the runtime either.
+    mockRequest.body.config = {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      description: '',
+      visibility: 'group',
+      sharedWithUsers: ['alice', 'bob'],
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      type: 'sse',
+      url: 'https://example.com/sse',
+      enabled: true,
+      owner: 'admin',
+      visibility: 'group',
+      sharedWithUsers: ['alice'],
+    });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).toHaveBeenCalled();
+    expect(mockUpdateServerInfoVisibility).toHaveBeenCalledWith('test-server', 'group', [
+      'alice',
+      'bob',
+    ]);
+    expect(mockBroadcastToolListChanged).toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server updated successfully',
+    });
+  });
+
+  it('uses the access-only fast path when the stored config carries tool/prompt/resource overrides', async () => {
+    // The dashboard payload never sends `tools`/`prompts`/`resources` (they are
+    // edited via dedicated endpoints and applied at read time), but a server may
+    // well have such overrides persisted. If they stay part of the comparable
+    // config, any access-only edit of such a server (e.g. changing the sharing
+    // allowlist) tears down and reconnects the runtime for nothing.
+    mockRequest.body.config = {
+      type: 'stdio',
+      command: 'uvx',
+      args: ['--with', 'mcp<2', 'mcp-server-fetch'],
+      description: '',
+      options: { resetTimeoutOnProgress: true },
+      visibility: 'group',
+      sharedWithUsers: ['admin2', 'test2'],
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+      env: {},
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      enabled: true,
+      owner: 'admin',
+      type: 'stdio',
+      command: 'uvx',
+      args: ['--with', 'mcp<2', 'mcp-server-fetch'],
+      visibility: 'group',
+      options: { resetTimeoutOnProgress: true },
+      prompts: {
+        'test-server::fetch': {
+          enabled: true,
+          description: 'Custom prompt description',
+        },
+      },
+      sharedWithUsers: ['admin2', 'test'],
+    });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).toHaveBeenCalled();
+    expect(mockUpdateServerInfoVisibility).toHaveBeenCalledWith('test-server', 'group', [
+      'admin2',
+      'test2',
+    ]);
+    expect(mockBroadcastToolListChanged).toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server updated successfully',
+    });
+  });
+
+  it('does not reload the runtime for a description-only edit', async () => {
+    // The server description is read-time display metadata. Changing it (while
+    // every connection-relevant field stays the same) must not tear down and
+    // reconnect the runtime.
+    mockRequest.body.config = {
+      type: 'sse',
+      url: 'https://example.com/sse',
+      description: 'New note text',
+      visibility: 'private',
+      sharedWithUsers: undefined,
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      type: 'sse',
+      url: 'https://example.com/sse',
+      enabled: true,
+      owner: 'admin',
+      visibility: 'private',
+      description: 'Old note text',
+    });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).toHaveBeenCalled();
+    expect(mockUpdateServerInfoVisibility).toHaveBeenCalledWith('test-server', 'private', undefined);
+    expect(mockBroadcastToolListChanged).toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith({
+      success: true,
+      message: 'Server updated successfully',
+    });
+  });
+
+  it('reloads the runtime when a connection-relevant field changes', async () => {
+    // Changing the launch command is a real connection change and must go
+    // through the reload path (addOrUpdateServer + targeted reconnect).
+    mockRequest.body.config = {
+      type: 'stdio',
+      command: 'node',
+      args: ['server.js'],
+      description: '',
+      visibility: 'private',
+      sharedWithUsers: undefined,
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+      env: {},
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      type: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-fetch'],
+      enabled: true,
+      owner: 'admin',
+      visibility: 'private',
+    });
+    mockAddOrUpdateServer.mockResolvedValue({ success: true });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).not.toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).toHaveBeenCalledWith('test-server', expect.any(Object), true);
+    expect(mockNotifyToolChanged).toHaveBeenCalled();
+  });
+
+  it('does not reload when the stored config carries an explicit default timeout the payload omits', async () => {
+    // The old dashboard payload dropped `timeout` when it equaled the 60000
+    // default. A server persisted with an explicit `timeout: 60000` (e.g. via
+    // API/file import) would then differ from the payload on every edit and
+    // reload for nothing. An explicit default timeout and an absent one are the
+    // same effective connection setting.
+    mockRequest.body.config = {
+      type: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-fetch'],
+      description: '',
+      options: { resetTimeoutOnProgress: true },
+      visibility: 'private',
+      sharedWithUsers: undefined,
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+      env: {},
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      type: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-fetch'],
+      options: { timeout: 60000, resetTimeoutOnProgress: true },
+      enabled: true,
+      owner: 'admin',
+      visibility: 'private',
+    });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not reload when the payload echoes the default timeout onto a server without one', async () => {
+    // Mirror case: the (new) dashboard always echoes `timeout: 60000`, while a
+    // form-created server has no explicit timeout persisted. The comparison must
+    // treat them as equal too.
+    mockRequest.body.config = {
+      type: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-fetch'],
+      description: '',
+      options: { timeout: 60000, resetTimeoutOnProgress: true },
+      visibility: 'private',
+      sharedWithUsers: undefined,
+      perSessionClient: undefined,
+      startOnDemand: undefined,
+      idleTimeoutMs: undefined,
+      env: {},
+    };
+    mockServerDao.findById.mockResolvedValue({
+      name: 'test-server',
+      type: 'stdio',
+      command: 'uvx',
+      args: ['mcp-server-fetch'],
+      options: { resetTimeoutOnProgress: true },
+      enabled: true,
+      owner: 'admin',
+      visibility: 'private',
+    });
+
+    await updateServer(mockRequest as Request, mockResponse as Response);
+
+    expect(mockServerDao.update).toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+    expect(mockNotifyToolChanged).not.toHaveBeenCalled();
+  });
+
   describe('when renaming a server', () => {
     beforeEach(() => {
       mockServerDao.exists.mockResolvedValue(false);
@@ -889,6 +1174,15 @@ describe('serverController - updateServer', () => {
         success: true,
         message: 'Server renamed and updated successfully',
       });
+    });
+
+    it('closes the runtime still registered under the old name', async () => {
+      // addOrUpdateServer closes by the NEW name, which finds nothing - the
+      // runtime stays keyed by the old name until the rebuild drops it. Without
+      // an explicit close of the old name the stdio child process is orphaned.
+      await updateServer(mockRequest as Request, mockResponse as Response);
+
+      expect(mockCloseServer).toHaveBeenCalledWith('test-server');
     });
   });
 });


### PR DESCRIPTION
## Summary

Editing a server (even just its visibility, shared-user list, or description) was **tearing down and reconnecting the MCP runtime** because the "fast path" decision used a denylist-style comparison that never matched the real dashboard payload. This PR makes the edit fast path decide by what actually matters — whether a **connection-relevant field** changed — and fixes a rename leak and the masked frontend typecheck gap.

## Problem

The `updateServer` fast path compared "everything except name/visibility/sharedWithUsers" with `isDeepStrictEqual`. That failed to match in common cases:

- **`enabled` asymmetry** — the DAO persists `enabled: true` by default, but `buildServerPayload` never sends `enabled`. Every visibility-only edit therefore failed the check and reloaded.
- **`tools`/`prompts`/`resources` overrides** — read-time metadata the payload never echoes; any server with an override (e.g. a custom prompt description) reloaded on every edit.
- **First-guard short-circuit** — `currentAccess === nextAccess` returned `false` for description-only edits, forcing a reload for display metadata.
- **Default timeout** — a stored explicit `timeout: 60000` vs an absent one looked like a connection change because the default wasn't normalized.
- **Rename leak** — `addOrUpdateServer` closes by the *new* name (finds nothing), so the old runtime (including its stdio child process tree) was orphaned until restart.

## Changes

**Backend** (`src/controllers/serverController.ts`, `src/services/mcpService.ts`)
- Replace the denylist comparison with a **connection-relevant allowlist** (`type/url/command/args/env/headers/passthroughHeaders/options/oauth/openapi/perSessionClient/startOnDemand/idleTimeoutMs/enableKeepAlive/keepAliveInterval/proxy`); editing any other field now persists + updates in-memory access metadata without reloading.
- Normalize the default request timeout (`60000`) in the comparison so explicit vs absent are equivalent; a real change to e.g. `30000` still reloads.
- On rename, explicitly `closeServer` the old name (exported from `mcpService`) before the rebuild drops it — fixes the orphaned stdio process leak.

**Frontend payload** (`serverFormPayload.ts`, `ServerForm.tsx`, `types/index.ts`)
- `buildOptions` always echoes `timeout` (backend comparison normalizes the default, so this stays symmetric).
- `ServerFormData` round-trips the stored proxychains `proxy` config.
- Add the missing `startOnDemand`/`idleTimeoutMs` fields to the frontend `ServerConfig`/`ServerFormData` types.

**Frontend typecheck** (`tsconfig.json`, `Button.tsx`, `EmbeddingSyncContext.tsx`)
- Remove invalid `"ignoreDeprecations": "6.0"` (TS5103 on tsc 5.9.x) that was aborting the entire frontend typecheck.
- Fix the 16 errors it masked: `onClick` may return a `Promise`, and the type-guarded `progress` is dereferenced into a const so narrowing survives inside the `setTimeout` closure.

## Tests

- Added 7 regression tests to `tests/controllers/serverController.test.ts`: visibility-only, sharedWithUsers-only, description-only, stored-overrides, stored/default timeout (both directions), connection-field change → reload, and rename closes the old runtime. Updated the no-op edit case to assert the fast path.
- `tests/controllers/serverController.test.ts`: 41/41 pass.
- Full suite: 148 suites / 1044 tests pass (the `sse-service-real-client` integration test hangs in this environment and was excluded — pre-existing, unrelated).
- `pnpm lint`, `pnpm build`, and `tsc --noEmit -p frontend/tsconfig.json` all pass.
