### PR TITLE
feat(oauth): surface resource target and client metadata on consent screen

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -246,7 +246,7 @@ const LoginPage: React.FC = () => {
                 height: 44,
                 borderRadius: 10,
                 background: 'var(--hub-ink)',
-                color: 'white',
+                color: 'var(--hub-bg)',
               }}
             >
               <span className="hub-mono font-semibold" style={{ fontSize: 18 }}>

--- a/frontend/src/pages/OAuthConsentPage.tsx
+++ b/frontend/src/pages/OAuthConsentPage.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, ExternalLink } from 'lucide-react';
 import { getBasePath } from '../utils/runtime';
 import ThemeSwitch from '@/components/ui/ThemeSwitch';
 import LanguageSwitch from '@/components/ui/LanguageSwitch';
-import type { OAuthConsentContext } from '../types/runtime';
+import type { OAuthConsentContext, ResourceTarget } from '../types/runtime';
 
 /**
  * OAuth consent screen, booted inside the dashboard SPA by the shell the
@@ -31,6 +31,9 @@ const OAuthConsentPage: React.FC = () => {
         <input type="hidden" name="redirect_uri" value={context.redirectUri} />
         <input type="hidden" name="response_type" value={context.responseType} />
         <input type="hidden" name="scope" value={context.scope} />
+        {context.resource ? (
+          <input type="hidden" name="resource" value={context.resource.raw} />
+        ) : null}
         {context.state ? <input type="hidden" name="state" value={context.state} /> : null}
         {context.codeChallenge ? (
           <input type="hidden" name="code_challenge" value={context.codeChallenge} />
@@ -44,13 +47,62 @@ const OAuthConsentPage: React.FC = () => {
     );
   };
 
+  const resourceLabel = (resource: ResourceTarget): string => {
+    switch (resource.kind) {
+      case 'all':
+        return t('oauthServer.resourceAll');
+      case 'smart':
+        return t('oauthServer.resourceSmart');
+      case 'server':
+        return t('oauthServer.resourceServer', { name: resource.name ?? '' });
+      case 'group':
+        return t('oauthServer.resourceGroup', { name: resource.name ?? '' });
+      default:
+        return resource.name || resource.raw;
+    }
+  };
+
+  const link = (href: string | undefined, label: string): React.ReactNode => {
+    if (!href) return null;
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 3,
+          fontSize: 11.5,
+          color: 'var(--hub-ink-2)',
+          textDecoration: 'none',
+          borderBottom: '1px solid var(--hub-line)',
+          paddingBottom: 1,
+          maxWidth: 220,
+        }}
+        title={href}
+      >
+        <span
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </span>
+        <ExternalLink size={10} className="flex-shrink-0" />
+      </a>
+    );
+  };
+
   if (!context) {
     return (
       <div
         className="relative min-h-screen w-full overflow-hidden"
         style={{ background: 'var(--hub-bg)', color: 'var(--hub-ink)' }}
       >
-        <div className="relative mx-auto flex min-h-screen w-full max-w-md items-center justify-center px-6">
+        <div className="relative mx-auto flex min-h-screen w-full max-w-lg items-center justify-center px-6">
           <div className="hub-card w-full" style={{ padding: '22px' }}>
             <div className="flex items-center gap-2" style={{ color: 'var(--hub-err)' }}>
               <AlertCircle size={16} className="flex-shrink-0" />
@@ -67,6 +119,10 @@ const OAuthConsentPage: React.FC = () => {
     );
   }
 
+  const clientIdFingerprint = `${context.clientId.slice(0, 8)}…`;
+  const client = context.client;
+  const hasLinks = Boolean(client?.policyUri || client?.tosUri || client?.clientUri);
+
   return (
     <div
       className="relative min-h-screen w-full overflow-hidden"
@@ -78,7 +134,7 @@ const OAuthConsentPage: React.FC = () => {
         <LanguageSwitch />
       </div>
 
-      <div className="relative mx-auto flex min-h-screen w-full max-w-md items-center justify-center px-6">
+      <div className="relative mx-auto flex min-h-screen w-full max-w-lg items-center justify-center px-6">
         <div className="w-full space-y-6">
           {/* Brand */}
           <div className="flex flex-col items-center gap-3">
