### PR TITLE
fix: handle missing ps when killing stdio process trees (#1072)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM python:3.13-slim-trixie AS base
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN apt-get update && apt-get install -y curl gnupg git build-essential \
+# procps provides `ps`, which tree-kill needs to walk stdio process trees
+# (missing it caused spawn ps ENOENT crashes — issue #1072)
+RUN apt-get update && apt-get install -y curl gnupg git build-essential procps \
   && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
   && apt-get install -y nodejs \
   && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import treeKill from 'tree-kill';
+import { isProcessTreeKillAvailable } from '../utils/processTree.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
@@ -2639,7 +2640,28 @@ export const resetServerOAuthConnection = (name: string): boolean => {
 // launched through a wrapper like `npx` / `npm exec`, the wrapper does not
 // forward signals to its descendants, so the real server process is left
 // running as an orphan. Walk the whole tree and force-kill it.
+//
+// When the process-lister tool tree-kill needs (`ps` on Linux) is missing —
+// e.g. slim Docker images without procps — tree-kill's internal spawn fails
+// with an unhandled 'error' event that would crash MCPHub. Fall back to
+// signaling just the direct child instead (issue #1072).
 function killStdioProcessTree(name: string, pid: number): void {
+  const safeDirectKill = (signal: 'SIGTERM' | 'SIGKILL'): void => {
+    try {
+      process.kill(pid, signal);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ESRCH') {
+        logger.warn('Failed to send signal to process', {
+          serverName: name,
+          pid,
+          signal,
+          err,
+        });
+      }
+    }
+  };
+
   const safeTreeKill = (signal: 'SIGTERM' | 'SIGKILL'): void => {
     try {
       treeKill(pid, signal, (err) => {
@@ -2670,13 +2692,24 @@ function killStdioProcessTree(name: string, pid: number): void {
     }
   };
 
-  safeTreeKill('SIGTERM');
+  const safeKill = isProcessTreeKillAvailable()
+    ? safeTreeKill
+    : (signal: 'SIGTERM' | 'SIGKILL'): void => {
+        logger.warn('Process lister unavailable, killing only the direct child process', {
+          serverName: name,
+          pid,
+          signal,
+        });
+        safeDirectKill(signal);
+      };
+
+  safeKill('SIGTERM');
 
   setTimeout(() => {
     if (!isProcessAlive(pid)) {
       return;
     }
-    safeTreeKill('SIGKILL');
+    safeKill('SIGKILL');
   }, STDIO_KILL_GRACE_PERIOD_MS);
 }
 

--- a/src/utils/processTree.test.ts
+++ b/src/utils/processTree.test.ts
@@ -1,0 +1,93 @@
+// Tests for the process-lister availability probe used by stdio cleanup.
+// Regression coverage for issue #1072: slim Docker images without procps
+// made tree-kill's internal `ps` spawn fail with an unhandled 'error' event,
+// crashing MCPHub via the global uncaughtException handler.
+
+import fs from 'fs';
+import path from 'path';
+import { isProcessTreeKillAvailable, resetProcessTreeKillCache } from './processTree.js';
+
+const setPlatform = (platform: NodeJS.Platform): void => {
+  Object.defineProperty(process, 'platform', { value: platform });
+};
+
+describe('isProcessTreeKillAvailable', () => {
+  const originalPlatform = process.platform;
+  const originalPath = process.env.PATH;
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    jest.restoreAllMocks();
+    resetProcessTreeKillCache();
+  });
+
+  it('is always true on win32 (tree-kill uses taskkill)', () => {
+    setPlatform('win32');
+    expect(isProcessTreeKillAvailable()).toBe(true);
+  });
+
+  it('is always true on darwin (tree-kill uses pgrep)', () => {
+    setPlatform('darwin');
+    expect(isProcessTreeKillAvailable()).toBe(true);
+  });
+
+  it('detects ps on a custom PATH entry on Linux', () => {
+    setPlatform('linux');
+    process.env.PATH = '/custom/bin';
+    jest
+      .spyOn(fs, 'accessSync')
+      .mockImplementation(((candidate: fs.PathLike) => {
+        if (String(candidate) === path.join('/custom/bin', 'ps')) return undefined;
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }) as typeof fs.accessSync);
+    expect(isProcessTreeKillAvailable()).toBe(true);
+  });
+
+  it('detects ps at well-known absolute paths even with an empty PATH', () => {
+    setPlatform('linux');
+    process.env.PATH = '';
+    jest
+      .spyOn(fs, 'accessSync')
+      .mockImplementation(((candidate: fs.PathLike) => {
+        if (String(candidate) === '/usr/bin/ps') return undefined;
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }) as typeof fs.accessSync);
+    expect(isProcessTreeKillAvailable()).toBe(true);
+  });
+
+  it('returns false when no ps executable exists anywhere', () => {
+    setPlatform('linux');
+    process.env.PATH = '';
+    jest.spyOn(fs, 'accessSync').mockImplementation((() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }) as typeof fs.accessSync);
+    expect(isProcessTreeKillAvailable()).toBe(false);
+  });
+
+  it('caches the result until reset', () => {
+    setPlatform('linux');
+    process.env.PATH = '';
+    const accessSync = jest
+      .spyOn(fs, 'accessSync')
+      .mockImplementation((() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      }) as typeof fs.accessSync);
+
+    expect(isProcessTreeKillAvailable()).toBe(false);
+
+    // ps appears afterwards — cached result must stay false until reset.
+    accessSync.mockImplementation(((candidate: fs.PathLike) => {
+      if (String(candidate) === '/bin/ps') return undefined;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    }) as typeof fs.accessSync);
+    expect(isProcessTreeKillAvailable()).toBe(false);
+
+    resetProcessTreeKillCache();
+    expect(isProcessTreeKillAvailable()).toBe(true);
+  });
+});

