### PR TITLE
fix(security): require full containment for scoped bearer keys on group routes (GHSA-454m-4vm6-842f)

### DIFF
--- a/src/services/sseService.test.ts
+++ b/src/services/sseService.test.ts
@@ -403,11 +403,13 @@ describe('sseService', () => {
       });
 
       (getGroupDao as jest.MockedFunction<any>).mockReturnValueOnce({
-        findByName: jest.fn().mockImplementation((name: string) =>
-          name === 'my-group'
-            ? Promise.resolve({ id: 'my-group-id', name: 'my-group', servers: [] })
-            : Promise.resolve(null),
-        ),
+        findByName: jest
+          .fn()
+          .mockImplementation((name: string) =>
+            name === 'my-group'
+              ? Promise.resolve({ id: 'my-group-id', name: 'my-group', servers: [] })
+              : Promise.resolve(null),
+          ),
         findById: jest.fn().mockResolvedValue(null),
       });
 
@@ -730,11 +732,13 @@ describe('sseService', () => {
 
       // Override group DAO so isBearerKeyAllowedForRequest can find the group for this test only
       (getGroupDao as jest.MockedFunction<any>).mockReturnValueOnce({
-        findByName: jest.fn().mockImplementation((name: string) =>
-          name === 'my-group'
-            ? Promise.resolve({ id: 'group-uuid', name: 'my-group', servers: [] })
-            : Promise.resolve(null),
-        ),
+        findByName: jest
+          .fn()
+          .mockImplementation((name: string) =>
+            name === 'my-group'
+              ? Promise.resolve({ id: 'group-uuid', name: 'my-group', servers: [] })
+              : Promise.resolve(null),
+          ),
         findById: jest.fn().mockResolvedValue(null),
       });
 
@@ -1013,6 +1017,127 @@ describe('sseService', () => {
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.end).toHaveBeenCalled();
       expect(StreamableHTTPServerTransport).not.toHaveBeenCalled();
+    });
+
+    describe('bearer key group scope escalation (GHSA-454m-4vm6-842f)', () => {
+      // Regression tests for the "any-overlap" group authorization flaw:
+      // a servers/custom-scoped bearer key must NOT gain access to every server
+      // in a group just because one group member appears in allowedServers.
+      const postToTeamGroup = async (key: Record<string, unknown>) => {
+        (getBearerKeyDao as jest.MockedFunction<any>).mockReturnValueOnce({
+          findEnabled: jest.fn().mockResolvedValue([key]),
+        });
+        (getGroupDao as jest.MockedFunction<any>).mockReturnValueOnce({
+          findByName: jest.fn().mockImplementation((name: string) =>
+            name === 'team-group'
+              ? Promise.resolve({
+                  id: 'team-group-uuid',
+                  name: 'team-group',
+                  servers: ['public-server', 'secret-server'],
+                })
+              : Promise.resolve(null),
+          ),
+          findById: jest.fn().mockResolvedValue(null),
+        });
+
+        setMockSystemConfig({
+          routing: {
+            enableGlobalRoute: true,
+            enableGroupNameRoute: true,
+            enableBearerAuth: true,
+            bearerAuthKey: 'scoped-token',
+            skipAuth: false,
+          },
+          enableSessionRebuild: false,
+        });
+
+        const req = createMockRequest({
+          params: { group: 'team-group' },
+          body: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+          headers: { authorization: 'Bearer scoped-token' },
+        });
+        const res = createMockResponse();
+
+        await handleMcpPostRequest(req, res);
+        return res;
+      };
+
+      const scopedKey = (overrides: Record<string, unknown> = {}) => ({
+        id: 'key-1',
+        name: 'contractor-key',
+        token: 'scoped-token',
+        enabled: true,
+        accessType: 'servers',
+        allowedGroups: [],
+        allowedServers: ['public-server'],
+        ...overrides,
+      });
+
+      it('denies a servers-scoped key access to a group containing a non-allowed server', async () => {
+        // Key is only granted public-server, but team-group also contains secret-server.
+        const res = await postToTeamGroup(scopedKey());
+        expectBearerUnauthorized(res, 'Invalid bearer token');
+      });
+
+      it('denies a custom-scoped key whose allowedServers overlap only partially with a group', async () => {
+        const res = await postToTeamGroup(scopedKey({ accessType: 'custom', allowedGroups: [] }));
+        expectBearerUnauthorized(res, 'Invalid bearer token');
+      });
+
+      it('allows a servers-scoped key when every server in the group is allowed', async () => {
+        const res = await postToTeamGroup(
+          scopedKey({ allowedServers: ['public-server', 'secret-server'] }),
+        );
+        expect(res.status).not.toHaveBeenCalledWith(401);
+      });
+
+      it('allows a custom-scoped key when the group itself is in allowedGroups', async () => {
+        const res = await postToTeamGroup(
+          scopedKey({
+            accessType: 'custom',
+            allowedGroups: ['team-group'],
+            allowedServers: [],
+          }),
+        );
+        expect(res.status).not.toHaveBeenCalledWith(401);
+      });
+
+      it('denies a servers-scoped key for an empty group (no servers to contain)', async () => {
+        (getBearerKeyDao as jest.MockedFunction<any>).mockReturnValueOnce({
+          findEnabled: jest.fn().mockResolvedValue([scopedKey()]),
+        });
+        (getGroupDao as jest.MockedFunction<any>).mockReturnValueOnce({
+          findByName: jest
+            .fn()
+            .mockImplementation((name: string) =>
+              name === 'empty-group'
+                ? Promise.resolve({ id: 'empty-group-uuid', name: 'empty-group', servers: [] })
+                : Promise.resolve(null),
+            ),
+          findById: jest.fn().mockResolvedValue(null),
+        });
+
+        setMockSystemConfig({
+          routing: {
+            enableGlobalRoute: true,
+            enableGroupNameRoute: true,
+            enableBearerAuth: true,
+            bearerAuthKey: 'scoped-token',
+            skipAuth: false,
+          },
+          enableSessionRebuild: false,
+        });
+
+        const req = createMockRequest({
+          params: { group: 'empty-group' },
+          body: { jsonrpc: '2.0', method: 'tools/list', id: 1 },
+          headers: { authorization: 'Bearer scoped-token' },
+        });
+        const res = createMockResponse();
+
+        await handleMcpPostRequest(req, res);
+        expectBearerUnauthorized(res, 'Invalid bearer token');
+      });
     });
   });
 

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -196,7 +196,9 @@ const isBearerKeyAllowedForRequest = async (req: Request, key: BearerKey): Promi
       }
 
       if (key.accessType === 'servers') {
-        // For server-scoped keys, check if any server in the group is allowed
+        // For server-scoped keys, the group is only accessible when every
+        // server in it is allowed (full containment). A key scoped to one
+        // group member must not gain access to the whole group (GHSA-454m-4vm6-842f).
         const allowedServers = key.allowedServers || [];
         if (allowedServers.length === 0) {
           return false;
@@ -209,7 +211,10 @@ const isBearerKeyAllowedForRequest = async (req: Request, key: BearerKey): Promi
         const groupServerNames = matchedGroup.servers.map((server) =>
           typeof server === 'string' ? server : server.name,
         );
-        return groupServerNames.some((name) => allowedServers.includes(name));
+        if (groupServerNames.length === 0) {
+          return false;
+        }
+        return groupServerNames.every((name) => allowedServers.includes(name));
       }
 
       if (key.accessType === 'custom') {
@@ -224,12 +229,17 @@ const isBearerKeyAllowedForRequest = async (req: Request, key: BearerKey): Promi
           return true;
         }
 
-        // Check if any server in the group is allowed
+        // Check if any server in the group is allowed. Require full
+        // containment: a key scoped to one group member must not gain access
+        // to the whole group (GHSA-454m-4vm6-842f).
         if (allowedServers.length > 0 && Array.isArray(matchedGroup.servers)) {
           const groupServerNames = matchedGroup.servers.map((server) =>
             typeof server === 'string' ? server : server.name,
           );
-          return groupServerNames.some((name) => allowedServers.includes(name));
+          if (groupServerNames.length === 0) {
+            return false;
+          }
+          return groupServerNames.every((name) => allowedServers.includes(name));
         }
 
         return false;
@@ -270,10 +280,7 @@ const isBearerKeyAllowedForRequest = async (req: Request, key: BearerKey): Promi
   }
 };
 
