### PR TITLE
fix(security): resolve CodeQL path injection, prototype pollution and rate limiting alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['v*.*.*']
 
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest

--- a/frontend/src/components/ui/DynamicForm.tsx
+++ b/frontend/src/components/ui/DynamicForm.tsx
@@ -187,6 +187,12 @@ const DynamicForm: React.FC<DynamicFormProps> = ({
     setFormValues((prev) => {
       const newValues = { ...prev };
       const keys = path.split('.');
+
+      // Guard against prototype pollution via malicious path segments
+      if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) {
+        return prev;
+      }
+
       let current = newValues;
 
       for (let i = 0; i < keys.length - 1; i++) {

--- a/src/controllers/mcpbController.ts
+++ b/src/controllers/mcpbController.ts
@@ -17,8 +17,12 @@ const storage = multer.diskStorage({
   },
   filename: (_req, file, cb) => {
     const timestamp = Date.now();
-    const originalName = path.parse(file.originalname).name;
-    cb(null, `${originalName}-${timestamp}.mcpb`);
+    // Sanitize the original name so the stored path cannot escape the upload directory
+    const safeOriginalName = path.parse(path.basename(file.originalname)).name.replace(
+      /[^A-Za-z0-9._-]/g,
+      '_',
+    );
+    cb(null, `${safeOriginalName}-${timestamp}.mcpb`);
   },
 });
 
@@ -42,6 +46,12 @@ const MCPB_UPLOAD_DIR = path.join('data', 'uploads', 'mcpb');
 const MCPB_SERVER_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 const getMcpbUploadDir = (): string => path.join(process.cwd(), MCPB_UPLOAD_DIR);
+
+const isPathInsideUploadDir = (targetPath: string): boolean => {
+  const uploadDir = path.resolve(getMcpbUploadDir());
+  const resolvedTargetPath = path.resolve(targetPath);
+  return resolvedTargetPath === uploadDir || resolvedTargetPath.startsWith(uploadDir + path.sep);
+};
 
 const validateMcpbServerName = (serverName: unknown): string => {
   if (typeof serverName !== 'string') {
@@ -112,6 +122,13 @@ export const uploadMcpbFile = async (req: Request, res: Response): Promise<void>
     }
 
     const mcpbFilePath = req.file.path;
+    if (!isPathInsideUploadDir(mcpbFilePath)) {
+      res.status(400).json({
+        success: false,
+        message: 'Invalid MCPB file location',
+      });
+      return;
+    }
     const timestamp = Date.now();
     const tempExtractDir = path.join(path.dirname(mcpbFilePath), `temp-extracted-${timestamp}`);
 

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -147,6 +147,11 @@ const assignServerOwner = (req: Request, config: ServerConfig, existingOwner?: s
   config.owner = currentUser.username;
 };
 
+// Keys that must never be used as config object indices to prevent prototype pollution
+const UNSAFE_CONFIG_ITEM_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+const isSafeConfigItemKey = (value: string): boolean => !UNSAFE_CONFIG_ITEM_KEYS.has(value);
+
 const clearDescriptionOverride = (
   items: DescribableConfig,
   itemName: string,
@@ -1313,7 +1318,7 @@ export const toggleTool = async (req: Request, res: Response): Promise<void> => 
     const toolName = decodeURIComponent(req.params.toolName);
     const { enabled } = req.body;
 
-    if (!serverName || !toolName) {
+    if (!serverName || !toolName || !isSafeConfigItemKey(toolName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and tool name are required',
@@ -1376,7 +1381,7 @@ export const updateToolDescription = async (req: Request, res: Response): Promis
     const toolName = decodeURIComponent(req.params.toolName);
     const { description } = req.body;
 
-    if (!serverName || !toolName) {
+    if (!serverName || !toolName || !isSafeConfigItemKey(toolName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and tool name are required',
@@ -1442,7 +1447,7 @@ export const resetToolDescription = async (req: Request, res: Response): Promise
     const serverName = decodeURIComponent(req.params.serverName);
     const toolName = decodeURIComponent(req.params.toolName);
 
-    if (!serverName || !toolName) {
+    if (!serverName || !toolName || !isSafeConfigItemKey(toolName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and tool name are required',
@@ -2196,7 +2201,7 @@ export const togglePrompt = async (req: Request, res: Response): Promise<void> =
     const promptName = decodeURIComponent(req.params.promptName);
     const { enabled } = req.body;
 
-    if (!serverName || !promptName) {
+    if (!serverName || !promptName || !isSafeConfigItemKey(promptName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and prompt name are required',
@@ -2259,7 +2264,7 @@ export const updatePromptDescription = async (req: Request, res: Response): Prom
     const promptName = decodeURIComponent(req.params.promptName);
     const { description } = req.body;
 
-    if (!serverName || !promptName) {
+    if (!serverName || !promptName || !isSafeConfigItemKey(promptName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and prompt name are required',
@@ -2322,7 +2327,7 @@ export const resetPromptDescription = async (req: Request, res: Response): Promi
     const serverName = decodeURIComponent(req.params.serverName);
     const promptName = decodeURIComponent(req.params.promptName);
 
-    if (!serverName || !promptName) {
+    if (!serverName || !promptName || !isSafeConfigItemKey(promptName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and prompt name are required',
@@ -2377,7 +2382,7 @@ export const toggleResource = async (req: Request, res: Response): Promise<void>
     const resourceUri = decodeURIComponent(req.params.resourceUri);
     const { enabled } = req.body;
 
-    if (!serverName || !resourceUri) {
+    if (!serverName || !resourceUri || !isSafeConfigItemKey(resourceUri)) {
       res.status(400).json({
         success: false,
         message: 'Server name and resource URI are required',
@@ -2440,7 +2445,7 @@ export const updateResourceDescription = async (req: Request, res: Response): Pr
     const resourceUri = decodeURIComponent(req.params.resourceUri);
     const { description } = req.body;
 
-    if (!serverName || !resourceUri) {
+    if (!serverName || !resourceUri || !isSafeConfigItemKey(resourceUri)) {
       res.status(400).json({
         success: false,
         message: 'Server name and resource URI are required',
@@ -2503,7 +2508,7 @@ export const resetResourceDescription = async (req: Request, res: Response): Pro
     const serverName = decodeURIComponent(req.params.serverName);
     const resourceUri = decodeURIComponent(req.params.resourceUri);
 
-    if (!serverName || !resourceUri) {
+    if (!serverName || !resourceUri || !isSafeConfigItemKey(resourceUri)) {
       res.status(400).json({
         success: false,
         message: 'Server name and resource URI are required',

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -170,10 +170,11 @@ import {
 import { auth } from '../middlewares/auth.js';
 import { getBetterAuthRuntimeConfig } from '../services/betterAuthConfig.js';
 import {
+  authAttemptRateLimiter,
   authenticatedRouteRateLimiter,
   hostedInternalEventRateLimiter,
-  templateRateLimiter,
   mcpConnectionRateLimiter,
+  templateRateLimiter,
 } from '../utils/rateLimit.js';
 
 const router = express.Router();
@@ -209,7 +210,7 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
   );
 
   // OAuth callback endpoint (no auth required, public callback URL)
-  app.get('/oauth/callback', handleOAuthCallback);
+  app.get('/oauth/callback', mcpConnectionRateLimiter, handleOAuthCallback);
 
   // OAuth Authorization Server endpoints (no auth required for OAuth flow)
   app.get('/oauth/authorize', mcpConnectionRateLimiter, getAuthorize);
@@ -422,6 +423,7 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
       check('username', 'Username is required').not().isEmpty(),
       check('password', 'Password is required').not().isEmpty(),
     ],
+    authAttemptRateLimiter,
     login,
   );
 
@@ -431,6 +433,7 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
       check('username', 'Username is required').not().isEmpty(),
       check('password', 'Password must be at least 6 characters').isLength({ min: 6 }),
     ],
+    authAttemptRateLimiter,
     register,
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ import { resolveCorsOrigin } from './utils/corsOrigin.js';
 import { setFrontendDistPath } from './utils/frontendShell.js';
 import http from 'http';
 import type { Socket } from 'net';
-import { mcpConnectionRateLimiter } from './utils/rateLimit.js';
+import { mcpConnectionRateLimiter, spaPageRateLimiter } from './utils/rateLimit.js';
 import { closeHttpServer } from './utils/serverShutdown.js';
 import { logger } from './utils/logger.js';
 
@@ -209,7 +209,7 @@ export class AppServer {
 
       // Add the wildcard route for SPA with base path
       if (fs.existsSync(path.join(this.frontendPath, 'index.html'))) {
-        this.app.get(`${this.basePath}/*`, (_req, res) => {
+        this.app.get(`${this.basePath}/*`, spaPageRateLimiter, (_req, res) => {
           res.sendFile(path.join(this.frontendPath!, 'index.html'));
         });
 

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -32,3 +32,13 @@ export const mcpConnectionRateLimiter = createStandardRateLimiter({
   windowMs: 60 * 1000,
   max: 480,
 });
+
+export const authAttemptRateLimiter = createStandardRateLimiter({
+  windowMs: 15 * 60 * 1000,
+  max: 20,
+});
+
+export const spaPageRateLimiter = createStandardRateLimiter({
+  windowMs: 60 * 1000,
+  max: 600,
+});

--- a/tests/integration/rate-limit-routing.test.ts
+++ b/tests/integration/rate-limit-routing.test.ts
@@ -61,6 +61,7 @@ jest.mock('../../src/middlewares/userContext.js', () => ({
 jest.mock('../../src/utils/rateLimit.js', () => ({
   __esModule: true,
   mcpConnectionRateLimiter: mcpConnectionRateLimiterMock,
+  spaPageRateLimiter: mcpConnectionRateLimiterMock,
 }));
 
 import { AppServer } from '../../src/server.js';

--- a/tests/integration/server-headless-mode.test.ts
+++ b/tests/integration/server-headless-mode.test.ts
@@ -69,6 +69,7 @@ jest.mock('../../src/middlewares/userContext.js', () => ({
 jest.mock('../../src/utils/rateLimit.js', () => ({
   __esModule: true,
   mcpConnectionRateLimiter: mcpConnectionRateLimiterMock,
+  spaPageRateLimiter: mcpConnectionRateLimiterMock,
 }));
 
 import { AppServer } from '../../src/server.js';


### PR DESCRIPTION
## Description

Resolves all 17 currently open CodeQL code-scanning alerts across 5 rule categories.

### js/path-injection (8 alerts, high) — `src/controllers/mcpbController.ts`
- **Real vulnerability**: multer `filename` used the raw `file.originalname`, so a crafted name like `../../x.mcpb` could escape the upload directory. The stored name is now sanitized (`basename` + `[A-Za-z0-9._-]` whitelist).
- Added `isPathInsideUploadDir()` containment check validated before any filesystem operation on `req.file.path` (read/rename/unlink/rm).

### js/prototype-polluting-assignment (3 alerts, medium) — `src/controllers/serverController.ts`
- `toolName` / `promptName` / `resourceUri` come from URL params; passing `__proto__` made `tools['__proto__'].description = ...` mutate `Object.prototype`.
- Added `isSafeConfigItemKey()` and applied it in all 9 tool/prompt/resource handlers (toggle, update description, reset description), returning 400 for unsafe keys.

### js/prototype-pollution-utility (1 alert, medium) — `frontend/src/components/ui/DynamicForm.tsx`
- `handleInputChange` recursively assigned along dot-separated path segments without guarding dangerous keys. Added a guard that rejects `__proto__` / `constructor` / `prototype` segments.

### js/missing-rate-limiting (3 alerts, high)
- `/auth/login` and `/auth/register`: new dedicated strict `authAttemptRateLimiter` (15 min window, 20 requests) to mitigate brute-force attempts.
- `/oauth/callback`: reuse existing `mcpConnectionRateLimiter`.
- SPA wildcard route in `AppServer.findAndServeFrontend()`: new generous `spaPageRateLimiter` (60 s window, 600 requests) — page loads are unaffected, filesystem access is now rate-limited.

### actions/missing-workflow-permissions (2 alerts, medium)
- Added top-level `permissions: contents: read` to `.github/workflows/ci.yml` and `.github/workflows/npm-publish.yml`.

The two integration tests mocking `utils/rateLimit.js` were updated to provide the new export (`spaPageRateLimiter`).

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:ci` passes (1105 tests, 158 suites)
- [x] `pnpm build` passes
- [ ] CodeQL scan on this branch should auto-close all 17 alerts

Alerts will auto-close after CodeQL analyzes this branch.
