### PR TITLE
fix: support BASE_PATH in local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 PORT=3000
 NODE_ENV=development
+# Optional sub-path for local development and reverse-proxy deployments.
+# BASE_PATH=/mcphub
 # DEFAULT_REQUEST_TIMEOUT=60000
 # INIT_TIMEOUT=300000
 

--- a/docs/development/getting-started.mdx
+++ b/docs/development/getting-started.mdx
@@ -103,6 +103,10 @@ Local development uses `admin` / `admin123` and writes runtime changes to
 `data/mcp_settings.dev.json`. The repository `mcp_settings.json` remains
 credential-free.
 
+To develop with a sub-path, set `BASE_PATH=/mcphub` in the project-root `.env`
+file, restart `pnpm dev`, and open `http://localhost:5173/mcphub/`. The Vite
+server proxies the runtime configuration and dashboard API through that prefix.
+
 ### Running Backend Only
 
 ```bash

--- a/docs/zh/development/getting-started.mdx
+++ b/docs/zh/development/getting-started.mdx
@@ -102,6 +102,10 @@ pnpm dev
 本地开发默认使用 `admin` / `admin123`，运行时变更会写入
 `data/mcp_settings.dev.json`，仓库里的 `mcp_settings.json` 不包含默认凭证。
 
+如果需要在子路径下开发，请在项目根目录的 `.env` 中设置
+`BASE_PATH=/mcphub`，重启 `pnpm dev`，然后访问
+`http://localhost:5173/mcphub/`。Vite 会通过该前缀代理运行时配置和控制台 API。
+
 ### 仅运行后端
 
 ```bash

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
+import { createDevBasePathRedirectPlugin } from './viteBasePath.js';
 import { createDevProxyConfig } from './viteProxy.js';
 // Import the package.json to get the version
 import { readFileSync } from 'fs';
@@ -15,7 +16,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     base: './',
-    plugins: [react(), tailwindcss()],
+    plugins: [createDevBasePathRedirectPlugin(env.BASE_PATH), react(), tailwindcss()],
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,86 +1,68 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
+import { createDevProxyConfig } from './viteProxy.js';
 // Import the package.json to get the version
 import { readFileSync } from 'fs';
 
 // Get package.json version
 const packageJson = JSON.parse(readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'));
 
-// For runtime configuration, we'll always use relative paths
-// BASE_PATH will be determined at runtime
-const basePath = '';
-
 // https://vitejs.dev/config/
-export default defineConfig({
-  base: './', // Always use relative paths for runtime configuration
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, path.resolve(__dirname, '..'), '');
+
+  return {
+    base: './',
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
-  define: {
-    // Make package version available as global variable
-    // BASE_PATH will be loaded at runtime
-    'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
-  },
-  build: {
-    sourcemap: true, // Enable source maps for production build
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (!id.includes('node_modules')) {
+    define: {
+      'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
+    },
+    build: {
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (!id.includes('node_modules')) {
+              return undefined;
+            }
+
+            if (
+              id.includes('/react/') ||
+              id.includes('/react-dom/') ||
+              id.includes('/scheduler/') ||
+              id.includes('/react-router/') ||
+              id.includes('/react-router-dom/') ||
+              id.includes('/@remix-run/')
+            ) {
+              return 'framework-vendor';
+            }
+
+            if (
+              id.includes('/i18next/') ||
+              id.includes('/react-i18next/') ||
+              id.includes('/i18next-browser-languagedetector/')
+            ) {
+              return 'i18n-vendor';
+            }
+
+            if (id.includes('/lucide-react/')) {
+              return 'icons-vendor';
+            }
+
             return undefined;
-          }
-
-          if (
-            id.includes('/react/') ||
-            id.includes('/react-dom/') ||
-            id.includes('/scheduler/') ||
-            id.includes('/react-router/') ||
-            id.includes('/react-router-dom/') ||
-            id.includes('/@remix-run/')
-          ) {
-            return 'framework-vendor';
-          }
-
-          if (
-            id.includes('/i18next/') ||
-            id.includes('/react-i18next/') ||
-            id.includes('/i18next-browser-languagedetector/')
-          ) {
-            return 'i18n-vendor';
-          }
-
-          if (id.includes('/lucide-react/')) {
-            return 'icons-vendor';
-          }
-
-          return undefined;
+          },
         },
       },
     },
-  },
-  server: {
-    proxy: {
-      [`${basePath}/api`]: {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-      [`${basePath}/auth`]: {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-      [`${basePath}/config`]: {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
-      [`${basePath}/public-config`]: {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
-      },
+    server: {
+      proxy: createDevProxyConfig(env.BASE_PATH),
     },
-  },
+  };
 });

--- a/frontend/viteBasePath.ts
+++ b/frontend/viteBasePath.ts
@@ -1,0 +1,52 @@
+import type { Connect, Plugin } from 'vite';
+import { normalizeBasePath } from '../src/utils/basePath.js';
+
+const NON_PAGE_PATHS = ['/api', '/config', '/public-config'];
+
+const isPathWithin = (pathname: string, prefix: string): boolean =>
+  pathname === prefix || pathname.startsWith(`${prefix}/`);
+
+const isHtmlRequest = (request: Connect.IncomingMessage): boolean => {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return false;
+  }
+
+  return request.headers.accept?.includes('text/html') ?? false;
+};
+
+export const createDevBasePathRedirectMiddleware = (
+  basePath?: string | null,
+): Connect.NextHandleFunction => {
+  const normalizedBasePath = normalizeBasePath(basePath);
+
+  return (request, response, next) => {
+    if (!normalizedBasePath || !isHtmlRequest(request)) {
+      next();
+      return;
+    }
+
+    const requestUrl = new URL(request.url ?? '/', 'http://localhost');
+    const { pathname, search } = requestUrl;
+
+    if (
+      isPathWithin(pathname, normalizedBasePath) ||
+      NON_PAGE_PATHS.some((path) => isPathWithin(pathname, path))
+    ) {
+      next();
+      return;
+    }
+
+    const targetPath = pathname === '/' ? '/' : pathname;
+    response.statusCode = 302;
+    response.setHeader('Location', `${normalizedBasePath}${targetPath}${search}`);
+    response.end();
+  };
+};
+
+export const createDevBasePathRedirectPlugin = (basePath?: string | null): Plugin => ({
+  name: 'mcphub-dev-base-path-redirect',
+  apply: 'serve',
+  configureServer(server) {
+    server.middlewares.use(createDevBasePathRedirectMiddleware(basePath));
+  },
+});

--- a/frontend/viteProxy.ts
+++ b/frontend/viteProxy.ts
@@ -1,0 +1,22 @@
+import { joinBasePath } from '../src/utils/basePath.js';
+
+export interface DevProxyEntry {
+  target: string;
+  changeOrigin: boolean;
+}
+
+const DEV_PROXY_ROUTES = ['/api', '/config', '/public-config'] as const;
+
+export const createDevProxyConfig = (
+  basePath?: string | null,
+  target = 'http://localhost:3000',
+): Record<string, DevProxyEntry> =>
+  Object.fromEntries(
+    DEV_PROXY_ROUTES.map((route) => [
+      joinBasePath(basePath, route),
+      {
+        target,
+        changeOrigin: true,
+      },
+    ]),
+  );

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import { McpSettings, IUser } from '../types/index.js';
 import { getPackageVersion } from '../utils/version.js';
+import { normalizeBasePath } from '../utils/basePath.js';
 import { getDataService } from '../services/services.js';
 import { DataService } from '../services/dataService.js';
 import { DaoConfigService, createDaoConfigService } from './DaoConfigService.js';
@@ -15,7 +16,7 @@ dotenv.config();
 const defaultConfig = {
   port: process.env.PORT || 3000,
   initTimeout: process.env.INIT_TIMEOUT || 300000,
-  basePath: process.env.BASE_PATH || '',
+  basePath: normalizeBasePath(process.env.BASE_PATH),
   readonly: 'true' === process.env.READONLY || false,
   mcpHubName: 'mcphub',
   mcpHubVersion: getPackageVersion(),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import fs from 'fs';
 import { McpSettings, IUser } from '../types/index.js';
 import { getConfigFilePath } from '../utils/path.js';
+import { normalizeBasePath } from '../utils/basePath.js';
 import { getCachedSystemConfig, isDatabaseModeEnabled } from '../utils/systemConfigCache.js';
 import { getPackageVersion } from '../utils/version.js';
 import { getDataService } from '../services/services.js';
@@ -13,7 +14,7 @@ dotenv.config();
 const defaultConfig = {
   port: process.env.PORT || 3000,
   initTimeout: process.env.INIT_TIMEOUT || 300000,
-  basePath: process.env.BASE_PATH || '',
+  basePath: normalizeBasePath(process.env.BASE_PATH),
   readonly: 'true' === process.env.READONLY || false,
   mcpHubName: 'mcphub',
   mcpHubVersion: getPackageVersion(),

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -1,0 +1,14 @@
+export const normalizeBasePath = (value?: string | null): string => {
+  const trimmed = value?.trim() ?? '';
+  if (!trimmed || trimmed === '/') {
+    return '';
+  }
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  return withLeadingSlash.replace(/\/+$/, '');
+};
+
+export const joinBasePath = (basePath: string | undefined | null, route: string): string => {
+  const normalizedRoute = route.startsWith('/') ? route : `/${route}`;
+  return `${normalizeBasePath(basePath)}${normalizedRoute}`;
+};

--- a/tests/config/base-path.test.ts
+++ b/tests/config/base-path.test.ts
@@ -1,0 +1,20 @@
+describe('runtime BASE_PATH configuration', () => {
+  const originalBasePath = process.env.BASE_PATH;
+
+  afterEach(() => {
+    if (originalBasePath === undefined) {
+      delete process.env.BASE_PATH;
+    } else {
+      process.env.BASE_PATH = originalBasePath;
+    }
+    jest.resetModules();
+  });
+
+  it('normalizes a trailing slash before routes are registered', async () => {
+    process.env.BASE_PATH = '/mcphub/';
+
+    const { default: config } = await import('../../src/config/index.js');
+
+    expect(config.basePath).toBe('/mcphub');
+  });
+});

--- a/tests/frontend/runtime.test.ts
+++ b/tests/frontend/runtime.test.ts
@@ -1,0 +1,34 @@
+import { loadRuntimeConfig } from '../../frontend/src/utils/runtime.js';
+
+describe('frontend runtime configuration', () => {
+  const originalWindow = globalThis.window;
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+    globalThis.fetch = originalFetch;
+  });
+
+  it('loads configuration from the current BASE_PATH entry path', async () => {
+    globalThis.window = {
+      location: { pathname: '/mcphub/' },
+    } as Window & typeof globalThis;
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: { basePath: '/mcphub', version: 'dev', name: 'mcphub' },
+      }),
+    }) as unknown as typeof fetch;
+
+    await expect(loadRuntimeConfig()).resolves.toEqual({
+      basePath: '/mcphub',
+      version: 'dev',
+      name: 'mcphub',
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      '/mcphub/config',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});

--- a/tests/frontend/viteBasePath.test.ts
+++ b/tests/frontend/viteBasePath.test.ts
@@ -1,0 +1,63 @@
+import { createDevBasePathRedirectMiddleware } from '../../frontend/viteBasePath.js';
+
+const runMiddleware = (basePath: string, url: string, accept = 'text/html') => {
+  const response = {
+    end: jest.fn(),
+    setHeader: jest.fn(),
+    statusCode: 0,
+  };
+  const next = jest.fn();
+
+  createDevBasePathRedirectMiddleware(basePath)(
+    { headers: { accept }, method: 'GET', url } as never,
+    response as never,
+    next,
+  );
+
+  return { next, response };
+};
+
+describe('createDevBasePathRedirectMiddleware', () => {
+  it.each([
+    ['/', '/mcphub/'],
+    ['/login?next=%2Fdashboard', '/mcphub/login?next=%2Fdashboard'],
+  ])('redirects %s to %s', (url, location) => {
+    const { next, response } = runMiddleware('/mcphub', url);
+
+    expect(response.statusCode).toBe(302);
+    expect(response.setHeader).toHaveBeenCalledWith('Location', location);
+    expect(response.end).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it.each(['/mcphub/', '/mcphub/login'])('passes through %s', (url) => {
+    const { next, response } = runMiddleware('/mcphub', url);
+
+    expect(next).toHaveBeenCalled();
+    expect(response.end).not.toHaveBeenCalled();
+  });
+
+  it.each(['/api/auth/login', '/config', '/public-config'])(
+    'does not redirect API or config request %s',
+    (url) => {
+      const { next, response } = runMiddleware('/mcphub', url);
+
+      expect(next).toHaveBeenCalled();
+      expect(response.end).not.toHaveBeenCalled();
+    },
+  );
+
+  it('passes through non-HTML requests', () => {
+    const { next, response } = runMiddleware('/mcphub', '/login', '*/*');
+
+    expect(next).toHaveBeenCalled();
+    expect(response.end).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when BASE_PATH is empty', () => {
+    const { next, response } = runMiddleware('', '/login');
+
+    expect(next).toHaveBeenCalled();
+    expect(response.end).not.toHaveBeenCalled();
+  });
+});

--- a/tests/frontend/viteProxy.test.ts
+++ b/tests/frontend/viteProxy.test.ts
@@ -1,0 +1,15 @@
+import { createDevProxyConfig } from '../../frontend/viteProxy.js';
+
+describe('createDevProxyConfig', () => {
+  it('prefixes the development API proxy with BASE_PATH', () => {
+    expect(Object.keys(createDevProxyConfig('/mcphub/'))).toEqual([
+      '/mcphub/api',
+      '/mcphub/config',
+      '/mcphub/public-config',
+    ]);
+  });
+
+  it('keeps root proxy paths when BASE_PATH is empty', () => {
+    expect(Object.keys(createDevProxyConfig(''))).toEqual(['/api', '/config', '/public-config']);
+  });
+});

--- a/tests/utils/basePath.test.ts
+++ b/tests/utils/basePath.test.ts
@@ -1,0 +1,14 @@
+import { normalizeBasePath } from '../../src/utils/basePath.js';
+
+describe('normalizeBasePath', () => {
+  it.each([
+    ['/mcphub/', '/mcphub'],
+    ['/mcphub////', '/mcphub'],
+    ['mcphub', '/mcphub'],
+    ['/', ''],
+    ['', ''],
+    [undefined, ''],
+  ])('normalizes %p to %p', (value, expected) => {
+    expect(normalizeBasePath(value)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize `BASE_PATH` consistently across backend configuration and route construction.
- Configure the Vite development proxy from the project-root `.env` so `/mcphub/config`, `/mcphub/public-config`, and `/mcphub/api/*` reach the backend.
- Add regression tests and document the `/mcphub/` local development entrypoint.

Closes #425

## Validation

- `pnpm test:ci` — 156 suites, 1091 tests passed.
- `pnpm lint`
- `pnpm build`
- `node scripts/verify-dist.js`
- Isolated Vite verification: `/mcphub/config` returned 200 and `/mcphub/api/auth/login` returned the backend validation response instead of 404/502.