-const resolveUserLevelKeyUser = async (
-  req: Request,
-  key: BearerKey,
-): Promise<BearerAuthResult> => {
+const resolveUserLevelKeyUser = async (req: Request, key: BearerKey): Promise<BearerAuthResult> => {
   if (key.kind !== 'user') {
     return { valid: true, keyId: key.id, keyName: key.name, kind: key.kind || 'system' };
   }
@@ -743,18 +750,14 @@ async function createSessionWithId(
   await server.connect(transport);
 
   if (!rehydrateRebuiltTransport(transport, sessionId)) {
-    console.error(
-      `[SESSION REBUILD] Failed to rehydrate transport state for session ${sessionId}`,
-    );
+    console.error(`[SESSION REBUILD] Failed to rehydrate transport state for session ${sessionId}`);
     await transport.close();
     throw new Error('Failed to rebuild session transport state');
   }
 
   transports[sessionId] = { transport, group, hostedAuth };
 
-  console.log(
-    `[SESSION REBUILD] Rehydrated session ${sessionId} for immediate request handling.`,
-  );
+  console.log(`[SESSION REBUILD] Rehydrated session ${sessionId} for immediate request handling.`);
 
   console.log(`[SESSION REBUILD] Successfully rebuilt session ${sessionId} in group: ${group}`);
   return transport;


### PR DESCRIPTION
## Summary

Fixes **GHSA-454m-4vm6-842f** (High, CWE-863): a bearer key scoped to specific servers (`accessType: 'servers'` or `'custom'`) gained access to an **entire group** as long as **any single server** in that group appeared in the key's `allowedServers` — including servers the key was never authorized for.

`isBearerKeyAllowedForRequest` in `src/services/sseService.ts` used an "any-overlap" (`Array.some`) check when matching a server-scoped key against a group route (`/mcp/:group`), and the group's servers were never re-filtered by `allowedServers` downstream.

## Changes

### `src/services/sseService.ts`
- `accessType === 'servers'` branch: group access now requires **full containment** — every server in the group must be in `allowedServers` (`Array.every`), replacing the `Array.some` any-overlap check.
- `accessType === 'custom'` branch: the server-matching half now applies the same full-containment rule; the `allowedGroups` direct-match path is unchanged.
- Empty groups fail closed (an empty `groupServerNames` array no longer grants access — `every()` on an empty array returns `true`, so it is explicitly rejected).

```diff
- return groupServerNames.some((name) => allowedServers.includes(name));
+ if (groupServerNames.length === 0) {
+   return false;
+ }
+ return groupServerNames.every((name) => allowedServers.includes(name));
```

Behavior is fail-closed: a key scoped to `{A}` cannot reach a group `{A, B}` at all (rather than getting a reduced `A`-only view). This is the conservative, least-privilege option recommended by the advisory.

## Tests

New regression suite `bearer key group scope escalation (GHSA-454m-4vm6-842f)` in `src/services/sseService.test.ts` (5 cases, driving the real `handleMcpPostRequest → validateBearerAuth → isBearerKeyAllowedForRequest` path with the DAO layer mocked):

| Scenario | Expected |
|---|---|
| servers-scoped key + group containing a non-allowed server | 401 (was: authorized — the bug) |
| custom-scoped key with partial `allowedServers` overlap | 401 (was: authorized — the bug) |
| servers-scoped key covering every group server | allowed |
| custom-scoped key with the group itself in `allowedGroups` | allowed |
| servers-scoped key + empty group | 401 (fail-closed guard) |

### Validation
- `pnpm jest src/services/sseService.test.ts` — 37/37 pass
- `pnpm lint` — pass
- `pnpm backend:build` (`tsc`) — pass
- `pnpm test:ci` — 148/149 suites pass; the only failure is `tests/integration/sse-service-real-client.test.ts`, a **pre-existing environment timeout** (spins up a real server + real MCP clients; reproduces on clean `main` without these changes).
- Prettier/ESLint clean on both changed files.
