### PR TITLE
fix(openapi): expose header parameters in generated MCP input schema

### DIFF
--- a/src/clients/__tests__/openapi-input-schema.test.ts
+++ b/src/clients/__tests__/openapi-input-schema.test.ts
@@ -165,4 +165,63 @@ describe('OpenAPIClient - Input Schema Generation', () => {
     expect(item.kind).toBe('tool');
     expect(item.cost).toBeGreaterThan(0);
   });
+  // Header parameters must reach the generated inputSchema. callTool() already
+  // reads `in: header` parameters back out of the tool arguments, but
+  // generateInputSchema only emitted path/query/body, so an operation whose
+  // per-call credential is a header (Authorization, X-API-Key, ...) was exposed
+  // to the model as a zero-argument tool with no way to supply it.
+  test('should expose header parameters in the generated input schema', async () => {
+    const config: ServerConfig = {
+      type: 'openapi',
+      openapi: {
+        schema: {
+          openapi: '3.0.0',
+          info: { title: 'Header API', version: '1.0.0' },
+          paths: {
+            '/bearer/protected': {
+              get: {
+                operationId: 'bearerProtected',
+                parameters: [
+                  {
+                    name: 'Authorization',
+                    in: 'header',
+                    required: true,
+                    description: 'Bearer token in the form: Bearer <accessToken>',
+                    schema: { type: 'string' },
+                  },
+                  {
+                    name: 'X-Tenant-Id',
+                    in: 'header',
+                    required: false,
+                    schema: { type: 'string' },
+                  },
+                ],
+                responses: { '200': { description: 'Success' } },
+              },
+            },
+          },
+        } as OpenAPIV3.Document,
+      },
+    };
+
+    const client = new OpenAPIClient(config);
+    await client.initialize();
+
+    const tool = client.getTools()[0];
+
+    expect(tool.inputSchema).toEqual({
+      type: 'object',
+      properties: {
+        Authorization: {
+          type: 'string',
+          description: 'Bearer token in the form: Bearer <accessToken>',
+        },
+        'X-Tenant-Id': {
+          type: 'string',
+          description: 'Header parameter: X-Tenant-Id',
+        },
+      },
+      required: ['Authorization'],
+    });
+  });
 });

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -531,6 +531,26 @@ export class OpenAPIClient {
       }
     }
 
+    // Handle header parameters. callTool() already copies `in: header`
+    // arguments into the outgoing request, so they must be advertised here too,
+    // otherwise an operation whose per-call credential is a header is exposed
+    // as a zero-argument tool the model cannot supply a value for.
+    const headerParams = operation.parameters?.filter(
+      (p: any) => 'in' in p && p.in === 'header',
+    ) as OpenAPIV3.ParameterObject[];
+
+    if (headerParams?.length) {
+      for (const param of headerParams) {
+        properties[param.name] = this.generateParameterSchema(
+          param,
+          `Header parameter: ${param.name}`,
+        );
+        if (param.required) {
+          required.push(param.name);
+        }
+      }
+    }
+
     // Handle request body
     if (operation.requestBody && 'content' in operation.requestBody) {
       const requestBody = operation.requestBody as OpenAPIV3.RequestBodyObject;


### PR DESCRIPTION
Fixes #1057.

### Problem

`OpenAPIClient.generateInputSchema()` builds the MCP tool `inputSchema` from `in: path`, `in: query` and `requestBody`, but silently skips `in: header` parameters. `callTool()` already does the opposite — it filters `tool.parameters` for `p.in === 'header'` and copies matching values out of `args` into the outgoing request headers.

So a header argument is honoured if it is passed, but it is never advertised. An operation whose per-call credential is a header (`Authorization`, `X-API-Key`, `X-Tenant-Id`, …) reaches the model as a zero-argument tool that it has no way to supply a value for. Static credentials in `openapi.security` do not cover this case, because the value is obtained at runtime — typically from a preceding `login` operation in the same MCP session — and differs per call.

### Change

Add a header branch to `generateInputSchema()` mirroring the existing query branch, and a regression test covering one required and one optional header parameter.

### Verification

Ran against a live instance (`samanhappy/mcphub:1.0.29`, whose `src/clients/openapi.ts` is byte-identical to `main`). Nothing but this function was changed — the OpenAPI spec, the MCPHub server config and the target API were untouched.

The new test fails on unpatched code for the expected reason:

```
✕ should expose header parameters in the generated input schema
  - Expected: properties: { Authorization: {…}, X-Tenant-Id: {…} }, required: ['Authorization']
  + Received: properties: {}, required: []
```

With the fix applied:

```
Test Suites: 8 passed, 8 total
Tests:      44 passed, 44 total    (src/clients/)
```

End-to-end after rebuilding and restarting, `tools/list` reports (previously `"properties": {}`):

```json
{ "name": "auth-test-bearerProtected",
  "inputSchema": {
    "type": "object",
    "properties": {
      "Authorization": {
        "anyOf": [{ "type": "string" }, { "type": "null" }],
        "description": "Bearer token in the form: Bearer <accessToken>",
        "title": "Authorization"
      }
    },
    "required": []
  } }
```

| check | result |
|---|---|
| `bearerProtected` with `Authorization` (now declared) | ✅ `authType: bearer` |
| `bearerProtected` with no token | ✅ still 401 — the change does not weaken auth |
| `cookieLogin` → `cookieProtected` | ✅ unaffected |
| `cookieProtected` inputSchema | ✅ still empty — operations without header params are untouched |

### Note

Operations that declare boilerplate headers (`Accept`, `Content-Type`, …) as explicit parameters will now surface them as tool arguments. That is consistent with how query parameters are already treated — the schema reflects what the spec declares — but if you would prefer a denylist for well-known transport headers, I am happy to add one.
