### PR TITLE
fix(mcp): isolate per-request abort signals to prevent listener leak

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -27,6 +27,7 @@ import { normalizeHeaders, type Transport } from '@modelcontextprotocol/sdk/shar
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import { createFetchWithProxy, getProxyConfigFromEnv } from './proxy.js';
 import { assertSafeUrl, createRedirectValidatingFetch } from '../utils/ssrf.js';
+import { createAbortIsolatingFetch } from '../utils/abortIsolatingFetch.js';
 import { ResilientJsonSchemaValidator } from '../utils/jsonSchemaValidator.js';
 import { getUserDao } from '../dao/index.js';
 import {
@@ -1265,7 +1266,7 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
   if (conf.type === 'streamable-http') {
     const options: StreamableHTTPClientTransportOptions = {};
     let headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
-    const baseFetch = createFetchWithProxy(getProxyConfigFromEnv(env));
+    const baseFetch = createAbortIsolatingFetch(createFetchWithProxy(getProxyConfigFromEnv(env)));
     const requestAwareFetch = createRedirectValidatingFetch(
       createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders),
       allowInternal,
@@ -1298,7 +1299,7 @@ export const createTransportFromConfig = async (name: string, conf: ServerConfig
     // SSE transport
     const options: any = {};
     let headers = conf.headers ? replaceEnvVars(conf.headers, env) : {};
-    const baseFetch = createFetchWithProxy(getProxyConfigFromEnv(env));
+    const baseFetch = createAbortIsolatingFetch(createFetchWithProxy(getProxyConfigFromEnv(env)));
     const requestAwareFetch = createRedirectValidatingFetch(
       createRequestContextAwareFetch(baseFetch, conf.passthroughHeaders),
       allowInternal,

--- a/src/utils/__tests__/abortIsolatingFetch.test.ts
+++ b/src/utils/__tests__/abortIsolatingFetch.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { getEventListeners, getMaxListeners, setMaxListeners } from 'node:events';
+
+import { createAbortIsolatingFetch, type FetchLike } from '../abortIsolatingFetch.js';
+
+const makeResponse = (status = 200, body: BodyInit = ''): Response =>
+  new Response(body, { status });
+
+// Mimics undici's behavior that causes the #1022 leak: every fetch call
+// registers an abort listener on the passed-in signal and only removes it
+// when the signal fires or the request object is garbage collected.
+const leakyFetch = (signalRef: { signal?: AbortSignal }): FetchLike => {
+  return (url, init) => {
+    const signal = init?.signal;
+    if (signal) {
+      signalRef.signal = signal;
+      const listener = () => {};
+      signal.addEventListener('abort', listener);
+    }
+    return Promise.resolve(makeResponse());
+  };
+};
+
+describe('createAbortIsolatingFetch', () => {
+  it('keeps parent-signal listeners bounded under sustained load', async () => {
+    const shared = new AbortController();
+    const seen: { signal?: AbortSignal } = {};
+    // Undici raises the limit to 1500 on the first warning; mirror that so the
+    // test reproduces production conditions instead of tripping at default 10.
+    setMaxListeners(1500, shared.signal);
+    const fetch = createAbortIsolatingFetch(leakyFetch(seen));
+
+    for (let i = 0; i < 2000; i++) {
+      await fetch('https://example.com/mcp', { signal: shared.signal });
+    }
+
+    // Each request must hand a private signal to the underlying fetch...
+    expect(seen.signal).not.toBe(shared.signal);
+    // ...and the wrapper's bridge listener is removed after each settle.
+    expect(getEventListeners(shared.signal, 'abort')).toHaveLength(0);
+  });
+
+  it('propagates parent abort to the in-flight private signal', async () => {
+    const shared = new AbortController();
+    let privateSignal: AbortSignal | undefined;
+    const baseFetch: FetchLike = (url, init) => {
+      privateSignal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+          once: true,
+        });
+      });
+    };
+    const fetch = createAbortIsolatingFetch(baseFetch);
+
+    const pending = fetch('https://example.com/mcp', { signal: shared.signal });
+    await Promise.resolve();
+    shared.abort(new Error('transport closed'));
+
+    await expect(pending).rejects.toMatchObject({ message: 'transport closed' });
+    expect(privateSignal?.aborted).toBe(true);
+    expect(privateSignal?.reason).toBe(shared.signal.reason);
+  });
+
+  it('passes through calls without a signal untouched', async () => {
+    const baseFetch = jest.fn(async (_url: string | URL, init?: RequestInit) => {
+      return makeResponse();
+    }) as unknown as jest.Mock & FetchLike;
+
+    const fetch = createAbortIsolatingFetch(baseFetch);
+    await fetch('https://example.com/mcp', { headers: { 'x-a': '1' } });
+
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = baseFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://example.com/mcp');
+    expect(init.signal).toBeUndefined();
+    expect(init.headers).toEqual({ 'x-a': '1' });
+  });
+
+  it('does not leave bridge listeners behind when the request rejects', async () => {
+    const shared = new AbortController();
+    const baseFetch: FetchLike = () => Promise.reject(new Error('boom'));
+    const fetch = createAbortIsolatingFetch(baseFetch);
+
+    await expect(fetch('https://example.com/mcp', { signal: shared.signal })).rejects.toThrow(
+      'boom',
+    );
+    expect(getEventListeners(shared.signal, 'abort')).toHaveLength(0);
+  });
+
+  it('removes the bridge listener once the response settles normally', async () => {
+    const shared = new AbortController();
+    const baseFetch: FetchLike = () => Promise.resolve(makeResponse());
+    const fetch = createAbortIsolatingFetch(baseFetch);
+
+    await fetch('https://example.com/mcp', { signal: shared.signal });
+    expect(getEventListeners(shared.signal, 'abort')).toHaveLength(0);
+  });
+});