@@ -89,7 +145,7 @@ const OAuthConsentPage: React.FC = () => {
                 height: 44,
                 borderRadius: 10,
                 background: 'var(--hub-ink)',
-                color: 'white',
+                color: 'var(--hub-bg)',
               }}
             >
               <span className="hub-mono font-semibold" style={{ fontSize: 18 }}>
@@ -115,6 +171,39 @@ const OAuthConsentPage: React.FC = () => {
 
           {/* Consent card */}
           <div className="hub-card" style={{ padding: '22px 22px 20px' }}>
+            {/* Resource target (RFC 8707) */}
+            {context.resource ? (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 4,
+                  padding: '12px 14px',
+                  borderRadius: 10,
+                  background: 'var(--hub-accent-soft)',
+                  border: '1px solid var(--hub-line)',
+                  marginBottom: 14,
+                }}
+              >
+                <span className="hub-sect">{t('oauthServer.grantingAccessTo')}</span>
+                <span style={{ fontWeight: 600, fontSize: 14, color: 'var(--hub-ink)' }}>
+                  {resourceLabel(context.resource)}
+                </span>
+                <span
+                  className="hub-mono"
+                  style={{
+                    fontSize: 11.5,
+                    color: 'var(--hub-ink-2)',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {context.resource.raw}
+                </span>
+              </div>
+            ) : null}
+
             {/* Client box */}
             <div
               style={{
@@ -127,10 +216,43 @@ const OAuthConsentPage: React.FC = () => {
                 border: '1px solid var(--hub-line)',
               }}
             >
-              <span className="hub-sect">{t('oauthServer.application')}</span>
-              <span style={{ fontWeight: 600, fontSize: 15, color: 'var(--hub-ink)' }}>
-                {context.clientName}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                {client?.logoUri ? (
+                  <img
+                    src={client.logoUri}
+                    alt=""
+                    width={20}
+                    height={20}
+                    style={{ borderRadius: 4, flexShrink: 0, objectFit: 'contain' }}
+                    referrerPolicy="no-referrer"
+                  />
+                ) : null}
+                <span style={{ fontWeight: 600, fontSize: 15, color: 'var(--hub-ink)' }}>
+                  {context.clientName}
+                </span>
+              </div>
+              <span className="hub-sect">
+                {t('oauthServer.clientId')}: <span className="hub-mono">{clientIdFingerprint}</span>
               </span>
+              <span
+                style={{
+                  fontSize: 11.5,
+                  color: 'var(--hub-ink-2)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+                title={context.redirectUri}
+              >
+                {t('oauthServer.willRedirectTo')} {context.redirectUri}
+              </span>
+              {hasLinks ? (
+                <div style={{ display: 'flex', gap: 12, marginTop: 6, flexWrap: 'wrap' }}>
+                  {link(client?.policyUri, t('oauthServer.policy'))}
+                  {link(client?.tosUri, t('oauthServer.terms'))}
+                  {link(client?.clientUri, t('oauthServer.homepage'))}
+                </div>
+              ) : null}
             </div>
 
             {/* Scopes */}
@@ -174,16 +296,6 @@ const OAuthConsentPage: React.FC = () => {
                   }}
                 >
                   <span style={{ lineHeight: 1.3 }}>{t('oauthServer.buttons.approve')}</span>
-                  <span
-                    style={{
-                      fontSize: 10.5,
-                      lineHeight: 1.3,
-                      opacity: 0.8,
-                      color: 'inherit',
-                    }}
-                  >
-                    {t('oauthServer.buttons.approveSubtitle')}
-                  </span>
                 </button>
               </form>
               <form method="POST" action={postUrl} style={{ flex: 1 }}>
@@ -200,16 +312,6 @@ const OAuthConsentPage: React.FC = () => {
                   }}
                 >
                   <span style={{ lineHeight: 1.3 }}>{t('oauthServer.buttons.deny')}</span>
-                  <span
-                    style={{
-                      fontSize: 10.5,
-                      lineHeight: 1.3,
-                      opacity: 0.75,
-                      color: 'inherit',
-                    }}
-                  >
-                    {t('oauthServer.buttons.denySubtitle')}
-                  </span>
                 </button>
               </form>
             </div>

--- a/frontend/src/types/runtime.ts
+++ b/frontend/src/types/runtime.ts
@@ -5,6 +5,24 @@ export interface RuntimeConfig {
   name: string;
 }
 
+// RFC 8707 resource target injected by the backend.
+export interface ResourceTarget {
+  raw: string;
+  path: string;
+  kind: 'all' | 'smart' | 'target' | 'server' | 'group' | 'unknown';
+  name?: string;
+}
+
+// RFC 7591 client metadata injected by the backend.
+export interface ConsentClientInfo {
+  clientUri?: string;
+  policyUri?: string;
+  tosUri?: string;
+  logoUri?: string;
+  contacts?: string[];
+  applicationType?: string;
+}
+
 // Consent context injected by the backend into the SPA shell at
 // /oauth/authorize. The server has already validated the OAuth request and
 // resolved the authenticated user before building this; the SPA only renders
@@ -20,6 +38,8 @@ export interface OAuthConsentContext {
   codeChallenge?: string;
   codeChallengeMethod?: string;
   token?: string;
+  resource?: ResourceTarget;
+  client?: ConsentClientInfo;
 }
 
 // Extend Window interface to include runtime config

--- a/locales/en.json
+++ b/locales/en.json
@@ -517,7 +517,17 @@
     "scopesTitle": "This application will be able to:",
     "noScopes": "No permissions requested.",
     "requestInvalidTitle": "Request invalid",
-    "requestInvalid": "This authorization request is invalid or has expired. Please go back and try again."
+    "requestInvalid": "This authorization request is invalid or has expired. Please go back and try again.",
+    "grantingAccessTo": "Granting access to:",
+    "resourceAll": "All MCP servers",
+    "resourceSmart": "Smart routing",
+    "resourceServer": "MCP server: {{name}}",
+    "resourceGroup": "MCP group: {{name}}",
+    "clientId": "Client ID",
+    "willRedirectTo": "Will redirect to:",
+    "policy": "Privacy policy",
+    "terms": "Terms",
+    "homepage": "Homepage"
   },
   "cloud": {
     "title": "Cloud Support",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -516,7 +516,17 @@
     "scopesTitle": "Cette application pourra :",
     "noScopes": "Aucune autorisation demandée.",
     "requestInvalidTitle": "Demande invalide",
-    "requestInvalid": "Cette demande d'autorisation est invalide ou a expiré. Veuillez revenir en arrière et réessayer."
+    "requestInvalid": "Cette demande d'autorisation est invalide ou a expiré. Veuillez revenir en arrière et réessayer.",
+    "grantingAccessTo": "Accord de l'accès à :",
+    "resourceAll": "Tous les serveurs MCP",
+    "resourceSmart": "Routage intelligent",
+    "resourceServer": "Serveur MCP : {{name}}",
+    "resourceGroup": "Groupe MCP : {{name}}",
+    "clientId": "ID client",
+    "willRedirectTo": "Redirigera vers :",
+    "policy": "Politique de confidentialité",
+    "terms": "Conditions d'utilisation",
+    "homepage": "Page d'accueil"
   },
   "cloud": {
     "title": "Support Cloud",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -516,7 +516,17 @@
     "scopesTitle": "Bu uygulama şunları yapabilecek:",
     "noScopes": "İzin istenmedi.",
     "requestInvalidTitle": "Geçersiz istek",
-    "requestInvalid": "Bu yetkilendirme isteği geçersiz veya süresi dolmuş. Lütfen geri dönüp tekrar deneyin."
+    "requestInvalid": "Bu yetkilendirme isteği geçersiz veya süresi dolmuş. Lütfen geri dönüp tekrar deneyin.",
+    "grantingAccessTo": "Erişim verilecek hedef:",
+    "resourceAll": "Tüm MCP sunucuları",
+    "resourceSmart": "Akıllı yönlendirme",
+    "resourceServer": "MCP sunucusu: {{name}}",
+    "resourceGroup": "MCP grubu: {{name}}",
+    "clientId": "İstemci kimliği",
+    "willRedirectTo": "Şuraya yönlendirilecek:",
+    "policy": "Gizlilik politikası",
+    "terms": "Hizmet şartları",
+    "homepage": "Ana sayfa"
   },
   "cloud": {
     "title": "Bulut Desteği",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -519,7 +519,17 @@
     "scopesTitle": "此应用程序将能够：",
     "noScopes": "未请求任何权限。",
     "requestInvalidTitle": "请求无效",
-    "requestInvalid": "此授权请求无效或已过期。请返回后重试。"
+    "requestInvalid": "此授权请求无效或已过期。请返回后重试。",
+    "grantingAccessTo": "将授予访问权限：",
+    "resourceAll": "所有 MCP 服务器",
+    "resourceSmart": "智能路由",
+    "resourceServer": "MCP 服务器：{{name}}",
+    "resourceGroup": "MCP 分组：{{name}}",
+    "clientId": "客户端 ID",
+    "willRedirectTo": "将重定向到：",
+    "policy": "隐私政策",
+    "terms": "服务条款",
+    "homepage": "主页"
   },
   "cloud": {
     "title": "云端支持",

--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -5,7 +5,7 @@ import {
   handleAuthenticateRequest,
 } from '../services/oauthServerService.js';
 import { findOAuthClientById } from '../models/OAuth.js';
-import { getSystemConfigDao } from '../dao/index.js';
+import { getSystemConfigDao, getGroupDao, getServerDao } from '../dao/index.js';
 import OAuth2Server from '@node-oauth/oauth2-server';
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET } from '../config/jwt.js';
@@ -15,7 +15,12 @@ import { resolveInstallBaseUrl } from '../utils/installBaseUrl.js';
 import {
   injectOAuthConsentShell,
   type OAuthConsentContext,
+  type ConsentClientInfo,
 } from '../utils/frontendShell.js';
+import {
+  parseResourceTarget,
+  type ResourceTarget,
+} from '../utils/oauthConsentResource.js';
 
 const { Request: OAuth2Request, Response: OAuth2Response } = OAuth2Server;
 
@@ -246,6 +251,40 @@ const generateAuthorizeHtml = (
 };
 
 /**
+ * Resolve an RFC 8707 `resource` URI into a display target for the consent
+ * screen, disambiguating `/mcp/{name}` between a group and a single server.
+ * Best-effort: unknown or unresolvable targets are surfaced as-is, never
+ * blocking the authorization request.
+ */
+async function resolveResourceTarget(raw: string | undefined): Promise<ResourceTarget | undefined> {
+  if (!raw) {
+    return undefined;
+  }
+
+  const parsed = parseResourceTarget(raw);
+  if (parsed.kind !== 'target' || !parsed.name) {
+    return parsed;
+  }
+
+  try {
+    const [group, server] = await Promise.all([
+      getGroupDao().findByName(parsed.name),
+      getServerDao().findById(parsed.name),
+    ]);
+    if (group) {
+      return { ...parsed, kind: 'group' };
+    }
+    if (server) {
+      return { ...parsed, kind: 'server' };
+    }
+    return { ...parsed, kind: 'unknown' };
+  } catch (error) {
+    console.warn('Failed to resolve OAuth consent resource target:', error);
+    return { ...parsed, kind: 'unknown' };
+  }
+}
+
+/**
  * GET /oauth/authorize
  * Display authorization page or handle authorization
  */
@@ -279,6 +318,12 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
           'code_challenge_method',
           /^(S256|plain)$/,
         )
