### PR TITLE
docs: clarify database configuration source of truth

### DIFF
--- a/docs/configuration/database-configuration.mdx
+++ b/docs/configuration/database-configuration.mdx
@@ -183,6 +183,8 @@ Once running in database mode, all configuration changes are stored in the datab
 
 The web dashboard works exactly the same way, but now stores changes in the database instead of the file.
 
+`mcp_settings.json` is used as a one-time seed when database mode is initialized. After the initial migration, PostgreSQL is the authoritative configuration source; later edits to `mcp_settings.json` are not imported automatically. Use the dashboard, API, or CLI to manage configuration in database mode.
+
 ## Database Schema
 
 MCPHub creates the following tables:

--- a/docs/zh/configuration/database-configuration.mdx
+++ b/docs/zh/configuration/database-configuration.mdx
@@ -183,6 +183,8 @@ node dist/scripts/migrate-to-database.js
 
 Web 仪表板的工作方式完全相同，但现在将更改存储在数据库中而不是文件中。
 
+启用数据库模式时，`mcp_settings.json` 仅在首次初始化时作为一次性种子配置使用。首次迁移后，PostgreSQL 是唯一的配置来源；之后对 `mcp_settings.json` 的修改不会自动导入。数据库模式下请通过仪表板、API 或 CLI 管理配置。
+
 ## 数据库架构
 
 MCPHub 创建以下表：


### PR DESCRIPTION
## Summary

- Document that mcp_settings.json is a one-time seed for database mode.
- Document that PostgreSQL is authoritative after the initial migration.
- Clarify that later file edits are not imported automatically.
- Update English and Chinese database configuration docs.

## Verification

- git diff --check

Refs #820