### PR TITLE
fix(security): use CodeQL-recognized barrier guards to close remaining 12 alerts

### DIFF
--- a/frontend/src/components/ui/DynamicForm.tsx
+++ b/frontend/src/components/ui/DynamicForm.tsx
@@ -187,22 +187,25 @@ const DynamicForm: React.FC<DynamicFormProps> = ({
     setFormValues((prev) => {
       const newValues = { ...prev };
       const keys = path.split('.');
-
-      // Guard against prototype pollution via malicious path segments
-      if (keys.some((key) => key === '__proto__' || key === 'constructor' || key === 'prototype')) {
-        return prev;
-      }
-
       let current = newValues;
 
       for (let i = 0; i < keys.length - 1; i++) {
-        if (!current[keys[i]]) {
-          current[keys[i]] = {};
+        const key = keys[i];
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+          return prev;
         }
-        current = current[keys[i]];
+        if (!current[key]) {
+          current[key] = {};
+        }
+        current = current[key];
       }
 
-      current[keys[keys.length - 1]] = value;
+      const lastKey = keys[keys.length - 1];
+      if (!lastKey || lastKey === '__proto__' || lastKey === 'constructor' || lastKey === 'prototype') {
+        return prev;
+      }
+
+      current[lastKey] = value;
 
       // Save to localStorage if storageKey is provided
       if (storageKey) {

--- a/src/controllers/mcpbController.ts
+++ b/src/controllers/mcpbController.ts
@@ -47,12 +47,6 @@ const MCPB_SERVER_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 const getMcpbUploadDir = (): string => path.join(process.cwd(), MCPB_UPLOAD_DIR);
 
-const isPathInsideUploadDir = (targetPath: string): boolean => {
-  const uploadDir = path.resolve(getMcpbUploadDir());
-  const resolvedTargetPath = path.resolve(targetPath);
-  return resolvedTargetPath === uploadDir || resolvedTargetPath.startsWith(uploadDir + path.sep);
-};
-
 const validateMcpbServerName = (serverName: unknown): string => {
   if (typeof serverName !== 'string') {
     throw new Error('Invalid manifest: missing name');
@@ -121,11 +115,12 @@ export const uploadMcpbFile = async (req: Request, res: Response): Promise<void>
       return;
     }
 
-    const mcpbFilePath = req.file.path;
-    if (!isPathInsideUploadDir(mcpbFilePath)) {
+    const mcpbFilePath = req.file?.path;
+    const uploadRoot = `${path.resolve(getMcpbUploadDir())}${path.sep}`;
+    if (!mcpbFilePath || !path.resolve(mcpbFilePath).startsWith(uploadRoot)) {
       res.status(400).json({
         success: false,
-        message: 'Invalid MCPB file location',
+        message: mcpbFilePath ? 'Invalid MCPB file location' : 'No MCPB file uploaded',
       });
       return;
     }

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -147,11 +147,6 @@ const assignServerOwner = (req: Request, config: ServerConfig, existingOwner?: s
   config.owner = currentUser.username;
 };
 
-// Keys that must never be used as config object indices to prevent prototype pollution
-const UNSAFE_CONFIG_ITEM_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
-
-const isSafeConfigItemKey = (value: string): boolean => !UNSAFE_CONFIG_ITEM_KEYS.has(value);
-
 const clearDescriptionOverride = (
   items: DescribableConfig,
   itemName: string,
@@ -1318,7 +1313,7 @@ export const toggleTool = async (req: Request, res: Response): Promise<void> => 
     const toolName = decodeURIComponent(req.params.toolName);
     const { enabled } = req.body;
 
-    if (!serverName || !toolName || !isSafeConfigItemKey(toolName)) {
+    if (!serverName || !toolName || ['__proto__', 'constructor', 'prototype'].includes(toolName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and tool name are required',
@@ -1381,7 +1376,7 @@ export const updateToolDescription = async (req: Request, res: Response): Promis
     const toolName = decodeURIComponent(req.params.toolName);
     const { description } = req.body;
 
-    if (!serverName || !toolName || !isSafeConfigItemKey(toolName)) {
+    if (!serverName || !toolName || ['__proto__', 'constructor', 'prototype'].includes(toolName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and tool name are required',
@@ -1447,7 +1442,7 @@ export const resetToolDescription = async (req: Request, res: Response): Promise
     const serverName = decodeURIComponent(req.params.serverName);
     const toolName = decodeURIComponent(req.params.toolName);
 
-    if (!serverName || !toolName || !isSafeConfigItemKey(toolName)) {
+    if (!serverName || !toolName || ['__proto__', 'constructor', 'prototype'].includes(toolName)) {
       res.status(400).json({
         success: false,
         message: 'Server name and tool name are required',
@@ -2201,7 +2196,11 @@ export const togglePrompt = async (req: Request, res: Response): Promise<void> =
     const promptName = decodeURIComponent(req.params.promptName);
     const { enabled } = req.body;
 
-    if (!serverName || !promptName || !isSafeConfigItemKey(promptName)) {
+    if (
+      !serverName ||
+      !promptName ||
+      ['__proto__', 'constructor', 'prototype'].includes(promptName)
+    ) {
       res.status(400).json({
         success: false,
         message: 'Server name and prompt name are required',
@@ -2264,7 +2263,11 @@ export const updatePromptDescription = async (req: Request, res: Response): Prom
     const promptName = decodeURIComponent(req.params.promptName);
     const { description } = req.body;
 
-    if (!serverName || !promptName || !isSafeConfigItemKey(promptName)) {
+    if (
+      !serverName ||
+      !promptName ||
+      ['__proto__', 'constructor', 'prototype'].includes(promptName)
+    ) {
       res.status(400).json({
         success: false,
         message: 'Server name and prompt name are required',
@@ -2327,7 +2330,11 @@ export const resetPromptDescription = async (req: Request, res: Response): Promi
     const serverName = decodeURIComponent(req.params.serverName);
     const promptName = decodeURIComponent(req.params.promptName);
 
-    if (!serverName || !promptName || !isSafeConfigItemKey(promptName)) {
+    if (
+      !serverName ||
+      !promptName ||
+      ['__proto__', 'constructor', 'prototype'].includes(promptName)
+    ) {
       res.status(400).json({
         success: false,
         message: 'Server name and prompt name are required',
@@ -2382,7 +2389,11 @@ export const toggleResource = async (req: Request, res: Response): Promise<void>
     const resourceUri = decodeURIComponent(req.params.resourceUri);
     const { enabled } = req.body;
 
-    if (!serverName || !resourceUri || !isSafeConfigItemKey(resourceUri)) {
+    if (
+      !serverName ||
+      !resourceUri ||
+      ['__proto__', 'constructor', 'prototype'].includes(resourceUri)
+    ) {
       res.status(400).json({
         success: false,
         message: 'Server name and resource URI are required',
@@ -2445,7 +2456,11 @@ export const updateResourceDescription = async (req: Request, res: Response): Pr
     const resourceUri = decodeURIComponent(req.params.resourceUri);
     const { description } = req.body;
 
-    if (!serverName || !resourceUri || !isSafeConfigItemKey(resourceUri)) {
+    if (
+      !serverName ||
+      !resourceUri ||
+      ['__proto__', 'constructor', 'prototype'].includes(resourceUri)
+    ) {
       res.status(400).json({
         success: false,
         message: 'Server name and resource URI are required',
@@ -2508,7 +2523,11 @@ export const resetResourceDescription = async (req: Request, res: Response): Pro
     const serverName = decodeURIComponent(req.params.serverName);
     const resourceUri = decodeURIComponent(req.params.resourceUri);
 
-    if (!serverName || !resourceUri || !isSafeConfigItemKey(resourceUri)) {
+    if (
+      !serverName ||
+      !resourceUri ||
+      ['__proto__', 'constructor', 'prototype'].includes(resourceUri)
+    ) {
       res.status(400).json({
         success: false,
         message: 'Server name and resource URI are required',


### PR DESCRIPTION
## Description

Round 1 (#1066) fixed 5 of the 17 open CodeQL alerts, but the remaining 12 persisted after merge because the fixes used **custom validation helpers, which CodeQL treats as opaque calls** — its taint analysis cannot see through them, so the alerts stayed open.

This PR rewrites the guards using barrier patterns that CodeQL's queries recognize natively (verified against the query sources in `github/codeql`):

### js/path-injection (8 alerts) — `src/controllers/mcpbController.ts`
Replaced `isPathInsideUploadDir()` helper with the inline pattern matching CodeQL's `RelativePathStartsWithSanitizer`:

```ts
if (!mcpbFilePath || !path.resolve(mcpbFilePath).startsWith(uploadRoot)) { ... }
```

`path.resolve(x).startsWith(dir)` directly sanitizes `x` for all downstream fs operations (existsSync/readFileSync/renameSync/unlinkSync/rmSync).

### js/prototype-polluting-assignment (3 alerts) — `src/controllers/serverController.ts`
Replaced the `Set.has()` helper with inline denylist array literals in all 9 tool/prompt/resource handlers, matching the query's `DenyListInclusionGuard`:

```ts
['__proto__', 'constructor', 'prototype'].includes(toolName)
```

### js/prototype-pollution-utility (1 alert) — `frontend/src/components/ui/DynamicForm.tsx`
The previous `.some()` callback guard was invisible to the query's data flow (which tracks `split('.')` array elements into property writes). Moved per-segment equality checks (`key === '__proto__' || key === 'constructor' || key === 'prototype'`) inside the assignment loop, exactly where the flow can observe them.

## Verification

Ran CodeQL locally (CLI 2.26.3 + codeql/javascript-queries 2.4.3) on both trees:

| Tree | TaintedPath | PrototypePollutingAssignment | PrototypePollutingFunction |
| --- | --- | --- | --- |
| current main (round-1 fix) | 8 alerts | 3 alerts | 1 alert — **identical locations to production** |
| this branch | **0** | **0** | **0** |

Also passing: `pnpm lint`, `pnpm test:ci` (1105 tests), `pnpm build`.

## Test plan
- [x] Local CodeQL evaluation shows zero findings for all three rules
- [x] Pre-fix tree reproduces the exact 12 open alerts (validates harness)
- [x] lint / tests / build pass