+      : undefined;
+    // RFC 8707: the resource URI the client wants to access (e.g. which MCP
+    // server). Optional here for compatibility with clients that omit it, but
+    // surfaced on the consent screen when present.
+    const resource = req.query.resource
+      ? validateQueryParam(req.query.resource, 'resource')
       : undefined;
 
     // Validate required parameters
@@ -341,6 +386,7 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
       <input type="hidden" name="response_type" value="${escapeHtml(response_type)}" />
       <input type="hidden" name="scope" value="${escapeHtml(scope || '')}" />
       <input type="hidden" name="state" value="${escapeHtml(state || '')}" />
+      ${resource ? `<input type="hidden" name="resource" value="${escapeHtml(resource)}" />` : ''}
       ${code_challenge ? `<input type="hidden" name="code_challenge" value="${escapeHtml(code_challenge)}" />` : ''}
       ${code_challenge_method ? `<input type="hidden" name="code_challenge_method" value="${escapeHtml(code_challenge_method)}" />` : ''}
       ${tokenField}
@@ -349,6 +395,14 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
     // Build the structured consent context handed to the React SPA. The server
     // has already validated the request and resolved the authenticated user, so
     // the SPA only renders this payload (never re-resolves auth).
+    const consentClientInfo: ConsentClientInfo = {
+      clientUri: client.metadata?.client_uri,
+      policyUri: client.metadata?.policy_uri,
+      tosUri: client.metadata?.tos_uri,
+      logoUri: client.metadata?.logo_uri,
+      contacts: client.metadata?.contacts,
+      applicationType: client.metadata?.application_type,
+    };
     const consentContext: OAuthConsentContext = {
       clientName: client.name || '',
       scopes,
@@ -360,6 +414,8 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
       codeChallenge: code_challenge || undefined,
       codeChallengeMethod: code_challenge_method || undefined,
       token: requestToken || undefined,
+      resource: await resolveResourceTarget(resource),
+      client: consentClientInfo,
     };
 
     // Serve the consent screen inside the React dashboard (SPA shell) when the

