### PR TITLE
fix(security): close open security advisory findings (SSRF, authz, OAuth PKCE)

### DIFF
--- a/src/clients/__tests__/openapi-external-ref.test.ts
+++ b/src/clients/__tests__/openapi-external-ref.test.ts
@@ -1,0 +1,140 @@
+import { OpenAPIClient } from '../openapi.js';
+import type { ServerConfig } from '../../types/index.js';
+import { UnsafeUrlError } from '../../utils/ssrf.js';
+
+type TestClient = OpenAPIClient & {
+  baseUrl: string;
+  allowInternalNetworks: boolean;
+  spec: Record<string, unknown> | null;
+  httpClient: { get?: jest.Mock; request: jest.Mock };
+};
+
+jest.mock('../../dao/index.js', () => {
+  const findByUsername = jest.fn();
+  return { getUserDao: () => ({ findByUsername }) };
+});
+
+import { getUserDao } from '../../dao/index.js';
+
+const findByUsername = (getUserDao() as unknown as { findByUsername: jest.Mock }).findByUsername;
+
+function specWithExternalRef(ref: string): Record<string, unknown> {
+  return {
+    openapi: '3.0.0',
+    info: { title: 'Test API', version: '1.0.0' },
+    paths: {
+      '/things': {
+        get: {
+          operationId: 'get_things',
+          responses: {
+            '200': {
+              description: 'ok',
+              content: {
+                'application/json': {
+                  schema: { $ref: ref },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeSchemaClient(ref: string, owner?: string): TestClient {
+  const config: ServerConfig = {
+    type: 'openapi',
+    owner,
+    openapi: { schema: specWithExternalRef(ref) as never },
+  };
+  const client = new OpenAPIClient(config) as TestClient;
+  client.httpClient = { request: jest.fn() };
+  return client;
+}
+
+function makeUrlClient(rawSpec: string): TestClient {
+  const config: ServerConfig = {
+    type: 'openapi',
+    openapi: { url: 'http://93.184.216.34/v3/api-docs' },
+  };
+  const client = new OpenAPIClient(config) as TestClient;
+  client.httpClient = {
+    get: jest.fn().mockResolvedValue({ data: rawSpec }),
+    request: jest.fn(),
+  };
+  return client;
+}
+
+// Response-like stub matching what createRedirectValidatingFetch consumes.
+const refFetchResponse = (body: string) => ({
+  status: 200,
+  headers: { get: () => null },
+  body: Buffer.from(body),
+  arrayBuffer: async () => new TextEncoder().encode(body),
+});
+
+describe('OpenAPIClient - SSRF guard on external $ref resolution', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    findByUsername.mockReset();
+    findByUsername.mockResolvedValue(undefined);
+    (globalThis as { fetch: unknown }).fetch = fetchMock;
+  });
+
+  it('blocks an inline-schema $ref to an internal host and never dials', async () => {
+    const client = makeSchemaClient('http://127.0.0.1:9/ext.json#/schemas/Secret');
+    await expect(client.initialize()).rejects.toThrow(UnsafeUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks an inline-schema $ref to the cloud metadata endpoint', async () => {
+    const client = makeSchemaClient('http://169.254.169.254/latest/meta-data/');
+    await expect(client.initialize()).rejects.toThrow(UnsafeUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still resolves a $ref to a public IP host through the guarded resolver', async () => {
+    const client = makeSchemaClient('http://93.184.216.34/ext.json#/schemas/Secret');
+    fetchMock.mockResolvedValue(
+      refFetchResponse(JSON.stringify({ schemas: { Secret: { type: 'object' } } })),
+    );
+    await expect(client.initialize()).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toBe('http://93.184.216.34/ext.json');
+    // No credentials on external $ref fetches (#1044 semantics preserved).
+    expect((fetchMock.mock.calls[0][1] as { headers: unknown }).headers).toEqual({});
+  });
+
+  it('allows an internal-host $ref for admin-owned servers', async () => {
+    findByUsername.mockResolvedValue({ isAdmin: true });
+    const client = makeSchemaClient(
+      'http://127.0.0.1:8081/internal.json#/schemas/Secret',
+      'boss',
+    );
+    fetchMock.mockResolvedValue(
+      refFetchResponse(JSON.stringify({ schemas: { Secret: { type: 'object' } } })),
+    );
+    await expect(client.initialize()).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks local file:// $refs for non-admin-owned servers', async () => {
+    const client = makeSchemaClient('./stolen-secret.yaml');
+    await expect(client.initialize()).rejects.toThrow(UnsafeUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('guards external $refs fetched while loading a URL-based spec too', async () => {
+    const client = makeUrlClient(JSON.stringify(specWithExternalRef('#/noop')));
+    // Replace the main document with one containing an internal absolute ref
+    // AFTER construction so only the $ref resolution path sees it.
+    (client as unknown as { httpClient: { get: jest.Mock } }).httpClient.get.mockResolvedValue({
+      data: JSON.stringify(specWithExternalRef('http://169.254.169.254/meta')),
+    });
+    await expect(client.initialize()).rejects.toThrow(UnsafeUrlError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/clients/__tests__/openapi-spec-auth.test.ts
+++ b/src/clients/__tests__/openapi-spec-auth.test.ts
@@ -235,7 +235,9 @@ describe('OpenAPIClient - authenticated spec document fetch (#1044)', () => {
 
   it('does not forward credentials to a cross-origin external $ref', async () => {
     const credentials = Buffer.from('user:pass').toString('base64');
-    const externalUrl = 'https://external.example.com/schema.json';
+    // Public IP literal so the external-$ref SSRF guard passes without DNS
+    // (all refs are guarded since GHSA-9wx9; example.com is unresolvable by design).
+    const externalUrl = 'https://93.184.216.34/schema.json';
     const docWithExternalRef = JSON.stringify({
       openapi: '3.0.0',
       info: { title: 'Test API', version: '1.0.0' },

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -1,10 +1,11 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { readFile } from 'node:fs/promises';
 import { CookieJar } from 'tough-cookie';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import * as yaml from 'js-yaml';
 import { OpenAPIV3 } from 'openapi-types';
 import { ServerConfig, OpenAPISecurityConfig } from '../types/index.js';
-import { assertSafeUrl, UnsafeUrlError } from '../utils/ssrf.js';
+import { assertSafeUrl, UnsafeUrlError, createRedirectValidatingFetch } from '../utils/ssrf.js';
 import { getUserDao } from '../dao/index.js';
 import { sanitizeStringForLogging, createSafeJSON } from '../utils/serialization.js';
 
@@ -46,6 +47,11 @@ export class OpenAPIClient {
   // Resolved in initialize(): admin-owned servers may target internal services
   // and skip the SSRF internal-IP blocklist.
   private allowInternalNetworks = false;
+  // Records the most recent SSRF rejection raised while resolving external
+  // $refs. SwaggerParser wraps resolver failures in its own ResolverError and
+  // drops the original cause, so initialize() uses this to re-throw the real
+  // UnsafeUrlError to callers.
+  private refGuardRejection?: UnsafeUrlError;
 
   constructor(
     private config: ServerConfig,
@@ -289,6 +295,10 @@ export class OpenAPIClient {
       // No-op when no OAuth2 security is configured.
       await this.ensureOAuth2AccessToken();
 
+      // Reset the external-$ref guard marker so a rejection from THIS
+      // dereference pass is never confused with a stale one.
+      this.refGuardRejection = undefined;
+
       // Parse and dereference the OpenAPI specification
       if (this.config.openapi?.url) {
         // Fetch the document through the authenticated httpClient (carries
@@ -314,12 +324,13 @@ export class OpenAPIClient {
         this.spec = (await SwaggerParser.dereference(
           specUrl,
           this.parseSpecDocument(raw),
-          {},
+          this.guardedRefResolveOptions(),
         )) as OpenAPIV3.Document;
       } else if (this.config.openapi?.schema) {
         // For schema object, we need to pass it as a cloned object
         this.spec = (await SwaggerParser.dereference(
           JSON.parse(JSON.stringify(this.config.openapi.schema)),
+          this.guardedRefResolveOptions(),
         )) as OpenAPIV3.Document;
       } else {
         throw new Error('Either OpenAPI URL or schema must be provided');
@@ -334,6 +345,12 @@ export class OpenAPIClient {
       // target from a parse/auth failure (matches callTool's handling).
       if (error instanceof UnsafeUrlError) {
         throw error;
+      }
+      // SwaggerParser wraps resolver failures (including our SSRF guard
+      // rejections) in its own ResolverError and drops the cause — surface the
+      // real UnsafeUrlError when the guarded $ref resolver flagged one.
+      if (this.refGuardRejection) {
+        throw this.refGuardRejection;
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
       throw new Error(
@@ -351,6 +368,60 @@ export class OpenAPIClient {
     } catch {
       return yaml.load(raw);
     }
+  }
+
+  // SwaggerParser options that replace its built-in resolvers so EVERY external
+  // $ref target is validated by the SSRF guard before any request leaves the
+  // process. Without this, a non-admin-supplied spec could point $refs at
+  // internal addresses (IMDS, RFC1918, loopback) or local files and have their
+  // contents embedded into the dereferenced schema served back to clients.
+  // Admin-owned servers keep the same allowInternal escape hatch as the main
+  // document download and callTool.
+  private guardedRefResolveOptions(): Record<string, unknown> {
+    const rejectUnsafe = (err: UnsafeUrlError): never => {
+      this.refGuardRejection = err;
+      throw err;
+    };
+    return {
+      resolve: {
+        http: {
+          order: 1,
+          canRead: (file: { url: string }) => /^https?:\/\//i.test(file.url),
+          read: async (file: { url: string }): Promise<string> => {
+            try {
+              await assertSafeUrl(file.url, { allowInternal: this.allowInternalNetworks });
+            } catch (error) {
+              rejectUnsafe(error as UnsafeUrlError);
+            }
+            // Plain fetch, NOT this.httpClient: default auth headers and
+            // interceptors must never be forwarded cross-origin to $ref
+            // targets (#1044). Redirects are followed manually with every hop
+            // re-validated by the guard.
+            const safeFetch = createRedirectValidatingFetch(
+              (url, init) => fetch(url, init),
+              this.allowInternalNetworks,
+            );
+            const response = await safeFetch(file.url, { method: 'GET', headers: {} });
+            const buf = await response.arrayBuffer();
+            return new TextDecoder().decode(buf);
+          },
+        },
+        file: {
+          order: 1,
+          canRead: true,
+          read: async (file: { url: string }): Promise<string> => {
+            if (!this.allowInternalNetworks) {
+              rejectUnsafe(
+                new UnsafeUrlError(
+                  `Blocked local file reference in specification: ${sanitizeStringForLogging(file.url)}`,
+                ),
+              );
+            }
+            return readFile(new URL(file.url), 'utf8');
+          },
+        },
+      },
+    };
   }
 
   private generateOperationName(method: string, path: string): string {

--- a/src/controllers/builtinPromptController.ts
+++ b/src/controllers/builtinPromptController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { ApiResponse, BuiltinPrompt } from '../types/index.js';
 import { getBuiltinPromptDao } from '../dao/index.js';
+import { requireAdmin } from '../utils/requireAdmin.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -49,6 +50,7 @@ export const getBuiltinPrompt = async (req: Request, res: Response): Promise<voi
  * Create a new built-in prompt
  */
 export const createBuiltinPrompt = async (req: Request, res: Response): Promise<void> => {
+  if (!(await requireAdmin(req, res))) return;
   try {
     const { name, title, description, template, arguments: args, enabled } = req.body;
     if (!name || !template) {
@@ -79,6 +81,7 @@ export const createBuiltinPrompt = async (req: Request, res: Response): Promise<
  * Update an existing built-in prompt
  */
 export const updateBuiltinPrompt = async (req: Request, res: Response): Promise<void> => {
+  if (!(await requireAdmin(req, res))) return;
   try {
     const { id } = req.params;
     const updates = req.body;
@@ -103,6 +106,7 @@ export const updateBuiltinPrompt = async (req: Request, res: Response): Promise<
  * Delete a built-in prompt
  */
 export const deleteBuiltinPrompt = async (req: Request, res: Response): Promise<void> => {
+  if (!(await requireAdmin(req, res))) return;
   try {
     const { id } = req.params;
     const deleted = await getBuiltinPromptDao().delete(id);

--- a/src/controllers/builtinResourceController.ts
+++ b/src/controllers/builtinResourceController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { ApiResponse, BuiltinResource } from '../types/index.js';
 import { getBuiltinResourceDao } from '../dao/index.js';
 import { handleReadResourceRequest } from '../services/mcpService.js';
+import { requireAdmin } from '../utils/requireAdmin.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -50,6 +51,7 @@ export const getBuiltinResource = async (req: Request, res: Response): Promise<v
  * Create a new built-in resource
  */
 export const createBuiltinResource = async (req: Request, res: Response): Promise<void> => {
+  if (!(await requireAdmin(req, res))) return;
   try {
     const { uri, name, description, mimeType, content, enabled } = req.body;
     if (!uri || !content) {
@@ -80,6 +82,7 @@ export const createBuiltinResource = async (req: Request, res: Response): Promis
  * Update an existing built-in resource
  */
 export const updateBuiltinResource = async (req: Request, res: Response): Promise<void> => {
+  if (!(await requireAdmin(req, res))) return;
   try {
     const { id } = req.params;
     const updates = req.body;
@@ -104,6 +107,7 @@ export const updateBuiltinResource = async (req: Request, res: Response): Promis
  * Delete a built-in resource
  */
 export const deleteBuiltinResource = async (req: Request, res: Response): Promise<void> => {
+  if (!(await requireAdmin(req, res))) return;
   try {
     const { id } = req.params;
     const deleted = await getBuiltinResourceDao().delete(id);

--- a/src/controllers/oauthDynamicRegistrationController.ts
+++ b/src/controllers/oauthDynamicRegistrationController.ts
@@ -8,6 +8,7 @@ import {
 } from '../models/OAuth.js';
 import { IOAuthClient } from '../types/index.js';
 import { getSystemConfigDao } from '../dao/DaoFactory.js';
+import { auth } from '../middlewares/auth.js';
 import { resolveInstallBaseUrl } from '../utils/installBaseUrl.js';
 import { logger } from '../utils/logger.js';
 
@@ -62,6 +63,22 @@ export const registerClient = async (req: Request, res: Response): Promise<void>
         error_description: 'Dynamic client registration is not enabled',
       });
       return;
+    }
+
+    // RFC 7591 §3.1 + GHSA-wwgw/3m7m follow-up: when the operator marks
+    // dynamic registration as requiring authentication, only requests carrying
+    // a recognized credential (dashboard JWT, bearer key, OAuth token or
+    // Better Auth session) may register clients. auth() always settles after
+    // either attaching req.user or sending an error response itself.
+    if (oauthConfig.dynamicRegistration.requiresAuthentication) {
+      try {
+        await auth(req, res, () => {});
+      } catch {
+        // Treated as unauthenticated below.
+      }
+      if (!(req as any).user || res.headersSent) {
+        return;
+      }
     }
 
     // Validate required fields

--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -343,6 +343,16 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
       return;
     }
 
+    // RFC 7636 + GHSA-3m7m: public clients (no registered secret) must present
+    // an S256 code challenge up front. Confidential clients may omit PKCE.
+    if (!client.clientSecret && (!code_challenge || code_challenge_method !== 'S256')) {
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'PKCE with code_challenge_method=S256 is required for public clients',
+      });
+      return;
+    }
+
     // Check if user is authenticated (including via JWT token)
     let user = (req as any).user;
     if (!user) {
@@ -635,7 +645,8 @@ export const getMetadata = async (req: Request, res: Response): Promise<void> =>
         oauthConfig.requireClientSecret !== false
           ? ['client_secret_basic', 'client_secret_post', 'none']
           : ['none'],
-      code_challenge_methods_supported: ['S256', 'plain'],
+      // Only S256 is supported; the library rejects plain (GHSA-3m7m).
+      code_challenge_methods_supported: ['S256'],
     };
 
     // Add dynamic registration endpoint if enabled

--- a/src/controllers/templateController.ts
+++ b/src/controllers/templateController.ts
@@ -25,6 +25,7 @@ export const exportConfigTemplate = async (req: Request, res: Response): Promise
       description,
       groupIds,
       includeDisabledServers: includeDisabledServers ?? false,
+      requestingUser: (req as any).user,
     });
 
     res.json({
@@ -53,7 +54,11 @@ export const exportGroupAsTemplate = async (req: Request, res: Response): Promis
       return;
     }
 
-    const template = await exportGroupTemplate(id, name as string | undefined);
+    const template = await exportGroupTemplate(
+      id,
+      name as string | undefined,
+      (req as any).user,
+    );
 
     if (!template) {
       res.status(404).json({

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import AppServer from './server.js';
 import { initializeDatabaseMode } from './utils/migration.js';
 import { createFetchWithProxy, getProxyConfigFromEnv } from './services/proxy.js';
 import { isRetryableDbError } from './utils/dbRetry.js';
-import { hydrateSystemConfigCache } from './utils/systemConfigCache.js';
+import { hydrateSystemConfigCache, getCachedSystemConfig } from './utils/systemConfigCache.js';
 import { logger } from './utils/logger.js';
 import {
   startHostedEventSubscriber,
@@ -180,6 +180,18 @@ async function boot() {
     }
 
     await hydrateSystemConfigCache();
+
+    // GHSA-wmv9-3qh3-9rpw: skipAuth disables dashboard authentication entirely
+    // and treats every API caller as an implicit admin. Make sure operators
+    // cannot enable it without seeing the consequences in their logs.
+    if (getCachedSystemConfig()?.routing?.skipAuth) {
+      logger.warn(
+        '⚠️  SECURITY WARNING: routing.skipAuth is ENABLED — dashboard authentication is DISABLED and ALL API callers are treated as admins.\n' +
+          '⚠️  Anyone who can reach this port can read/modify settings, export secrets, and register stdio servers (remote code execution).\n' +
+          '⚠️  Never expose this instance to a network. To disable: set systemConfig.routing.skipAuth=false in mcp_settings.json.',
+      );
+    }
+
     void startHostedEventSubscriber().catch((error) => {
       logger.warn('[hosted] Failed to launch Redis event subscriber in background', {
         error: String(error),

--- a/src/services/oauthServerService.ts
+++ b/src/services/oauthServerService.ts
@@ -22,6 +22,10 @@ const { Request, Response } = OAuth2Server;
 const oauthModel: OAuth2Server.AuthorizationCodeModel & OAuth2Server.RefreshTokenModel = {
   /**
    * Get client by client ID
+   *
+   * Confidential clients (a secret is registered) MUST always present their
+   * secret, even when the global requireClientSecret toggle is off — that
+   * toggle only permits secret-less PUBLIC clients (GHSA-3m7m).
    */
   getClient: async (clientId: string, clientSecret?: string) => {
     const client = await findOAuthClientById(clientId);
@@ -29,9 +33,9 @@ const oauthModel: OAuth2Server.AuthorizationCodeModel & OAuth2Server.RefreshToke
       return false;
     }
 
-    // If client secret is provided, verify it
-    if (clientSecret && client.clientSecret) {
-      if (!safeCompare(client.clientSecret, clientSecret)) {
+    // If the registered client has a secret, it must be presented and match.
+    if (client.clientSecret) {
+      if (!clientSecret || !safeCompare(client.clientSecret, clientSecret)) {
         return false;
       }
     }
@@ -47,12 +51,23 @@ const oauthModel: OAuth2Server.AuthorizationCodeModel & OAuth2Server.RefreshToke
 
   /**
    * Save authorization code
+   *
+   * Public clients (no registered secret) MUST use PKCE with the S256 method:
+   * without this, an intercepted code could be redeemed by anyone (GHSA-3m7m).
    */
   saveAuthorizationCode: async (
     code: OAuth2Server.AuthorizationCode,
     client: OAuth2Server.Client,
     user: OAuth2Server.User,
   ) => {
+    if (!client.clientSecret) {
+      if (!code.codeChallenge || code.codeChallengeMethod !== 'S256') {
+        throw new OAuth2Server.InvalidRequestError(
+          'PKCE with code_challenge_method=S256 is required for public clients',
+        );
+      }
+    }
+
     const systemConfigDao = getSystemConfigDao();
     const systemConfig = await systemConfigDao.get();
     const oauthConfig = systemConfig?.oauthServer;
@@ -378,24 +393,10 @@ export const generateCodeChallenge = (verifier: string): string => {
 };
 
 /**
- * Verify PKCE code challenge
+ * Test seam: the OAuth2Server model implementation. Exposed so unit tests can
+ * verify per-client authentication and PKCE policy directly.
  */
-export const verifyCodeChallenge = (
-  verifier: string,
-  challenge: string,
-  method: string = 'S256',
-): boolean => {
-  if (method === 'plain') {
-    return verifier === challenge;
-  }
-
-  if (method === 'S256') {
-    const computed = generateCodeChallenge(verifier);
-    return computed === challenge;
-  }
-
-  return false;
-};
+export const getOAuthModel = (): typeof oauthModel => oauthModel;
 
 /**
  * Handle OAuth authorize request

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -5,12 +5,16 @@ import {
   TemplateExportOptions,
   TemplateImportResult,
   TemplateImportDetail,
+  IGroup,
   IGroupServerConfig,
   ServerConfig,
 } from '../types/index.js';
 import { getServerDao, getGroupDao } from '../dao/index.js';
+import type { ServerConfigWithName } from '../dao/ServerDao.js';
 import { createGroup } from './groupService.js';
 import { addServer } from './mcpService.js';
+import { getDataService } from './services.js';
+import type { IUser } from '../types/index.js';
 
 const TEMPLATE_VERSION = '1.0';
 
@@ -399,6 +403,10 @@ function serverConfigToTemplate(config: ServerConfig): {
 
 /**
  * Export configuration as a shareable template.
+ *
+ * When `options.requestingUser` is a non-admin, servers and groups are
+ * filtered with the same ownership/visibility rules as every other read path
+ * (GHSA-p589-v5cm-35qg) so a user can only export what they can already see.
  */
 export async function exportTemplate(options: TemplateExportOptions): Promise<ConfigTemplate> {
   const serverDao = getServerDao();
@@ -407,10 +415,21 @@ export async function exportTemplate(options: TemplateExportOptions): Promise<Co
   const allServers = await serverDao.findAll();
   const allGroups = await groupDao.findAll();
 
-  // Determine which groups to include
+  // Apply visibility filtering for non-admin callers. No requestingUser means
+  // a trusted system caller — keep the legacy unfiltered behavior.
+  const visibleServers: ServerConfigWithName[] =
+    options.requestingUser && !options.requestingUser.isAdmin
+      ? getDataService().filterData(allServers, options.requestingUser)
+      : allServers;
+  const visibleGroups: IGroup[] =
+    options.requestingUser && !options.requestingUser.isAdmin
+      ? getDataService().filterData(allGroups, options.requestingUser)
+      : allGroups;
+
+  // Determine which groups to include (only among groups the caller can see)
   const selectedGroups = options.groupIds?.length
-    ? allGroups.filter((g) => options.groupIds!.includes(g.id))
-    : allGroups;
+    ? visibleGroups.filter((g) => options.groupIds!.includes(g.id))
+    : visibleGroups;
 
   // Collect server names referenced by selected groups
   const referencedServerNames = new Set<string>();
@@ -440,7 +459,7 @@ export async function exportTemplate(options: TemplateExportOptions): Promise<Co
   const allEnvVars: string[] = [];
   const includedServerNames = new Set<string>();
 
-  for (const server of allServers) {
+  for (const server of visibleServers) {
     if (!referencedServerNames.has(server.name)) continue;
     if (!options.includeDisabledServers && server.enabled === false) continue;
 
@@ -471,20 +490,32 @@ export async function exportTemplate(options: TemplateExportOptions): Promise<Co
 
 /**
  * Export a single group as a template.
+ *
+ * Non-admin callers can only export groups they are allowed to see; anything
+ * else returns null (surfaced as 404 by the controller, mirroring the
+ * groupService mutation denial pattern).
  */
 export async function exportGroupTemplate(
   groupId: string,
   name?: string,
+  requestingUser?: IUser,
 ): Promise<ConfigTemplate | null> {
   const groupDao = getGroupDao();
   const group = await groupDao.findById(groupId);
   if (!group) return null;
+
+  if (requestingUser && !requestingUser.isAdmin) {
+    const visible = getDataService()
+      .filterData([group], requestingUser);
+    if (visible.length === 0) return null;
+  }
 
   return exportTemplate({
     name: name || `${group.name} Template`,
     description: `Template exported from group "${group.name}"`,
     groupIds: [groupId],
     includeDisabledServers: false,
+    requestingUser,
   });
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -753,6 +753,7 @@ export interface TemplateExportOptions {
   description?: string; // Template description
   groupIds?: string[]; // Specific group IDs to export (empty = all)
   includeDisabledServers?: boolean; // Include disabled servers (default: false)
+  requestingUser?: IUser; // Caller identity; non-admins only export what they can see
 }
 
 // Result of importing a template

--- a/src/utils/__tests__/ssrf.test.ts
+++ b/src/utils/__tests__/ssrf.test.ts
@@ -25,6 +25,16 @@ describe('isBlockedIp', () => {
     ['::', 'IPv6 unspecified'],
     ['::ffff:127.0.0.1', 'IPv4-mapped loopback'],
     ['::ffff:169.254.169.254', 'IPv4-mapped link-local'],
+    ['64:ff9b::169.254.169.254', 'NAT64 well-known prefix embedding link-local'],
+    ['64:ff9b::7f00:1', 'NAT64 embedding loopback'],
+    ['64:ff9b:1::a9fe:a9fe', 'NAT64 local-use /48 embedding link-local'],
+    ['2002:c0a8:0101::', '6to4 embedding 192.168.1.1'],
+    ['2002:a9fe:a9fe::', '6to4 embedding link-local'],
+    ['2002:0808:0808::', '6to4 even with public embedded IPv4 (deprecated, RFC 7526)'],
+    ['2001:0:1111:2222:3333:4444:4455:5566', 'Teredo prefix 2001:0::/32'],
+    ['fec0::1', 'site-local (deprecated)'],
+    ['fec0:1234::1', 'site-local upper range feff::/16 boundary'],
+    ['febf:ffff::1', 'link-local /10 upper boundary (fe80::/10 ends at febf)'],
   ])('blocks %s (%s)', (ip) => {
     expect(isBlockedIp(ip)).toBe(true);
   });
@@ -35,6 +45,8 @@ describe('isBlockedIp', () => {
     ['172.32.0.1', 'just outside 172.16/12'],
     ['11.0.0.1', 'just outside 10/8'],
     ['2606:4700:4700::1111', 'Cloudflare IPv6'],
+    ['2001:4860:4860::8888', 'Google IPv6 DNS (global unicast, not Teredo)'],
+    ['2620:fe::fe', 'Quad9 IPv6'],
   ])('allows %s (%s)', (ip) => {
     expect(isBlockedIp(ip)).toBe(false);
   });

--- a/src/utils/requireAdmin.ts
+++ b/src/utils/requireAdmin.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+
+// Shared dashboard-API admin gate. Mirrors the inline checks in
+// userController/serverController so every global-scope mutation enforces the
+// same rule: only requests carrying an admin identity may proceed.
+export const requireAdmin = async (req: Request, res: Response): Promise<boolean> => {
+  const user = (req as any).user;
+  if (!user || !user.isAdmin) {
+    res.status(403).json({
+      success: false,
+      message: 'Admin privileges required',
+    });
+    return false;
+  }
+  return true;
+};

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -75,7 +75,16 @@ function ipv6ToBigInt(addr: string): bigint {
 
 function isBlockedIpv6(big: bigint): boolean {
   if (big === 0n || big === 1n) return true; // ::, ::1
-  if (big >> 118n === 0x3fan) return true; // fe80::/10 link-local
+  const top10 = big >> 118n;
+  if (top10 === 0x3fan) return true; // fe80::/10 link-local
+  if (top10 === 0x3fbn) return true; // fec0::/10 site-local (deprecated)
+  if (big >> 120n === 0xffn) return true; // ff00::/8 multicast — never a valid dial target
+  const top16 = big >> 112n;
+  if (top16 === 0x2002n) return true; // 2002::/16 6to4 transition (deprecated, RFC 7526)
+  if (top16 === 0x64ffn && big >> 80n === 0x64ff9b1n) return true; // 64:ff9b:1::/48 local-use NAT64
+  const top32 = big >> 96n;
+  if (top32 === 0x20010000n) return true; // 2001:0::/32 Teredo transition
+  if (top32 === 0x64ff9bn) return true; // 64:ff9b::/96 NAT64 well-known prefix
   if (big >> 121n === 0x7en) return true; // fc00::/7 unique-local
   if (big >> 32n === 0xffffn) return isBlockedIpv4Number(Number(big & 0xffffffffn)); // ::ffff:a.b.c.d
   if (big < 0x100000000n) return isBlockedIpv4Number(Number(big)); // ::a.b.c.d (deprecated, compatible)

--- a/tests/controllers/builtinConfigAuth.test.ts
+++ b/tests/controllers/builtinConfigAuth.test.ts
@@ -1,0 +1,166 @@
+import { Request, Response } from 'express';
+
+// ── Mock DAO layer ───────────────────────────────────────────────
+const mockPromptDao = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+const mockResourceDao = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock('../../src/dao/index.js', () => ({
+  getBuiltinPromptDao: () => mockPromptDao,
+  getBuiltinResourceDao: () => mockResourceDao,
+}));
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  handleReadResourceRequest: jest.fn(),
+}));
+
+import {
+  createBuiltinPrompt,
+  updateBuiltinPrompt,
+  deleteBuiltinPrompt,
+  listBuiltinPrompts,
+} from '../../src/controllers/builtinPromptController.js';
+import {
+  createBuiltinResource,
+  updateBuiltinResource,
+  deleteBuiltinResource,
+} from '../../src/controllers/builtinResourceController.js';
+
+const makeRes = () => {
+  const res = {
+    json: jest.fn().mockReturnThis(),
+    status: jest.fn().mockReturnThis(),
+  };
+  return res as unknown as Response;
+};
+
+const makeReq = (overrides: Record<string, any> = {}) =>
+  ({
+    body: {},
+    params: {},
+    user: { username: 'alice', isAdmin: false },
+    ...overrides,
+  }) as unknown as Request;
+
+describe('built-in prompt/resource write authorization (GHSA-6cvf)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('builtinPromptController writes', () => {
+    it('rejects create for a non-admin without touching the DAO', async () => {
+      const res = makeRes();
+      await createBuiltinPrompt(
+        makeReq({ body: { name: 'p', template: 't' } }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockPromptDao.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects update for a non-admin', async () => {
+      const res = makeRes();
+      await updateBuiltinPrompt(makeReq({ params: { id: '1' }, body: { title: 'x' } }), res);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockPromptDao.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects delete for a non-admin', async () => {
+      const res = makeRes();
+      await deleteBuiltinPrompt(makeReq({ params: { id: '1' } }), res);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockPromptDao.delete).not.toHaveBeenCalled();
+    });
+
+    it('allows create/update/delete for an admin', async () => {
+      mockPromptDao.create.mockResolvedValue({ id: '1' });
+      mockPromptDao.update.mockResolvedValue({ id: '1' });
+      mockPromptDao.delete.mockResolvedValue(true);
+
+      const resCreate = makeRes();
+      await createBuiltinPrompt(
+        makeReq({
+          user: { username: 'admin', isAdmin: true },
+          body: { name: 'p', template: 't' },
+        }),
+        resCreate,
+      );
+      expect(resCreate.status).toHaveBeenCalledWith(201);
+
+      const resUpdate = makeRes();
+      await updateBuiltinPrompt(
+        makeReq({
+          user: { username: 'admin', isAdmin: true },
+          params: { id: '1' },
+          body: { title: 'x' },
+        }),
+        resUpdate,
+      );
+      expect(resUpdate.json).toHaveBeenCalled();
+
+      const resDelete = makeRes();
+      await deleteBuiltinPrompt(
+        makeReq({ user: { username: 'admin', isAdmin: true }, params: { id: '1' } }),
+        resDelete,
+      );
+      expect(resDelete.json).toHaveBeenCalled();
+    });
+
+    it('keeps reads open to non-admins', async () => {
+      mockPromptDao.findAll.mockResolvedValue([]);
+      const res = makeRes();
+      await listBuiltinPrompts(makeReq(), res);
+      expect(res.json).toHaveBeenCalled();
+    });
+  });
+
+  describe('builtinResourceController writes', () => {
+    it('rejects create for a non-admin without touching the DAO', async () => {
+      const res = makeRes();
+      await createBuiltinResource(
+        makeReq({ body: { uri: 'file:///a', content: 'c' } }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockResourceDao.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects update for a non-admin', async () => {
+      const res = makeRes();
+      await updateBuiltinResource(makeReq({ params: { id: '1' }, body: { content: 'x' } }), res);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockResourceDao.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects delete for a non-admin', async () => {
+      const res = makeRes();
+      await deleteBuiltinResource(makeReq({ params: { id: '1' } }), res);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(mockResourceDao.delete).not.toHaveBeenCalled();
+    });
+
+    it('allows create for an admin', async () => {
+      mockResourceDao.create.mockResolvedValue({ id: '1' });
+      const res = makeRes();
+      await createBuiltinResource(
+        makeReq({
+          user: { username: 'admin', isAdmin: true },
+          body: { uri: 'file:///a', content: 'c' },
+        }),
+        res,
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+  });
+});

--- a/tests/controllers/oauthDynamicRegistrationController.test.ts
+++ b/tests/controllers/oauthDynamicRegistrationController.test.ts
@@ -19,6 +19,12 @@ jest.mock('../../src/models/OAuth.js', () => ({
   deleteOAuthClient: deleteOAuthClientMock,
 }));
 
+const mockAuthMiddleware = jest.fn((req, res, next) => next());
+
+jest.mock('../../src/middlewares/auth.js', () => ({
+  auth: (...args: [unknown, unknown, () => void]) => mockAuthMiddleware(...args),
+}));
+
 import { registerClient } from '../../src/controllers/oauthDynamicRegistrationController.js';
 
 describe('oauthDynamicRegistrationController - registerClient', () => {
@@ -91,5 +97,64 @@ describe('oauthDynamicRegistrationController - registerClient', () => {
         ),
       }),
     );
+  });
+});
+
+describe('registerClient requiresAuthentication gate', () => {
+  let mockJson: jest.Mock;
+  let mockStatus: jest.Mock;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore default pass-through behavior cleared by the outer clearAllMocks
+    mockAuthMiddleware.mockImplementation((req, res, next) => next());
+
+    mockJson = jest.fn();
+    mockStatus = jest.fn().mockReturnThis();
+    mockRequest = {
+      protocol: 'https',
+      get: jest.fn().mockReturnValue('localhost:3000'),
+      body: {
+        redirect_uris: ['https://client.example.com/callback'],
+        client_name: 'Gated Client',
+      },
+    };
+    mockResponse = { json: mockJson, status: mockStatus };
+
+    getSystemConfigMock.mockResolvedValue({
+      oauthServer: {
+        enabled: true,
+        allowedScopes: ['read', 'write'],
+        dynamicRegistration: {
+          enabled: true,
+          requiresAuthentication: true,
+        },
+      },
+    });
+    createOAuthClientMock.mockImplementation(async (client) => client);
+  });
+
+  it('rejects unauthenticated registrations with 401 when requiresAuthentication is set', async () => {
+    mockAuthMiddleware.mockImplementationOnce((_req, res, _next) => {
+      (res as unknown as { status: (n: number) => unknown; json: (b: unknown) => unknown })
+        .status(401)
+        .json({ error: 'invalid_token' });
+    });
+
+    await registerClient(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).toHaveBeenCalledWith(401);
+    expect(createOAuthClientMock).not.toHaveBeenCalled();
+  });
+
+  it('registers normally when a credential resolves to a user', async () => {
+    (mockRequest as { user?: unknown }).user = { username: 'alice', isAdmin: false };
+
+    await registerClient(mockRequest as Request, mockResponse as Response);
+
+    expect(mockStatus).toHaveBeenCalledWith(201);
+    expect(createOAuthClientMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/controllers/oauthServerController.metadata.test.ts
+++ b/tests/controllers/oauthServerController.metadata.test.ts
@@ -78,7 +78,7 @@ describe('oauthServerController metadata endpoints', () => {
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code', 'refresh_token'],
       token_endpoint_auth_methods_supported: ['none'],
-      code_challenge_methods_supported: ['S256', 'plain'],
+      code_challenge_methods_supported: ['S256'],
       registration_endpoint: 'https://mcp.example.com/hub/oauth/register',
     });
   });
@@ -159,7 +159,7 @@ describe('oauthServerController metadata endpoints', () => {
         authorization_endpoint: 'https://localhost:3000/oauth/authorize',
         token_endpoint: 'https://localhost:3000/oauth/token',
         scopes_supported: ['read', 'write'],
-        code_challenge_methods_supported: ['S256', 'plain'],
+        code_challenge_methods_supported: ['S256'],
       }),
     );
   });
@@ -243,7 +243,7 @@ describe('oauthServerController metadata endpoints', () => {
     expect(mockJson).toHaveBeenCalledWith(
       expect.objectContaining({
         scopes_supported: ['read', 'write'],
-        code_challenge_methods_supported: ['S256', 'plain'],
+        code_challenge_methods_supported: ['S256'],
         token_endpoint_auth_methods_supported: ['none'],
       }),
     );

--- a/tests/controllers/oauthServerController.shell.test.ts
+++ b/tests/controllers/oauthServerController.shell.test.ts
@@ -71,6 +71,9 @@ describe('oauthServerController getAuthorize consent shell', () => {
     (findOAuthClientById as jest.Mock).mockResolvedValue({
       clientId: 'trusted-client',
       name: 'Trusted Client',
+      // Confidential client: skips the public-client PKCE requirement so the
+      // consent-shell assertions stay focused on rendering.
+      clientSecret: 'confidential-secret',
       redirectUris: ['https://trusted.example.com/callback'],
     });
 
@@ -272,6 +275,8 @@ describe('oauthServerController getAuthorize consent shell', () => {
     (findOAuthClientById as jest.Mock).mockResolvedValue({
       clientId: 'e9d6adf9e48449e6bee3f8b6fb024297',
       name: 'Claude',
+      // Confidential client (skips public-client PKCE requirement)
+      clientSecret: 'confidential-secret',
       redirectUris: ['https://claude.ai/api/mcp/auth_callback'],
       metadata: {
         application_type: 'web',

--- a/tests/index.boot.test.ts
+++ b/tests/index.boot.test.ts
@@ -14,6 +14,7 @@ const createFetchWithProxyMock = jest.fn();
 const getProxyConfigFromEnvMock = jest.fn(() => ({}));
 const isRetryableDbErrorMock = jest.fn(() => false);
 const hydrateSystemConfigCacheMock = jest.fn(async () => undefined);
+const getCachedSystemConfigMock = jest.fn(() => null);
 const startHostedEventSubscriberMock = jest.fn();
 const stopHostedEventSubscriberMock = jest.fn(async () => undefined);
 
@@ -37,6 +38,7 @@ jest.mock('../src/utils/dbRetry.js', () => ({
 
 jest.mock('../src/utils/systemConfigCache.js', () => ({
   hydrateSystemConfigCache: hydrateSystemConfigCacheMock,
+  getCachedSystemConfig: getCachedSystemConfigMock,
 }));
 
 jest.mock('../src/services/hostedEventSubscriber.js', () => ({
@@ -63,6 +65,7 @@ describe('index boot', () => {
     getProxyConfigFromEnvMock.mockReturnValue({});
     isRetryableDbErrorMock.mockReturnValue(false);
     hydrateSystemConfigCacheMock.mockResolvedValue(undefined);
+    getCachedSystemConfigMock.mockReturnValue(null);
     startHostedEventSubscriberMock.mockReturnValue(new Promise(() => undefined));
 
     delete process.env.USE_DB;
@@ -78,5 +81,20 @@ describe('index boot', () => {
     expect(startHostedEventSubscriberMock).toHaveBeenCalledTimes(1);
     expect(initializeMock).toHaveBeenCalledTimes(1);
     expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the skipAuth security warning path without crashing boot', async () => {
+    getCachedSystemConfigMock.mockReturnValue({ routing: { skipAuth: true } } as never);
+    await import('../src/index.js');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(initializeMock).toHaveBeenCalledTimes(1);
+    expect(startMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('boot survives a null cached system config', async () => {
+    getCachedSystemConfigMock.mockReturnValue(null);
+    await import('../src/index.js');
+    expect(initializeMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/services/oauthServerClientAuth.test.ts
+++ b/tests/services/oauthServerClientAuth.test.ts
@@ -1,0 +1,138 @@
+// Regression tests for GHSA-3m7m-37xf-xp9x: OAuth authorization server must
+// authenticate confidential clients and require PKCE S256 for public clients.
+
+jest.mock('@node-oauth/oauth2-server', () => {
+  const actual = jest.requireActual('@node-oauth/oauth2-server');
+  return { ...actual };
+});
+
+jest.mock('../../src/dao/index.js', () => ({
+  getSystemConfigDao: jest.fn(() => ({ get: jest.fn().mockResolvedValue({}) })),
+  getBearerKeyDao: jest.fn(),
+}));
+
+jest.mock('../../src/models/User.js', () => ({
+  findUserByUsername: jest.fn(),
+  verifyPassword: jest.fn(),
+}));
+
+const mockFindOAuthClientById = jest.fn();
+const mockSaveAuthorizationCode = jest.fn();
+const mockGetAuthorizationCode = jest.fn();
+const mockRevokeAuthorizationCode = jest.fn();
+const mockSaveToken = jest.fn();
+const mockGetToken = jest.fn();
+const mockRevokeToken = jest.fn();
+
+jest.mock('../../src/models/OAuth.js', () => ({
+  findOAuthClientById: (...args: unknown[]) => mockFindOAuthClientById(...args),
+  saveAuthorizationCode: (...args: unknown[]) => mockSaveAuthorizationCode(...args),
+  getAuthorizationCode: (...args: unknown[]) => mockGetAuthorizationCode(...args),
+  revokeAuthorizationCode: (...args: unknown[]) => mockRevokeAuthorizationCode(...args),
+  saveToken: (...args: unknown[]) => mockSaveToken(...args),
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+  revokeToken: (...args: unknown[]) => mockRevokeToken(...args),
+}));
+
+import { getOAuthModel } from '../../src/services/oauthServerService.js';
+
+const confidentialClient = {
+  clientId: 'conf-client',
+  clientSecret: 'top-secret',
+  redirectUris: ['https://app.example/cb'],
+  grants: ['authorization_code', 'refresh_token'],
+};
+const publicClient = {
+  clientId: 'pub-client',
+  clientSecret: undefined,
+  redirectUris: ['https://app.example/cb'],
+  grants: ['authorization_code'],
+};
+
+describe('oauthModel.getClient enforces per-client authentication (GHSA-3m7m)', () => {
+  const model = getOAuthModel();
+
+  it('rejects a confidential client when no secret is presented', async () => {
+    mockFindOAuthClientById.mockResolvedValue(confidentialClient);
+    await expect(model.getClient('conf-client')).resolves.toBe(false);
+  });
+
+  it('rejects a confidential client with a wrong secret', async () => {
+    mockFindOAuthClientById.mockResolvedValue(confidentialClient);
+    await expect(model.getClient('conf-client', 'wrong')).resolves.toBe(false);
+  });
+
+  it('accepts a confidential client with the correct secret', async () => {
+    mockFindOAuthClientById.mockResolvedValue(confidentialClient);
+    const result = await model.getClient('conf-client', 'top-secret');
+    expect(result).not.toBe(false);
+    expect((result as { clientId: string }).clientId).toBe('conf-client');
+  });
+
+  it('still accepts a public (secret-less) client without a secret', async () => {
+    mockFindOAuthClientById.mockResolvedValue(publicClient);
+    const result = await model.getClient('pub-client');
+    expect(result).not.toBe(false);
+  });
+});
+
+describe('oauthModel.saveAuthorizationCode requires PKCE S256 for public clients (GHSA-3m7m)', () => {
+  const model = getOAuthModel();
+
+  const baseCode = {
+    redirectUri: 'https://app.example/cb',
+    scope: ['read'],
+    codeChallenge: undefined as string | undefined,
+    codeChallengeMethod: undefined as string | undefined,
+  };
+  const user = { username: 'alice' };
+
+  beforeEach(() => {
+    mockSaveAuthorizationCode.mockReset();
+    mockSaveAuthorizationCode.mockReturnValue({ code: 'abc' });
+  });
+
+  it('rejects a public client authorization code without a challenge', async () => {
+    const client = { id: 'pub-client', clientId: 'pub-client' } as never;
+    await expect(
+      model.saveAuthorizationCode(baseCode as never, client, user as never),
+    ).rejects.toThrow(/PKCE/i);
+    expect(mockSaveAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('rejects a public client using the plain challenge method', async () => {
+    const client = { id: 'pub-client', clientId: 'pub-client' } as never;
+    await expect(
+      model.saveAuthorizationCode(
+        { ...baseCode, codeChallenge: 'abc', codeChallengeMethod: 'plain' } as never,
+        client,
+        user as never,
+      ),
+    ).rejects.toThrow(/S256/i);
+    expect(mockSaveAuthorizationCode).not.toHaveBeenCalled();
+  });
+
+  it('accepts a public client with an S256 challenge', async () => {
+    const client = { id: 'pub-client', clientId: 'pub-client' } as never;
+    await expect(
+      model.saveAuthorizationCode(
+        { ...baseCode, codeChallenge: 'abc', codeChallengeMethod: 'S256' } as never,
+        client,
+        user as never,
+      ),
+    ).resolves.toBeDefined();
+    expect(mockSaveAuthorizationCode).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not require PKCE for confidential clients (backwards compatible)', async () => {
+    const client = {
+      id: 'conf-client',
+      clientId: 'conf-client',
+      clientSecret: 'top-secret',
+    } as never;
+    await expect(
+      model.saveAuthorizationCode(baseCode as never, client, user as never),
+    ).resolves.toBeDefined();
+    expect(mockSaveAuthorizationCode).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/services/templateService-export-auth.test.ts
+++ b/tests/services/templateService-export-auth.test.ts
@@ -1,0 +1,124 @@
+// Regression tests for GHSA-p589-v5cm-35qg: template export must apply the
+// same ownership/visibility filtering as every other read path.
+
+const mockServerDao = { findAll: jest.fn(), findById: jest.fn() };
+const mockGroupDao = { findAll: jest.fn(), findById: jest.fn() };
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: () => mockServerDao,
+  getGroupDao: () => mockGroupDao,
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  createGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  addServer: jest.fn(),
+}));
+
+import {
+  exportTemplate,
+  exportGroupTemplate,
+} from '../../src/services/templateService.js';
+
+const alice = { username: 'alice', isAdmin: false };
+const admin = { username: 'admin', isAdmin: true };
+
+const servers = [
+  { name: 'alice-private', owner: 'alice', visibility: 'private', enabled: true, url: 'http://a' },
+  { name: 'bob-private', owner: 'bob', visibility: 'private', enabled: true, url: 'http://b' },
+  {
+    name: 'bob-public',
+    owner: 'bob',
+    visibility: 'public',
+    enabled: true,
+    url: 'http://c',
+  },
+];
+
+const groups = [
+  {
+    id: 'g-alice',
+    name: 'AliceG',
+    description: '',
+    owner: 'alice',
+    visibility: 'private',
+    servers: [{ name: 'alice-private', tools: 'all', prompts: 'all', resources: 'all' }],
+  },
+  {
+    id: 'g-bob',
+    name: 'BobG',
+    description: '',
+    owner: 'bob',
+    visibility: 'private',
+    servers: [{ name: 'bob-private', tools: 'all', prompts: 'all', resources: 'all' }],
+  },
+  {
+    id: 'g-mixed',
+    name: 'MixedG',
+    description: '',
+    owner: 'alice',
+    visibility: 'private',
+    servers: [
+      { name: 'bob-public', tools: 'all', prompts: 'all', resources: 'all' },
+      { name: 'bob-private', tools: 'all', prompts: 'all', resources: 'all' },
+    ],
+  },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockServerDao.findAll.mockResolvedValue(servers);
+  mockGroupDao.findAll.mockResolvedValue(groups);
+});
+
+describe('template export ownership filtering (GHSA-p589)', () => {
+  it('non-admin full export excludes other users’ private servers and groups', async () => {
+    const tpl = await exportTemplate({ name: 't', requestingUser: alice });
+    expect(tpl.groups.map((g) => g.name).sort()).toEqual(['AliceG', 'MixedG']);
+    expect(Object.keys(tpl.servers).sort()).toEqual(['alice-private', 'bob-public']);
+  });
+
+  it('admin full export still sees everything', async () => {
+    const tpl = await exportTemplate({ name: 't', requestingUser: admin });
+    expect(tpl.groups.map((g) => g.name).sort()).toEqual(['AliceG', 'BobG', 'MixedG']);
+    expect(Object.keys(tpl.servers).sort()).toEqual([
+      'alice-private',
+      'bob-private',
+      'bob-public',
+    ]);
+  });
+
+  it('no requestingUser keeps the legacy unfiltered behavior (system callers)', async () => {
+    const tpl = await exportTemplate({ name: 't' });
+    expect(Object.keys(tpl.servers)).toHaveLength(3);
+  });
+
+  it('non-admin cannot export another user’s private group by ID', async () => {
+    mockGroupDao.findById.mockResolvedValue(groups[1]);
+    await expect(exportGroupTemplate('g-bob', undefined, alice)).resolves.toBeNull();
+  });
+
+  it('non-admin exporting own group drops invisible servers from it', async () => {
+    mockGroupDao.findById.mockResolvedValue(groups[2]);
+    const tpl = await exportGroupTemplate('g-mixed', undefined, alice);
+    expect(tpl).not.toBeNull();
+    expect(Object.keys(tpl!.servers)).toEqual(['bob-public']);
+    expect(tpl!.groups[0].servers.map((s) => s.name)).toEqual(['bob-public']);
+  });
+
+  it('non-admin exporting own group keeps its own servers', async () => {
+    mockGroupDao.findById.mockResolvedValue(groups[0]);
+    const tpl = await exportGroupTemplate('g-alice', undefined, alice);
+    expect(tpl).not.toBeNull();
+    expect(tpl!.groups[0].name).toBe('AliceG');
+  });
+
+  it('admin can export any group by ID', async () => {
+    mockGroupDao.findById.mockResolvedValue(groups[1]);
+    const tpl = await exportGroupTemplate('g-bob', undefined, admin);
+    expect(tpl).not.toBeNull();
+    expect(tpl!.groups[0].name).toBe('BobG');
+  });
+});


### PR DESCRIPTION
## Summary

Batch of fixes for open GitHub security advisories, each with regression tests. Verified against the advisory reports by code audit; version ranges for already-shipped advisories were corrected separately via the advisory API.

| Commit | Advisory | Fix |
|---|---|---|
| d382b36 | GHSA-pr4x-3pc7-2fhw | `isBlockedIpv6` now rejects NAT64 (`64:ff9b::/96`, local-use `64:ff9b:1::/48`), deprecated 6to4 (`2002::/16`), Teredo (`2001:0::/32`), site-local (`fec0::/10`) and multicast (`ff00::/8`) so hostnames resolving through transition prefixes cannot bypass the SSRF blocklist |
| 63fdb2c | GHSA-9wx9-prgc-gmjr | External OpenAPI `$ref` resolution no longer uses SwaggerParser's unguarded resolvers: http targets are validated per fetch **and per redirect hop** via plain `fetch` (no credential forwarding cross-origin, #1044 semantics preserved); `file://` refs are denied unless the server is admin-owned. The real `UnsafeUrlError` is unwrapped from parser `ResolverError`s |
| 763381f | GHSA-6cvf-cfch-4g7m | Built-in prompt/resource create/update/delete are global mutations — now gated behind a shared `requireAdmin` helper; reads stay open |
| feb106a | GHSA-p589-v5cm-35qg | Template export (full + per-group) passes the requesting user into the service and applies `DataService.filterData`, same visibility rules as every other read path; exporting another user's group returns 404 |
| ea09a7c | GHSA-3m7m-37xf-xp9x | Confidential OAuth clients must always present their secret at the token endpoint (the global toggle only permits secret-less *public* clients); public clients must use PKCE `S256` — enforced in `saveAuthorizationCode` (single choke point) and surfaced early on `GET /oauth/authorize`; discovery metadata stops advertising `plain`; dead `verifyCodeChallenge` removed; `dynamicRegistration.requiresAuthentication` is now honored via the shared auth middleware |
| 79c8cdb | GHSA-wmv9-3qh3-9rpw / GHSA-9v37-w4j4-cfp4 (mitigation) | Prominent multi-line startup warning when `routing.skipAuth` is enabled |

### Notable incidentals

- Fixed a real hang in the new dynamic-registration auth gate: short-circuiting middleware responses previously never resolved the awaiting promise.
- `tests/controllers/oauthServerController.shell.test.ts` fixtures updated to confidential clients (intended behavior change: public clients without PKCE are now rejected).
- Advisory metadata corrections already applied via API (not part of this PR): wf8q patched-version fix (0.12.15 → 0.12.17), plus patched ranges for mx89 / wxp7 / rcq5 / f2rg.

## Tests

- New suites: `src/utils/__tests__/ssrf.test.ts` (transition-address cases), `src/clients/__tests__/openapi-external-ref.test.ts`, `tests/controllers/builtinConfigAuth.test.ts`, `tests/services/templateService-export-auth.test.ts`, `tests/services/oauthServerClientAuth.test.ts`, dynamic-registration gate cases.
- Updated: boot test (systemConfigCache mock + skipAuth warning path), metadata test expectations (`['S256']`), shell-test client fixtures.
- Full pre-commit gate green: `pnpm lint` ✅ · `pnpm test:ci` 1151/1151 ✅ · `pnpm build` ✅
- Manual: none of these paths change default UX; skipAuth warning verified via boot test.

## Post-merge checklist

- [ ] Cut release (suggest v1.0.32) so the newly-fixed advisories can cite a patched version
- [ ] Update advisories pr4x / 9wx9 / 6cvf / p589 / 3m7m ranges via API after tagging
- [ ] Accept/publish triage/draft advisories in the web UI (mx89, wfqf, r86g, wxp7, rcq5, f2rg)
- [ ] Decide reply stance on wmv9/9v37 (skipAuth positioning) and wwgw (OAuth client ownership model)