### PR TITLE
feat(oauth): render consent screen inside the React dashboard (SPA)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import EmbeddingSyncAlertListener from './components/EmbeddingSyncAlertListener'
 import { getBasePath } from './utils/runtime';
 
 const LoginPage = lazy(() => import('./pages/LoginPage'));
+const OAuthConsentPage = lazy(() => import('./pages/OAuthConsentPage'));
 const DashboardPage = lazy(() => import('./pages/Dashboard'));
 const ServersPage = lazy(() => import('./pages/ServersPage'));
 const GroupsPage = lazy(() => import('./pages/GroupsPage'));
@@ -51,6 +52,17 @@ function App() {
                     element={
                       <Suspense fallback={<RouteFallback />}>
                         <LoginPage />
+                      </Suspense>
+                    }
+                  />
+
+                  {/* OAuth consent screen: server injects the consent context
+                      into the SPA shell served at /oauth/authorize */}
+                  <Route
+                    path="/oauth/authorize"
+                    element={
+                      <Suspense fallback={<RouteFallback />}>
+                        <OAuthConsentPage />
                       </Suspense>
                     }
                   />

--- a/frontend/src/pages/OAuthConsentPage.tsx
+++ b/frontend/src/pages/OAuthConsentPage.tsx
@@ -1,0 +1,223 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertCircle } from 'lucide-react';
+import { getBasePath } from '../utils/runtime';
+import ThemeSwitch from '@/components/ui/ThemeSwitch';
+import LanguageSwitch from '@/components/ui/LanguageSwitch';
+import type { OAuthConsentContext } from '../types/runtime';
+
+/**
+ * OAuth consent screen, booted inside the dashboard SPA by the shell the
+ * backend serves at GET /oauth/authorize (context injected into
+ * window.__OAUTH_CONSENT_CONTEXT__). The server has already validated the
+ * request and resolved the user, so this page only renders the payload and
+ * POSTs the decision back to /oauth/authorize.
+ */
+const OAuthConsentPage: React.FC = () => {
+  const { t } = useTranslation();
+
+  const context = useMemo<OAuthConsentContext | null>(
+    () => window.__OAUTH_CONSENT_CONTEXT__ ?? null,
+    [],
+  );
+
+  const postUrl = `${getBasePath()}/oauth/authorize`;
+
+  const hiddenInputs = (allow: string): React.ReactNode => {
+    if (!context) return null;
+    return (
+      <>
+        <input type="hidden" name="client_id" value={context.clientId} />
+        <input type="hidden" name="redirect_uri" value={context.redirectUri} />
+        <input type="hidden" name="response_type" value={context.responseType} />
+        <input type="hidden" name="scope" value={context.scope} />
+        {context.state ? <input type="hidden" name="state" value={context.state} /> : null}
+        {context.codeChallenge ? (
+          <input type="hidden" name="code_challenge" value={context.codeChallenge} />
+        ) : null}
+        {context.codeChallengeMethod ? (
+          <input type="hidden" name="code_challenge_method" value={context.codeChallengeMethod} />
+        ) : null}
+        {context.token ? <input type="hidden" name="token" value={context.token} /> : null}
+        <input type="hidden" name="allow" value={allow} />
+      </>
+    );
+  };
+
+  if (!context) {
+    return (
+      <div
+        className="relative min-h-screen w-full overflow-hidden"
+        style={{ background: 'var(--hub-bg)', color: 'var(--hub-ink)' }}
+      >
+        <div className="relative mx-auto flex min-h-screen w-full max-w-md items-center justify-center px-6">
+          <div className="hub-card w-full" style={{ padding: '22px' }}>
+            <div className="flex items-center gap-2" style={{ color: 'var(--hub-err)' }}>
+              <AlertCircle size={16} className="flex-shrink-0" />
+              <h1 className="hub-h1" style={{ fontSize: 15 }}>
+                {t('oauthServer.requestInvalidTitle')}
+              </h1>
+            </div>
+            <p className="hub-sub" style={{ marginTop: 8 }}>
+              {t('oauthServer.requestInvalid')}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="relative min-h-screen w-full overflow-hidden"
+      style={{ background: 'var(--hub-bg)', color: 'var(--hub-ink)' }}
+    >
+      {/* Top-right controls, matching the login screen */}
+      <div className="absolute top-3 right-4 z-20 flex items-center gap-1">
+        <ThemeSwitch />
+        <LanguageSwitch />
+      </div>
+
+      <div className="relative mx-auto flex min-h-screen w-full max-w-md items-center justify-center px-6">
+        <div className="w-full space-y-6">
+          {/* Brand */}
+          <div className="flex flex-col items-center gap-3">
+            <div
+              className="relative grid place-items-center"
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 10,
+                background: 'var(--hub-ink)',
+                color: 'white',
+              }}
+            >
+              <span className="hub-mono font-semibold" style={{ fontSize: 18 }}>
+                M
+              </span>
+            </div>
+            <div className="text-center">
+              <h1
+                style={{
+                  fontSize: 20,
+                  fontWeight: 600,
+                  letterSpacing: '-0.02em',
+                  color: 'var(--hub-ink)',
+                }}
+              >
+                {t('oauthServer.authorizeTitle')}
+              </h1>
+              <p className="hub-sub" style={{ marginTop: 4 }}>
+                {t('oauthServer.authorizeSubtitle')}
+              </p>
+            </div>
+          </div>
+
+          {/* Consent card */}
+          <div className="hub-card" style={{ padding: '22px 22px 20px' }}>
+            {/* Client box */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 4,
+                padding: '12px 14px',
+                borderRadius: 10,
+                background: 'var(--hub-bg-2)',
+                border: '1px solid var(--hub-line)',
+              }}
+            >
+              <span className="hub-sect">{t('oauthServer.application')}</span>
+              <span style={{ fontWeight: 600, fontSize: 15, color: 'var(--hub-ink)' }}>
+                {context.clientName}
+              </span>
+            </div>
+
+            {/* Scopes */}
+            <div style={{ marginTop: 18 }}>
+              <div className="hub-sect" style={{ marginBottom: 4 }}>
+                {t('oauthServer.scopesTitle')}
+              </div>
+              {context.scopes.length === 0 ? (
+                <p className="hub-sub" style={{ marginTop: 8 }}>
+                  {t('oauthServer.noScopes')}
+                </p>
+              ) : (
+                <div className="hub-divider">
+                  {context.scopes.map((scope) => (
+                    <div key={scope.name} style={{ padding: '10px 0' }}>
+                      <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--hub-ink)' }}>
+                        <span className="hub-mono">{scope.name}</span>
+                      </div>
+                      <div style={{ fontSize: 12.5, color: 'var(--hub-ink-2)', marginTop: 2 }}>
+                        {scope.description}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Approve / deny */}
+            <div style={{ marginTop: 22, display: 'flex', gap: 10 }}>
+              <form method="POST" action={postUrl} style={{ flex: 1 }}>
+                {hiddenInputs('true')}
+                <button
+                  type="submit"
+                  className="hub-btn primary w-full justify-center"
+                  style={{
+                    height: 'auto',
+                    minHeight: 40,
+                    padding: '8px 12px',
+                    flexDirection: 'column',
+                    gap: 1,
+                  }}
+                >
+                  <span style={{ lineHeight: 1.3 }}>{t('oauthServer.buttons.approve')}</span>
+                  <span
+                    style={{
+                      fontSize: 10.5,
+                      lineHeight: 1.3,
+                      opacity: 0.8,
+                      color: 'inherit',
+                    }}
+                  >
+                    {t('oauthServer.buttons.approveSubtitle')}
+                  </span>
+                </button>
+              </form>
+              <form method="POST" action={postUrl} style={{ flex: 1 }}>
+                {hiddenInputs('false')}
+                <button
+                  type="submit"
+                  className="hub-btn danger w-full justify-center"
+                  style={{
+                    height: 'auto',
+                    minHeight: 40,
+                    padding: '8px 12px',
+                    flexDirection: 'column',
+                    gap: 1,
+                  }}
+                >
+                  <span style={{ lineHeight: 1.3 }}>{t('oauthServer.buttons.deny')}</span>
+                  <span
+                    style={{
+                      fontSize: 10.5,
+                      lineHeight: 1.3,
+                      opacity: 0.75,
+                      color: 'inherit',
+                    }}
+                  >
+                    {t('oauthServer.buttons.denySubtitle')}
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OAuthConsentPage;

--- a/frontend/src/types/runtime.ts
+++ b/frontend/src/types/runtime.ts
@@ -5,10 +5,28 @@ export interface RuntimeConfig {
   name: string;
 }
 
+// Consent context injected by the backend into the SPA shell at
+// /oauth/authorize. The server has already validated the OAuth request and
+// resolved the authenticated user before building this; the SPA only renders
+// what it is given and echoes the fields back on the decision POST.
+export interface OAuthConsentContext {
+  clientName: string;
+  scopes: { name: string; description: string }[];
+  clientId: string;
+  redirectUri: string;
+  responseType: string;
+  scope: string;
+  state?: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  token?: string;
+}
+
 // Extend Window interface to include runtime config
 declare global {
   interface Window {
     __MCPHUB_CONFIG__?: RuntimeConfig;
+    __OAUTH_CONSENT_CONTEXT__?: OAuthConsentContext;
   }
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -512,7 +512,12 @@
       "deny": "Deny",
       "approveSubtitle": "Recommended if you trust this application.",
       "denySubtitle": "You can always grant access later."
-    }
+    },
+    "application": "Application",
+    "scopesTitle": "This application will be able to:",
+    "noScopes": "No permissions requested.",
+    "requestInvalidTitle": "Request invalid",
+    "requestInvalid": "This authorization request is invalid or has expired. Please go back and try again."
   },
   "cloud": {
     "title": "Cloud Support",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -511,7 +511,12 @@
       "deny": "Refuser",
       "approveSubtitle": "Recommandé si vous faites confiance à cette application.",
       "denySubtitle": "Vous pourrez toujours accorder l'accès plus tard."
-    }
+    },
+    "application": "Application",
+    "scopesTitle": "Cette application pourra :",
+    "noScopes": "Aucune autorisation demandée.",
+    "requestInvalidTitle": "Demande invalide",
+    "requestInvalid": "Cette demande d'autorisation est invalide ou a expiré. Veuillez revenir en arrière et réessayer."
   },
   "cloud": {
     "title": "Support Cloud",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -511,7 +511,12 @@
       "deny": "Reddet",
       "approveSubtitle": "Bu uygulamaya güveniyorsanız izin vermeniz önerilir.",
       "denySubtitle": "İstediğiniz zaman daha sonra erişim verebilirsiniz."
-    }
+    },
+    "application": "Uygulama",
+    "scopesTitle": "Bu uygulama şunları yapabilecek:",
+    "noScopes": "İzin istenmedi.",
+    "requestInvalidTitle": "Geçersiz istek",
+    "requestInvalid": "Bu yetkilendirme isteği geçersiz veya süresi dolmuş. Lütfen geri dönüp tekrar deneyin."
   },
   "cloud": {
     "title": "Bulut Desteği",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -514,7 +514,12 @@
       "deny": "拒绝",
       "approveSubtitle": "如果您信任此应用，建议选择允许。",
       "denySubtitle": "您可以在之后随时再次授权。"
-    }
+    },
+    "application": "应用程序",
+    "scopesTitle": "此应用程序将能够：",
+    "noScopes": "未请求任何权限。",
+    "requestInvalidTitle": "请求无效",
+    "requestInvalid": "此授权请求无效或已过期。请返回后重试。"
   },
   "cloud": {
     "title": "云端支持",

--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -12,6 +12,10 @@ import { JWT_SECRET } from '../config/jwt.js';
 import { resolveBetterAuthUser } from '../services/betterAuthSession.js';
 import { cloneDefaultOAuthServerConfig } from '../constants/oauthServerDefaults.js';
 import { resolveInstallBaseUrl } from '../utils/installBaseUrl.js';
+import {
+  injectOAuthConsentShell,
+  type OAuthConsentContext,
+} from '../utils/frontendShell.js';
 
 const { Request: OAuth2Request, Response: OAuth2Response } = OAuth2Server;
 
@@ -341,6 +345,32 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
       ${code_challenge_method ? `<input type="hidden" name="code_challenge_method" value="${escapeHtml(code_challenge_method)}" />` : ''}
       ${tokenField}
     `;
+
+    // Build the structured consent context handed to the React SPA. The server
+    // has already validated the request and resolved the authenticated user, so
+    // the SPA only renders this payload (never re-resolves auth).
+    const consentContext: OAuthConsentContext = {
+      clientName: client.name || '',
+      scopes,
+      clientId: client_id,
+      redirectUri: redirect_uri,
+      responseType: response_type,
+      scope: scope || '',
+      state: state || undefined,
+      codeChallenge: code_challenge || undefined,
+      codeChallengeMethod: code_challenge_method || undefined,
+      token: requestToken || undefined,
+    };
+
+    // Serve the consent screen inside the React dashboard (SPA shell) when the
+    // frontend build is available, so it shares the dashboard's visual
+    // language, i18n and dark mode. Fall back to the legacy inline page when
+    // the frontend is not deployed (e.g. DISABLE_WEB / headless installs).
+    const shell = injectOAuthConsentShell(consentContext);
+    if (shell) {
+      res.type('html').send(shell);
+      return;
+    }
 
     // Render authorization consent page with consistent, localized styling
     res.send(

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { initOAuthProvider, getOAuthRouter } from './services/oauthService.js';
 import { initOAuthServer } from './services/oauthServerService.js';
 import { safeStringify } from './utils/serialization.js';
 import { resolveTrustProxySetting } from './utils/proxyTrust.js';
+import { setFrontendDistPath } from './utils/frontendShell.js';
 import http from 'http';
 import type { Socket } from 'net';
 import { mcpConnectionRateLimiter } from './utils/rateLimit.js';
@@ -185,6 +186,9 @@ export class AppServer {
 
     // Find frontend path
     this.frontendPath = this.findFrontendDistPath();
+    // Register the discovered SPA build so server-rendered pages (e.g. the
+    // OAuth consent screen) can boot the shell with injected context.
+    setFrontendDistPath(this.frontendPath);
 
     if (this.frontendPath) {
       console.log('Serving frontend', JSON.stringify({ frontendPath: this.frontendPath }));

--- a/src/utils/frontendShell.ts
+++ b/src/utils/frontendShell.ts
@@ -1,0 +1,118 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Shared holder for the frontend dist directory.
+ *
+ * `AppServer.findAndServeFrontend()` discovers the built SPA at startup and
+ * registers it here so server-rendered endpoints (e.g. the OAuth consent
+ * screen) can boot the SPA shell with extra context injected. Kept out of
+ * `server.ts` to avoid the controller depending on the server class.
+ */
+let frontendDistPath: string | null = null;
+
+export const setFrontendDistPath = (value: string | null): void => {
+  frontendDistPath = value;
+};
+
+export const getFrontendDistPath = (): string | null => frontendDistPath;
+
+/**
+ * Data the OAuth consent screen needs to render. This is the security-relevant
+ * payload the server hands to the React SPA: the server has already validated
+ * the request and resolved the authenticated user before this is built, and the
+ * SPA only renders what it is given.
+ */
+export type OAuthConsentContext = {
+  clientName: string;
+  scopes: { name: string; description: string }[];
+  // Fields echoed back on the POST to /oauth/authorize so the decision is bound
+  // to the exact request that was authorized.
+  clientId: string;
+  redirectUri: string;
+  responseType: string;
+  scope: string;
+  state?: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  token?: string;
+};
+
+/**
+ * Escape a value for use inside a double-quoted HTML attribute.
+ */
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Inject the OAuth consent context into the built SPA shell and return the
+ * resulting HTML document, or `null` when no frontend build is available.
+ *
+ * Two things must be injected:
+ *
+ * - A `<base>` element as the first child of `<head>`. The SPA's built
+ *   `index.html` references assets with relative paths (`./assets/...`), which
+ *   resolve against the current URL. `/oauth/authorize` lives in a non-root
+ *   directory, so without `<base>` every asset request would 404. The base
+ *   must be the first element in `<head>` so it applies to the script/link
+ *   tags that follow it.
+ *
+ * - The consent context as an inline script (`</script>` is neutralized to
+ *   avoid breaking out of the script element). The SPA reads it from
+ *   `window.__OAUTH_CONSENT_CONTEXT__` when rendering the consent page.
+ */
+export function injectOAuthConsentShell(context: OAuthConsentContext): string | null {
+  if (!frontendDistPath) {
+    return null;
+  }
+
+  const indexPath = path.join(frontendDistPath, 'index.html');
+  if (!fs.existsSync(indexPath)) {
+    return null;
+  }
+
+  let html: string;
+  try {
+    html = fs.readFileSync(indexPath, 'utf8');
+  } catch (error) {
+    console.warn('Failed to read frontend index.html for OAuth consent shell:', error);
+    return null;
+  }
+
+  // BASE_PATH mirrors src/config/index.ts (the only source of basePath).
+  const basePath = process.env.BASE_PATH || '';
+  const baseHref = `${basePath}/`;
+  const baseTag = `<base href="${escapeHtmlAttribute(baseHref)}">`;
+
+  // Neutralize `</script>` / `<!--` so the serialized context cannot break out
+  // of the inline script element.
+  const safeJson = JSON.stringify(context).replace(/</g, '\\u003c');
+  const contextScript = `<script>window.__OAUTH_CONSENT_CONTEXT__ = ${safeJson};</script>`;
+
+  // `<base>` must precede every relative resource reference, so place it
+  // directly after the opening <head> tag (index.html uses a plain `<head>`).
+  const headRe = /<head([^>]*)>/i;
+  const headMatch = html.match(headRe);
+  if (headMatch) {
+    const headTag = headMatch[0];
+    html = html.replace(headTag, `${headTag}${baseTag}`);
+  }
+
+  // Inject the context script at the end of <head>, before the deferred module
+  // entry executes, so the SPA always sees it after boot.
+  const headCloseRe = /<\/head>/i;
+  const headCloseMatch = html.match(headCloseRe);
+  if (headCloseMatch) {
+    html = html.replace(headCloseRe, `${contextScript}</head>`);
+  } else {
+    // Defensive: no closing head tag, append before </body>.
+    html = html.replace(/<\/body>/i, `${contextScript}</body>`);
+  }
+
+  return html;
+}

--- a/tests/controllers/oauthServerController.shell.test.ts
+++ b/tests/controllers/oauthServerController.shell.test.ts
@@ -1,0 +1,167 @@
+jest.mock('../../src/services/oauthServerService.js', () => ({
+  getOAuthServer: jest.fn(),
+  handleTokenRequest: jest.fn(),
+  handleAuthenticateRequest: jest.fn(),
+}));
+
+jest.mock('../../src/models/OAuth.js', () => ({
+  findOAuthClientById: jest.fn(),
+}));
+
+jest.mock('../../src/services/betterAuthSession.js', () => ({
+  resolveBetterAuthUser: jest.fn(),
+}));
+
+jest.mock('../../src/utils/frontendShell.js', () => ({
+  injectOAuthConsentShell: jest.fn(),
+}));
+
+import { getAuthorize } from '../../src/controllers/oauthServerController.js';
+import { getOAuthServer } from '../../src/services/oauthServerService.js';
+import { findOAuthClientById } from '../../src/models/OAuth.js';
+import { resolveBetterAuthUser } from '../../src/services/betterAuthSession.js';
+import { injectOAuthConsentShell } from '../../src/utils/frontendShell.js';
+
+type MockResponse = {
+  status: jest.Mock;
+  json: jest.Mock;
+  redirect: jest.Mock;
+  type: jest.Mock;
+  send: jest.Mock;
+};
+
+const createResponse = (): MockResponse => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    redirect: jest.fn().mockReturnThis(),
+    type: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  };
+
+  return res;
+};
+
+const createRequest = (overrides: Record<string, unknown> = {}) => ({
+  query: {
+    client_id: 'trusted-client',
+    redirect_uri: 'https://trusted.example.com/callback',
+    response_type: 'code',
+    scope: 'read write',
+  },
+  body: {},
+  header: jest.fn().mockReturnValue(undefined),
+  originalUrl: '/oauth/authorize?client_id=trusted-client',
+  t: (key: string) => key,
+  ...overrides,
+});
+
+describe('oauthServerController getAuthorize consent shell', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getOAuthServer as jest.Mock).mockReturnValue({});
+
+    (findOAuthClientById as jest.Mock).mockResolvedValue({
+      clientId: 'trusted-client',
+      name: 'Trusted Client',
+      redirectUris: ['https://trusted.example.com/callback'],
+    });
+
+    (resolveBetterAuthUser as jest.Mock).mockResolvedValue({
+      username: 'alice',
+      isAdmin: false,
+    });
+  });
+
+  it('serves the SPA consent shell with the injected consent context when the frontend build is available', async () => {
+    (injectOAuthConsentShell as jest.Mock).mockReturnValue(
+      '<html><body data-test="shell">SPA consent shell</body></html>',
+    );
+
+    const req = createRequest();
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    expect(injectOAuthConsentShell).toHaveBeenCalledTimes(1);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context).toMatchObject({
+      clientName: 'Trusted Client',
+      clientId: 'trusted-client',
+      redirectUri: 'https://trusted.example.com/callback',
+      responseType: 'code',
+      scope: 'read write',
+    });
+    expect(context.scopes).toEqual([
+      { name: 'read', description: 'Read access to your MCP servers and tools' },
+      { name: 'write', description: 'Execute tools and modify MCP server configurations' },
+    ]);
+
+    expect(res.type).toHaveBeenCalledWith('html');
+    expect(res.send).toHaveBeenCalledWith(
+      '<html><body data-test="shell">SPA consent shell</body></html>',
+    );
+  });
+
+  it('includes state, PKCE and token fields in the injected consent context when present', async () => {
+    (injectOAuthConsentShell as jest.Mock).mockReturnValue('<html>shell</html>');
+
+    const req = createRequest({
+      query: {
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        response_type: 'code',
+        scope: 'read',
+        state: 'state-123',
+        code_challenge: 'abc123',
+        code_challenge_method: 'S256',
+        token: 'jwt-token',
+      },
+    });
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context).toMatchObject({
+      state: 'state-123',
+      codeChallenge: 'abc123',
+      codeChallengeMethod: 'S256',
+      token: 'jwt-token',
+    });
+  });
+
+  it('falls back to the legacy inline consent HTML when the frontend shell is unavailable', async () => {
+    (injectOAuthConsentShell as jest.Mock).mockReturnValue(null);
+
+    const req = createRequest();
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    expect(injectOAuthConsentShell).toHaveBeenCalledTimes(1);
+    expect(res.send).toHaveBeenCalledWith(expect.any(String));
+
+    const html = (res.send as jest.Mock).mock.calls[0][0] as string;
+    // Legacy page is still a fully functional consent form POSTing to /oauth/authorize.
+    expect(html).toContain('<form method="POST" action="/oauth/authorize"');
+    expect(html).toContain('Trusted Client');
+  });
+
+  it('redirects unauthenticated users to the login page before rendering consent', async () => {
+    (resolveBetterAuthUser as jest.Mock).mockResolvedValue(null);
+
+    const req = createRequest();
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      expect.stringContaining('/login?returnUrl='),
+    );
+    expect(injectOAuthConsentShell).not.toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **option (γ)** from [#822](https://github.com/samanhappy/mcphub/issues/822): the OAuth Server consent screen (`/oauth/authorize`) is moved from a standalone inline-HTML page into the React dashboard, so it shares the dashboard's visual language, i18n, dark mode, and component primitives.

**Before**: a self-contained inline `<style>` page with hardcoded colors/fonts, visually unrelated to the dashboard — a different "product" on the most security-critical surface.
**After**: the dashboard SPA boots at `/oauth/authorize` and renders the consent card using the `--hub-*` design tokens (same as `/login`), with theme + language switches.

## Behavior change

- `GET /oauth/authorize` (authenticated) now serves the built SPA shell with the validated consent context injected as `window.__OAUTH_CONSENT_CONTEXT__`.
  - A `<base href="{basePath}/">` is injected as the first element of `<head>` so the SPA's relative `./assets/*` resolve correctly from the non-root URL.
  - The injected JSON neutralizes `<` as `\u003c` so client-supplied values cannot break out of the inline script.
- The React `OAuthConsentPage` renders the payload and POSTs the decision back to `/oauth/authorize` with the original request fields (`client_id`, `redirect_uri`, `response_type`, `scope`, `state`, `code_challenge`, `code_challenge_method`, `token`, `allow`).
- **Security boundary unchanged**: request validation, client/redirect_uri checks, and user resolution (JWT / bearer / Better Auth) all still happen server-side before the shell is served; unauthenticated users still redirect to `/login?returnUrl=...`.
- **Fallback preserved**: when the frontend build is unavailable (`DISABLE_WEB=true` / headless installs), the legacy inline consent page is still served, so the OAuth flow never breaks.

## Files changed

Backend:
- `src/utils/frontendShell.ts` (new) — shell injection util + `OAuthConsentContext` type
- `src/server.ts` — register the discovered frontend dist via `setFrontendDistPath`
- `src/controllers/oauthServerController.ts` — `getAuthorize` builds the structured context, serves the SPA shell, falls back to the inline page
- `tests/controllers/oauthServerController.shell.test.ts` (new) — 4 tests

Frontend:
- `frontend/src/pages/OAuthConsentPage.tsx` (new) — consent UI (dashboard visual language, mirrors `LoginPage`)
- `frontend/src/App.tsx` — public route `/oauth/authorize`
- `frontend/src/types/runtime.ts` — `OAuthConsentContext` type + `window` declaration
- `locales/{en,fr,tr,zh}.json` — 5 new `oauthServer.*` keys

## Tests

Automated (TDD — failing test written first):
- `oauthServerController.shell.test.ts`: serves SPA shell with injected context · passes PKCE/state/token through · falls back to legacy HTML when shell unavailable · redirects unauthenticated users to `/login`.
- Full `test:ci`: **149 suites / 1054 tests pass** (the only excluded suite, `sse-service-real-client.test.ts`, was verified to fail identically on a clean worktree at `main` — a pre-existing environment issue, unrelated to this change).
- `pnpm lint` ✅ · `pnpm build` ✅ · `node scripts/verify-dist.js` ✅
- Smoke-tested `injectOAuthConsentShell` against the real built `frontend/dist`: `<base>` placement, context injection, XSS-neutralization, and asset resolution all verified.

Manual checks performed / recommended:
- Start server with built frontend; sign in; open `/oauth/authorize` for a registered client → consent page renders in dashboard style (light + dark).
- `DISABLE_WEB=true` → consent still renders via the legacy inline page.
- Approve / Deny both redirect to the registered `redirect_uri` with `code` / `error=access_denied` as before.

## Notes / follow-ups

- Content enhancements from [#821](https://github.com/samanhappy/mcphub/issues/821) (`resource` param, clientId fingerprint, RFC 7591 metadata) are intentionally out of scope; `OAuthConsentPage` already consumes the structured context, so those can be added as component/context fields without another render-model change.
- `frontend/dist` is a generated artifact (gitignored) and is not part of this diff.

Closes #822