--- a/src/utils/frontendShell.ts
+++ b/src/utils/frontendShell.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import type { ResourceTarget } from './oauthConsentResource.js';
 
 /**
  * Shared holder for the frontend dist directory.
@@ -16,6 +17,18 @@ export const setFrontendDistPath = (value: string | null): void => {
 };
 
 export const getFrontendDistPath = (): string | null => frontendDistPath;
+
+/**
+ * RFC 7591 client metadata surfaced on the consent screen as trust signals.
+ */
+export type ConsentClientInfo = {
+  clientUri?: string;
+  policyUri?: string;
+  tosUri?: string;
+  logoUri?: string;
+  contacts?: string[];
+  applicationType?: string;
+};
 
 /**
  * Data the OAuth consent screen needs to render. This is the security-relevant
@@ -36,6 +49,10 @@ export type OAuthConsentContext = {
   codeChallenge?: string;
   codeChallengeMethod?: string;
   token?: string;
+  // RFC 8707 `resource` — which MCPHub target the client wants to access.
+  resource?: ResourceTarget;
+  // RFC 7591 client identity / trust metadata (populated when registered).
+  client?: ConsentClientInfo;
 };
 
 /**

--- a/src/utils/oauthConsentResource.ts
+++ b/src/utils/oauthConsentResource.ts
@@ -35,7 +35,11 @@ export function parseResourceTarget(raw: string): ResourceTarget {
     pathname = raw;
   }
 
-  const clean = pathname.replace(/\/+$/, '');
+  // Strip trailing slashes without a regex: `/\/+$/` is quadratic on a long
+  // run of slashes followed by a non-slash (user-controlled `resource`), i.e.
+  // an unauthenticated ReDoS on GET /oauth/authorize (CWE-1333).
+  let clean = pathname;
+  while (clean.endsWith('/')) clean = clean.slice(0, -1);
 
   if (!clean || clean === '/mcp') {
     return { raw, path: clean, kind: 'all' };

--- a/src/utils/oauthConsentResource.ts
+++ b/src/utils/oauthConsentResource.ts
@@ -1,0 +1,60 @@
+/**
+ * Human-readable description of an RFC 8707 `resource` URI for the OAuth
+ * consent screen. The resource tells the user which MCPHub target the client
+ * is asking to access (e.g. the aggregated `/mcp` endpoint or a single server
+ * behind `/mcp/{name}`).
+ */
+export type ResourceTargetKind = 'all' | 'smart' | 'target' | 'server' | 'group' | 'unknown';
+
+export interface ResourceTarget {
+  /** The raw `resource` URI as sent by the client. */
+  raw: string;
+  /** URL pathname (trailing slashes stripped), or the raw string when unparseable. */
+  path: string;
+  kind: ResourceTargetKind;
+  /** Target name for `/mcp/{name}` resources (e.g. a server or group name). */
+  name?: string;
+}
+
+/**
+ * Parse a `resource` URI into a ResourceTarget. Best-effort: an unparseable
+ * URI is surfaced as `unknown` rather than failing the authorization request,
+ * so a malformed-but-harmless parameter can never block consent.
+ *
+ * Mapping follows the routing surface (see AGENTS.md):
+ * - `/` or `/mcp` (the aggregate endpoint) -> `all`
+ * - `/mcp/$smart` (smart routing) -> `smart`
+ * - `/mcp/{name}` -> `target` (caller may resolve to `server`/`group`)
+ * - anything else -> `unknown`
+ */
+export function parseResourceTarget(raw: string): ResourceTarget {
+  let pathname = '';
+  try {
+    pathname = new URL(raw).pathname;
+  } catch {
+    pathname = raw;
+  }
+
+  const clean = pathname.replace(/\/+$/, '');
+
+  if (!clean || clean === '/mcp') {
+    return { raw, path: clean, kind: 'all' };
+  }
+
+  if (clean === '/mcp/$smart') {
+    return { raw, path: clean, kind: 'smart' };
+  }
+
+  const mcpMatch = clean.match(/^\/mcp\/([^/]+)$/);
+  if (mcpMatch) {
+    let name = mcpMatch[1];
+    try {
+      name = decodeURIComponent(name);
+    } catch {
+      // Leave the raw name as-is if it is not valid percent-encoding.
+    }
+    return { raw, path: clean, kind: 'target', name };
+  }
+
+  return { raw, path: clean, kind: 'unknown' };
+}