--- a/src/utils/processTree.ts
+++ b/src/utils/processTree.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+
+// tree-kill walks the stdio process tree by spawning `ps` on Linux (and other
+// Unix platforms). Slim container images often ship without procps, so that
+// spawn fails with ENOENT as an unhandled 'error' event on tree-kill's
+// internal child process — an uncaught exception MCPHub cannot intercept via
+// tree-kill's callback. Detect tool availability up front so callers can fall
+// back to signaling the direct child only (issue #1072).
+
+let cachedAvailability: boolean | null = null;
+
+const WELL_KNOWN_BIN_DIRS = ['/bin', '/usr/bin', '/sbin', '/usr/sbin'];
+
+function findExecutableOnDisk(name: string): boolean {
+  const candidates = WELL_KNOWN_BIN_DIRS.map((dir) => path.join(dir, name));
+  const pathDirs = (process.env.PATH ?? '')
+    .split(path.delimiter)
+    .filter((dir) => dir.length > 0);
+  candidates.push(...pathDirs.map((dir) => path.join(dir, name)));
+
+  for (const candidate of candidates) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return true;
+    } catch {
+      // Not present or not executable here — keep looking.
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether the external tool tree-kill relies on is available on this platform.
+ * win32 uses taskkill and darwin uses pgrep — both ship with the OS. All other
+ * platforms require `ps` from procps, which minimal images frequently lack.
+ * The result is cached for the process lifetime; use
+ * `resetProcessTreeKillCache` in tests.
+ */
+export function isProcessTreeKillAvailable(): boolean {
+  if (cachedAvailability === null) {
+    cachedAvailability =
+      process.platform === 'win32' ||
+      process.platform === 'darwin' ||
+      findExecutableOnDisk('ps');
+  }
+  return cachedAvailability;
+}
+
+export function resetProcessTreeKillCache(): void {
+  cachedAvailability = null;
+}

--- a/tests/services/mcpService-stdio-cleanup.test.ts
+++ b/tests/services/mcpService-stdio-cleanup.test.ts
@@ -47,6 +47,13 @@ const mockTreeKill = jest.fn((_pid: number, _signal: string, cb?: (err?: Error) 
 });
 jest.mock('tree-kill', () => mockTreeKill);
 
+// Mutable holder for the process-lister availability probe (issue #1072).
+// The jest.mock factory must be self-contained, hence the wrapper object.
+const mockProcessTreeKillAvailability = { value: true };
+jest.mock('../../src/utils/processTree', () => ({
+  isProcessTreeKillAvailable: () => mockProcessTreeKillAvailability.value,
+}));
+
 jest.mock('../../src/services/oauthService.js', () => ({
   initializeAllOAuthClients: jest.fn(),
 }));
@@ -174,6 +181,7 @@ describe('orphan stdio process cleanup (issue #920)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     currentTestPid = 12345;
+    mockProcessTreeKillAvailability.value = true;
     setServerInfosForTest([]);
     installProcessKillMock();
   });