--- a/src/utils/abortIsolatingFetch.ts
+++ b/src/utils/abortIsolatingFetch.ts
@@ -1,0 +1,32 @@
+import type { FetchLike } from './ssrf.js';
+
+/**
+ * Wraps a fetch so each request receives its own AbortSignal instead of the
+ * caller's long-lived one.
+ *
+ * Why: the MCP SDK's StreamableHTTPClientTransport shares a single
+ * AbortController across every request on a connection, and undici registers
+ * an abort listener on the passed signal per fetch call, removing it only on
+ * abort or GC. Under sustained traffic the shared signal accumulates tens of
+ * thousands of listeners (MaxListenersExceededWarning, #1022). Bridging
+ * through a per-request controller keeps at most one in-flight listener on
+ * the parent signal, and it is removed deterministically when the request
+ * settles.
+ */
+export const createAbortIsolatingFetch = (baseFetch: FetchLike): FetchLike => {
+  return async (url, init) => {
+    const parentSignal = init?.signal;
+    if (!parentSignal) {
+      return baseFetch(url, init);
+    }
+
+    const controller = new AbortController();
+    const onAbort = () => controller.abort(parentSignal.reason);
+    parentSignal.addEventListener('abort', onAbort, { once: true });
+    try {
+      return await baseFetch(url, { ...init, signal: controller.signal });
+    } finally {
+      parentSignal.removeEventListener('abort', onAbort);
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- Fixes #1022
- Each fetch issued by an upstream HTTP transport (streamable-http / sse) now receives its own private `AbortSignal` instead of the connection-shared one, via a new `createAbortIsolatingFetch` wrapper.
- The private signal is bridged from the parent (transport-level) signal with a `{ once: true }` listener that is removed deterministically when the request settles — cancellation semantics are unchanged.

## Root cause
The MCP SDK's `StreamableHTTPClientTransport` shares a single `AbortController` across every request on a connection (`streamableHttp.js` passes `this._abortController.signal` into each fetch). Node's undici registers an abort listener on the passed-in signal for **every** fetch call and only removes it on abort or GC (via `FinalizationRegistry`, a known-lagging path). Under sustained tool-call traffic the shared signal accumulated ~39,500 listeners, tripping `MaxListenersExceededWarning` (the "MaxListeners is 1500" in the report matches undici raising the limit itself at `request.js`) and eventually destabilizing pods.

## Tests
- New suite `src/utils/__tests__/abortIsolatingFetch.test.ts`:
  - 2000 sequential requests against an undici-like leaky mock leave **zero** listeners on the parent signal (fails before the fix).
  - Parent abort propagates to the in-flight private signal with the same reason.
  - Calls without a signal pass through untouched; bridge listener removed on both success and rejection paths.
- Full gate: `pnpm lint && pnpm test:ci && pnpm build` — 152 suites / 1081 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)