--- a/tests/controllers/oauthServerController.shell.test.ts
+++ b/tests/controllers/oauthServerController.shell.test.ts
@@ -16,11 +16,17 @@ jest.mock('../../src/utils/frontendShell.js', () => ({
   injectOAuthConsentShell: jest.fn(),
 }));
 
+jest.mock('../../src/dao/index.js', () => ({
+  getGroupDao: jest.fn(),
+  getServerDao: jest.fn(),
+}));
+
 import { getAuthorize } from '../../src/controllers/oauthServerController.js';
 import { getOAuthServer } from '../../src/services/oauthServerService.js';
 import { findOAuthClientById } from '../../src/models/OAuth.js';
 import { resolveBetterAuthUser } from '../../src/services/betterAuthSession.js';
 import { injectOAuthConsentShell } from '../../src/utils/frontendShell.js';
+import { getGroupDao, getServerDao } from '../../src/dao/index.js';
 
 type MockResponse = {
   status: jest.Mock;
@@ -71,6 +77,14 @@ describe('oauthServerController getAuthorize consent shell', () => {
     (resolveBetterAuthUser as jest.Mock).mockResolvedValue({
       username: 'alice',
       isAdmin: false,
+    });
+
+    // Default: no group/server matches the target name.
+    (getGroupDao as jest.Mock).mockReturnValue({
+      findByName: jest.fn().mockResolvedValue(null),
+    });
+    (getServerDao as jest.Mock).mockReturnValue({
+      findById: jest.fn().mockResolvedValue(null),
     });
   });
 
@@ -163,5 +177,132 @@ describe('oauthServerController getAuthorize consent shell', () => {
     );
     expect(injectOAuthConsentShell).not.toHaveBeenCalled();
     expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('passes the RFC 8707 resource target into the consent context', async () => {
+    (injectOAuthConsentShell as jest.Mock).mockReturnValue('<html>shell</html>');
+
+    const req = createRequest({
+      query: {
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        response_type: 'code',
+        scope: 'read',
+        resource: 'https://mcphub.example.com/mcp',
+      },
+    });
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context.resource).toEqual({
+      raw: 'https://mcphub.example.com/mcp',
+      path: '/mcp',
+      kind: 'all',
+    });
+  });
+
+  it('resolves /mcp/{name} to a server via the DAOs', async () => {
+    (getServerDao as jest.Mock).mockReturnValue({
+      findById: jest.fn().mockResolvedValue({ name: 'toggl' }),
+    });
+
+    const req = createRequest({
+      query: {
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        response_type: 'code',
+        scope: 'read',
+        resource: 'https://mcphub.example.com/mcp/toggl',
+      },
+    });
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context.resource).toMatchObject({ kind: 'server', name: 'toggl' });
+  });
+
+  it('resolves /mcp/{name} to a group via the DAOs (group wins over server)', async () => {
+    (getGroupDao as jest.Mock).mockReturnValue({
+      findByName: jest.fn().mockResolvedValue({ name: 'toggl' }),
+    });
+
+    const req = createRequest({
+      query: {
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        response_type: 'code',
+        scope: 'read',
+        resource: 'https://mcphub.example.com/mcp/toggl',
+      },
+    });
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context.resource).toMatchObject({ kind: 'group', name: 'toggl' });
+  });
+
+  it('marks /mcp/{name} as unknown when it matches no server or group', async () => {
+    const req = createRequest({
+      query: {
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        response_type: 'code',
+        scope: 'read',
+        resource: 'https://mcphub.example.com/mcp/does-not-exist',
+      },
+    });
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context.resource).toMatchObject({
+      kind: 'unknown',
+      name: 'does-not-exist',
+    });
+  });
+
+  it('passes RFC 7591 client metadata into the consent context', async () => {
+    (findOAuthClientById as jest.Mock).mockResolvedValue({
+      clientId: 'e9d6adf9e48449e6bee3f8b6fb024297',
+      name: 'Claude',
+      redirectUris: ['https://claude.ai/api/mcp/auth_callback'],
+      metadata: {
+        application_type: 'web',
+        contacts: ['security@example.com'],
+        logo_uri: 'https://example.com/logo.png',
+        client_uri: 'https://example.com',
+        policy_uri: 'https://example.com/privacy',
+        tos_uri: 'https://example.com/terms',
+      },
+    });
+
+    const req = createRequest({
+      query: {
+        client_id: 'e9d6adf9e48449e6bee3f8b6fb024297',
+        redirect_uri: 'https://claude.ai/api/mcp/auth_callback',
+        response_type: 'code',
+        scope: 'read',
+      },
+    });
+    const res = createResponse();
+
+    await getAuthorize(req as any, res as any);
+
+    const context = (injectOAuthConsentShell as jest.Mock).mock.calls[0][0];
+    expect(context.client).toEqual({
+      applicationType: 'web',
+      contacts: ['security@example.com'],
+      logoUri: 'https://example.com/logo.png',
+      clientUri: 'https://example.com',
+      policyUri: 'https://example.com/privacy',
+      tosUri: 'https://example.com/terms',
+    });
   });
 });