@@ -333,6 +341,73 @@ describe('orphan stdio process cleanup (issue #920)', () => {
       expect(mockClientClose).toHaveBeenCalledTimes(1);
       expect(mockStdioTransportClose).toHaveBeenCalledTimes(1);
       expect(mockTreeKill).toHaveBeenCalledWith(7777, 'SIGTERM', expect.any(Function));
+    });
+  });
+
+  describe('when the process lister (ps) is unavailable (issue #1072)', () => {
+    beforeEach(() => {
+      mockProcessTreeKillAvailability.value = false;
+    });
+
+    // Replace the liveness-probe-aware mock with a plain recording mock so we
+    // never signal real PIDs on the host machine.
+    const recordProcessKills = (): jest.Mock => {
+      const kill = jest.fn(() => true);
+      (process.kill as jest.Mock).mockImplementation(kill as any);
+      return kill;
+    };
+
+    it('does not call tree-kill and signals only the direct child', async () => {
+      const kill = recordProcessKills();
+      currentTestPid = 6161;
+      const info = makeStdioServerInfo('no-ps-server');
+      setServerInfosForTest([info]);
+
+      await removeServer('no-ps-server');
+
+      expect(mockTreeKill).not.toHaveBeenCalled();
+      expect(kill).toHaveBeenCalledWith(6161, 'SIGTERM');
+    });
+
+    it('still escalates to SIGKILL on the direct child after the grace period', async () => {
+      jest.useFakeTimers();
+      try {
+        const kill = recordProcessKills();
+        currentTestPid = 6262;
+        const info = makeStdioServerInfo('stubborn-no-ps-server');
+        setServerInfosForTest([info]);
+
+        await removeServer('stubborn-no-ps-server');
+
+        expect(kill).toHaveBeenCalledWith(6262, 'SIGTERM');
+        kill.mockClear();
+
+        jest.advanceTimersByTime(2000);
+
+        expect(mockTreeKill).not.toHaveBeenCalled();
+        expect(kill).toHaveBeenCalledWith(6262, 'SIGKILL');
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not throw when the direct child no longer exists', async () => {
+      const kill = recordProcessKills();
+      kill.mockImplementation(((pid: number, signal?: string | number) => {
+        if (signal !== 0 && signal !== undefined && pid === currentTestPid) {
+          throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        }
+        return true;
+      }) as any);
+      currentTestPid = 6363;
+      const info = makeStdioServerInfo('gone-no-ps-server');
+      setServerInfosForTest([info]);
+
+      await expect(removeServer('gone-no-ps-server')).resolves.toEqual(
+        expect.objectContaining({ success: true }),
+      );
+      expect(mockTreeKill).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1072.

`tree-kill@1.2.2` walks the stdio process tree by spawning `ps` on Linux, but the official Docker image (based on `python:3.13-slim-trixie`) ships without procps. The failed spawn emits an unhandled `'error'` event on tree-kill's internal child process — something neither the callback nor a try/catch around `treeKill()` can intercept — so every rename/disable/delete of a running stdio server raised `spawn ps ENOENT` as an application-level uncaught exception. Five occurrences within 60 seconds tripped MCPHub's fatal-error circuit breaker (`process.exit(1)`) and Docker restarted the container.

### Root cause detail

`buildProcessTree` in tree-kill attaches only `data`/`close` listeners to its `ps` spawn; there is no `error` handler, so ENOENT escapes to `process.on('uncaughtException')` ([src/index.ts](src/index.ts)). Upstream tree-kill has not published a release since 2019, so waiting for an upstream fix is not viable.

## Changes

- **Defensive fallback** ([src/utils/processTree.ts](src/utils/processTree.ts), [src/services/mcpService.ts](src/services/mcpService.ts)): detect once whether the platform's process-lister tool is available (win32 → `taskkill`, darwin → `pgrep`, both OS-shipped; other platforms → `ps` resolved across `PATH` and well-known bin dirs). When unavailable, `killStdioProcessTree` falls back to signaling just the direct child via `process.kill` with the same two-stage SIGTERM → SIGKILL escalation and ESRCH tolerance as the tree-kill path. This degrades gracefully to pre-#924 behavior instead of crashing.
- **Image fix** ([Dockerfile](Dockerfile)): install `procps` so full process-tree cleanup works in the official image.
- **Tests**: unit tests for the availability probe (platform branches, PATH scanning, caching) and regression tests asserting that when the lister is missing, tree-kill is never invoked, the direct child still receives SIGTERM/SIGKILL, and ESRCH does not throw.

## Test plan

- [x] New failing tests written first (red), then implementation turned them green
- [x] `pnpm lint`
- [x] `pnpm test:ci` — 163 suites / 1160 tests pass
- [x] `pnpm build`
- [ ] Manual: build the image from this branch, add + rename a stdio server several times in a row, confirm no `[FATAL]` lines and no container restart

## Related

- #920 — original orphaned stdio descendants report
- #924 — PR that introduced tree-kill cleanup
- #989 — mentions the missing `ps` executable as additional info