--- a/tests/utils/oauthConsentResource.test.ts
+++ b/tests/utils/oauthConsentResource.test.ts
@@ -1,0 +1,59 @@
+import { parseResourceTarget } from '../../src/utils/oauthConsentResource.js';
+
+describe('parseResourceTarget', () => {
+  it('maps a bare install URL (aggregate /mcp connector) to "all"', () => {
+    expect(parseResourceTarget('https://mcphub.example.com/')).toEqual({
+      raw: 'https://mcphub.example.com/',
+      path: '',
+      kind: 'all',
+    });
+    expect(parseResourceTarget('https://mcphub.example.com')).toEqual({
+      raw: 'https://mcphub.example.com',
+      path: '',
+      kind: 'all',
+    });
+  });
+
+  it('maps /mcp to "all"', () => {
+    expect(parseResourceTarget('https://mcphub.example.com/mcp')).toMatchObject({
+      kind: 'all',
+      path: '/mcp',
+    });
+  });
+
+  it('maps /mcp/$smart to "smart"', () => {
+    expect(parseResourceTarget('https://mcphub.example.com/mcp/$smart')).toMatchObject({
+      kind: 'smart',
+      path: '/mcp/$smart',
+    });
+  });
+
+  it('maps /mcp/{name} to a named target', () => {
+    expect(parseResourceTarget('https://mcphub.example.com/mcp/toggl')).toMatchObject({
+      kind: 'target',
+      name: 'toggl',
+      path: '/mcp/toggl',
+    });
+  });
+
+  it('decodes URL-encoded target names', () => {
+    expect(parseResourceTarget('https://mcphub.example.com/mcp/my%20group')).toMatchObject({
+      kind: 'target',
+      name: 'my group',
+    });
+  });
+
+  it('accepts relative resource paths', () => {
+    expect(parseResourceTarget('/mcp/toggl')).toMatchObject({
+      kind: 'target',
+      name: 'toggl',
+    });
+  });
+
+  it('surfaces unrecognized URIs as unknown rather than throwing', () => {
+    expect(parseResourceTarget('not a url')).toMatchObject({ kind: 'unknown' });
+    expect(parseResourceTarget('https://example.com/something/else')).toMatchObject({
+      kind: 'unknown',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the consent-screen content additions from [#821](https://github.com/samanhappy/mcphub/issues/821), on top of the SPA consent screen landed in #1060. The OAuth consent screen now tells the user **which target** the client wants to access and **which client** is asking — turning "Authorize Claude" into "Authorize Claude to access the **toggl** MCP server", with a client identity fingerprint and RFC 7591 trust links.

## Behavior change

- `getAuthorize` now reads the RFC 8707 `resource` parameter (previously silently ignored) and resolves it into a display target:
  - `/` or `/mcp` (aggregate endpoint) → "All MCP servers"
  - `/mcp/$smart` → "Smart routing"
  - `/mcp/{name}` → resolved to "MCP server: X" / "MCP group: X" via the group/server DAOs (group wins on collision), or surfaced as unknown otherwise
  - Unparseable/unresolvable targets are shown as-is and **never block the authorization request** (additive, non-breaking).
- The consent context now carries the resource target plus the client's RFC 7591 metadata (`client_uri`, `policy_uri`, `tos_uri`, `logo_uri`, `contacts`, `application_type`).
- The consent screen renders:
  - a **Granting access to** block with the resolved target + raw resource URI
  - client logo (when registered), a **client_id fingerprint** (`e9d6adf9…`), the **redirect target**, and Policy · Terms · Homepage links (when registered)
- `resource` is echoed back on the authorize POST (both SPA form and legacy fallback), so the granted authorization stays bound to the requested target.

## Files changed

Backend:
- `src/utils/oauthConsentResource.ts` (new) — pure `parseResourceTarget()` (RFC 8707 → kind/name)
- `src/controllers/oauthServerController.ts` — read `resource`, resolve target via DAOs, build resource + client context, echo `resource` on POST
- `src/utils/frontendShell.ts` — `ResourceTarget` / `ConsentClientInfo` types wired into `OAuthConsentContext`
- `tests/utils/oauthConsentResource.test.ts` (new) — 7 unit tests for the parser
- `tests/controllers/oauthServerController.shell.test.ts` — +5 tests (resource pass-through, server/group/unknown resolution, RFC 7591 metadata)

Frontend:
- `frontend/src/pages/OAuthConsentPage.tsx` — resource target block, client identity + metadata links, `resource` hidden field
- `frontend/src/types/runtime.ts` — `ResourceTarget` / `ConsentClientInfo` types
- `locales/{en,fr,tr,zh}.json` — 10 new `oauthServer.*` keys each

## Tests

Automated (TDD — failing tests written first):
- `parseResourceTarget`: `/` → all, `/mcp` → all, `/mcp/$smart` → smart, `/mcp/{name}` → named target (+ URL-decoding, relative paths), unknown for anything else.
- Controller: resource passed into context, `/mcp/{name}` resolves to server / group / unknown via mocked DAOs, RFC 7591 metadata reaches the context.
- Full suite: **150 suites / 1066 tests pass** (`sse-service-real-client.test.ts` excluded — a pre-existing environment issue verified on a clean `main` worktree in the previous PR).
- `pnpm lint` ✅ · `pnpm build` ✅ · `node scripts/verify-dist.js` ✅
- Smoke-tested shell injection against the real built `frontend/dist` with the extended context (base href, context JSON, XSS-neutralization, asset resolution).

Manual checks recommended: register an OAuth client with RFC 7591 metadata, authorize with `resource=https://<host>/mcp/toggl` and with `resource=https://<host>/mcp` — both variants show distinct targets on the consent screen.

## Notes

- `resource` is intentionally **optional** on the request (RFC 8707-compatible clients omit it) rather than strictly required as the issue floated — making it mandatory would break existing non-MCP clients. It's displayed whenever present.
- Per-server scope phrasing (#817) remains out of scope; the target name shown is derived from the `resource` URI, not from scope resolution.
- `frontend/dist` is generated (gitignored) and not part of this diff.

Closes #821
