### PR TITLE
feat(oauth): add RFC 9207 issuer identification and CIMD client support

### DIFF
--- a/docs/adr/0003-mcp-2026-07-28-staged-upgrade-path.md
+++ b/docs/adr/0003-mcp-2026-07-28-staged-upgrade-path.md
@@ -1,0 +1,23 @@
+# Adopt MCP 2026-07-28 through a staged upgrade path
+
+MCPHub adopts the MCP `2026-07-28` specification (stateless core: no `initialize` handshake, no `Mcp-Session-Id`) in three decoupled steps instead of a single migration:
+
+1. **OAuth hardening on the current SDK** (no wire change): add RFC 9207 `iss` to our authorization server's authorize responses (`oauthServerController.ts` builds redirects with only `code`/`state` today) and validate `iss` when redeeming codes as an upstream OAuth client; add Client ID Metadata Documents (CIMD) alongside Dynamic Client Registration — DCR is formally deprecated in the new revision but keeps working.
+2. **SDK v2 API migration, wire unchanged**: move from the monolithic `@modelcontextprotocol/sdk` (currently ^1.29.0, negotiating `2025-11-25`) to the v2 split packages (`@modelcontextprotocol/server`, `/client`, HTTP adapters), using the official codemod. Servers keep speaking `2025-11-25` until step 3.
+3. **Protocol enablement via dual-stack handler**: serve both revisions from one endpoint with v2's `createMcpHandler`, run a deprecation window on the legacy SSE transport, then remove the session layer.
+
+The path's shape comes from what the code actually binds to sessions. Most downstream state is derivable: the `enableSessionRebuild` mechanism already reconstructs full sessions from `(sessionId, group)` alone, per-session `Server` instances (`mcpService.ts`) are pure functions of group, and bearer auth is revalidated on every request. Two pieces are genuinely sticky and block step 3: `perSessionClient` upstream isolation plus OpenAPI per-session cookie jars (need an explicit-handle or header-correlation redesign), and the legacy SSE `/messages` endpoint whose group lives only in the session (dies with the transport). We use no sampling/elicitation/roots anywhere, so Multi Round-Trip Requests require zero migration.
+
+## Considered Options
+
+- **Big-bang move to v2 + new protocol now** — rejected: v2 GA'd weeks ago; bundling the transport/session rewrite (~700 lines of session tests plus integration tests encoding session-continuity semantics) with independently valuable OAuth fixes maximizes risk on both.
+- **Stay on `2025-11-25` indefinitely** — rejected: the stateless core targets exactly gateway deployments like ours; staying means keeping the session-rebuild workaround layer forever and forgoing header-based routing (`Mcp-Method`/`Mcp-Name`) and list-cache (`ttlMs`/`cacheScope`) passthrough.
+- **Gate all work on client ecosystem readiness** — rejected as a blocker: `createMcpHandler` answers both revisions from one endpoint, so old clients keep working throughout; the only real gate is letting early v2 patch releases prove stable before step 2.
+
+## Consequences
+
+- Step 2 drops Node 18 from the support matrix (v2 is ESM-only, Node 20+): update `engines`, CI matrix, and Docker base image together.
+- The legacy HTTP+SSE transport carries a ≥12-month deprecation window per spec policy; its removal takes the group-in-session quirk and the session-rebuild machinery with it.
+- `perSessionClient` isolation must gain an explicit design (tool-minted handles passed as arguments, per the spec's recommended pattern, or a header correlation key) before the session layer can be deleted.
+- During the dual-stack period, the group-resolution fallback chain must preserve the GHSA-454m-4vm6-842f scope-validation behavior for requests arriving under either revision.
+- Session-continuity tests (cached-session-id reuse after rebuild, initialize-gated session creation) are rewritten at step 3, not patched beforehand.

--- a/src/constants/oauthServerDefaults.ts
+++ b/src/constants/oauthServerDefaults.ts
@@ -13,6 +13,10 @@ export const DEFAULT_OAUTH_SERVER_CONFIG: OAuthServerConfig = {
     allowedGrantTypes: ['authorization_code', 'refresh_token'],
     requiresAuthentication: false,
   },
+  clientIdMetadata: {
+    enabled: false,
+    cacheTtlMs: 3_600_000,
+  },
 };
 
 export const cloneDefaultOAuthServerConfig = (): OAuthServerConfig => {
@@ -37,5 +41,6 @@ export const cloneDefaultOAuthServerConfig = (): OAuthServerConfig => {
     ...DEFAULT_OAUTH_SERVER_CONFIG,
     allowedScopes,
     dynamicRegistration,
+    clientIdMetadata: { ...DEFAULT_OAUTH_SERVER_CONFIG.clientIdMetadata },
   };
 };

--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -25,6 +25,7 @@ import {
 } from '../services/mcpService.js';
 import { replaceEnvVars } from '../config/index.js';
 import { loadServerConfig } from '../services/oauthSettingsStore.js';
+import { validateAuthorizationIss } from '../utils/oauthIssuer.js';
 import type { ServerInfo } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 
@@ -276,6 +277,40 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
     }
 
     logger.log('Processing OAuth callback for server', { serverName: serverInfo.name });
+
+    // RFC 9207 / SEP-2468: when the authorization response carries `iss`,
+    // validate it against the issuer we sent the authorization request to
+    // before redeeming the code (mix-up attack mitigation). Legacy servers
+    // that omit `iss` are allowed through.
+    const issParam = normalizeQueryParam(req.query.iss);
+    const issResult = validateAuthorizationIss({
+      iss: issParam,
+      authorizationUrl:
+        serverInfo.oauth?.authorizationUrl ??
+        serverInfo.config?.oauth?.pendingAuthorization?.authorizationUrl,
+      configuredIssuer: serverInfo.config?.oauth?.dynamicRegistration?.issuer,
+    });
+    if (!issResult.valid) {
+      logger.error('OAuth callback iss validation failed', {
+        serverName: serverInfo.name,
+        reason: issResult.reason,
+      });
+      return res
+        .status(400)
+        .send(
+          generateHtmlResponse(
+            t,
+            'error',
+            t('oauthCallback.authorizationFailed'),
+            issResult.reason,
+          ),
+        );
+    }
+    if (issParam && !issResult.checked) {
+      logger.warn('OAuth callback carried iss but no expected issuer is known; accepting', {
+        serverName: serverInfo.name,
+      });
+    }
 
     // For StreamableHTTPClientTransport, we need to call finishAuth() on the transport
     // This will exchange the authorization code for tokens automatically

--- a/src/controllers/oauthServerController.ts
+++ b/src/controllers/oauthServerController.ts
@@ -4,7 +4,7 @@ import {
   handleTokenRequest,
   handleAuthenticateRequest,
 } from '../services/oauthServerService.js';
-import { findOAuthClientById } from '../models/OAuth.js';
+import { findOAuthClientIncludingCimd, isCimdClientId } from '../services/cimdClientService.js';
 import { getSystemConfigDao, getGroupDao, getServerDao } from '../dao/index.js';
 import OAuth2Server from '@node-oauth/oauth2-server';
 import jwt from 'jsonwebtoken';
@@ -129,7 +129,7 @@ async function validateClientRedirectUri(
     return null;
   }
 
-  const client = await findOAuthClientById(clientId);
+  const client = await findOAuthClientIncludingCimd(clientId);
   if (!client) {
     res.status(400).json({ error: 'invalid_client', error_description: 'Client not found' });
     return null;
@@ -144,6 +144,33 @@ async function validateClientRedirectUri(
   }
 
   return redirectUri;
+}
+
+/**
+ * Resolve this install's issuer identifier (RFC 9207). Uses the same
+ * resolution chain as the RFC 8414 metadata endpoint (`issuer` field) so
+ * clients validating `iss` compare against a value they can discover.
+ */
+async function resolveIssuer(req: Request): Promise<string | undefined> {
+  try {
+    const systemConfig = await getSystemConfigDao().get();
+    const host = typeof req.get === 'function' ? req.get('host') : undefined;
+    const fallback = host ? `${req.protocol ?? 'http'}://${host}` : undefined;
+    return resolveInstallBaseUrl(systemConfig, fallback);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Attach the RFC 9207 `iss` parameter to an authorization response redirect.
+ * A no-op when the issuer cannot be resolved (defensive: authorization
+ * responses must never fail because of this hardening).
+ */
+function setIssuerParam(redirectUrl: URL, issuer: string | undefined): void {
+  if (issuer) {
+    redirectUrl.searchParams.set('iss', issuer);
+  }
 }
 
 /**
@@ -293,7 +320,13 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
     }
 
     // Get and validate query parameters
-    const client_id = validateQueryParam(req.query.client_id, 'client_id', /^[a-zA-Z0-9_-]+$/);
+    // CIMD (draft-ietf-oauth-client-id-metadata-document) client_ids are HTTPS
+    // URLs; registered client_ids stay restricted to the legacy safe charset.
+    const rawClientId = validateQueryParam(req.query.client_id, 'client_id');
+    const isUrlClientId = isCimdClientId(rawClientId);
+    const client_id = isUrlClientId
+      ? rawClientId
+      : validateQueryParam(rawClientId, 'client_id', /^[a-zA-Z0-9_-]+$/);
     const redirect_uri = validateQueryParam(req.query.redirect_uri, 'redirect_uri');
     const response_type = validateQueryParam(req.query.response_type, 'response_type', /^code$/);
     // RFC 6749 §3.3: scope tokens are printable ASCII (!#-[]-~) excluding " and \, space-delimited
@@ -331,7 +364,7 @@ export const getAuthorize = async (req: Request, res: Response): Promise<void> =
     }
 
     // Verify client
-    const client = await findOAuthClientById(client_id as string);
+    const client = await findOAuthClientIncludingCimd(client_id as string);
     if (!client) {
       res.status(400).json({ error: 'invalid_client', error_description: 'Client not found' });
       return;
@@ -474,6 +507,7 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
       return;
     }
 
+    const issuer = await resolveIssuer(req);
     const { allow, client_id, redirect_uri, state } = req.body;
 
     validatedRedirectUri = await validateClientRedirectUri(res, client_id, redirect_uri);
@@ -485,6 +519,7 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
     if (allow !== 'true') {
       const redirectUrl = new URL(validatedRedirectUri);
       redirectUrl.searchParams.set('error', 'access_denied');
+      setIssuerParam(redirectUrl, issuer);
       if (state) {
         redirectUrl.searchParams.set('state', state);
       }
@@ -525,6 +560,7 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
     // Build redirect URL with authorization code
     const redirectUrl = new URL(validatedRedirectUri);
     redirectUrl.searchParams.set('code', code.authorizationCode);
+    setIssuerParam(redirectUrl, issuer);
     if (state) {
       redirectUrl.searchParams.set('state', state);
     }
@@ -544,6 +580,7 @@ export const postAuthorize = async (req: Request, res: Response): Promise<void> 
         if (oauthError.message) {
           redirectUrl.searchParams.set('error_description', oauthError.message);
         }
+        setIssuerParam(redirectUrl, await resolveIssuer(req));
         if (state) {
           redirectUrl.searchParams.set('state', state);
         }

--- a/src/services/cimdClientService.ts
+++ b/src/services/cimdClientService.ts
@@ -1,0 +1,260 @@
+/**
+ * Client ID Metadata Documents (CIMD) support for MCPHub's authorization server.
+ *
+ * Implements the client side of draft-ietf-oauth-client-id-metadata-document:
+ * a client may present an HTTPS URL as its client_id; the authorization server
+ * fetches a metadata document from that URL and uses it in place of a
+ * registration. CIMD clients are always treated as PUBLIC clients (no shared
+ * secret can be established out-of-band), so PKCE with S256 is enforced by the
+ * existing public-client policy.
+ *
+ * Documents are fetched with SSRF protection (private-IP blocklist +
+ * redirect validation, shared with upstream MCP connections) and cached with
+ * a TTL. Resolution is opt-in via systemConfig.oauthServer.clientIdMetadata.enabled.
+ */
+
+import { getSystemConfigDao } from '../dao/index.js';
+import { cloneDefaultOAuthServerConfig } from '../constants/oauthServerDefaults.js';
+import { findOAuthClientById } from '../models/OAuth.js';
+import { assertSafeUrl, createRedirectValidatingFetch, type SsrfLookup } from '../utils/ssrf.js';
+import type { IOAuthClient } from '../types/index.js';
+import { logger } from '../utils/logger.js';
+
+const METADATA_FETCH_TIMEOUT_MS = 5_000;
+const DEFAULT_CACHE_TTL_MS = 3_600_000;
+const MAX_DOCUMENT_BYTES = 256 * 1024;
+
+export const isCimdClientId = (clientId: string): boolean => {
+  return typeof clientId === 'string' && clientId.startsWith('https://');
+};
+
+interface CimdDocument {
+  client_id?: unknown;
+  client_name?: unknown;
+  redirect_uris?: unknown;
+  token_endpoint_auth_method?: unknown;
+  application_type?: unknown;
+  contacts?: unknown;
+  logo_uri?: unknown;
+  client_uri?: unknown;
+  policy_uri?: unknown;
+  tos_uri?: unknown;
+  jwks_uri?: unknown;
+}
+
+interface CacheEntry {
+  client: IOAuthClient;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<IOAuthClient | undefined>>();
+
+let fetchImpl: typeof fetch = (...args) => fetch(...args);
+
+// Test seam: DNS resolution used by the SSRF guard, so tests never hit real DNS.
+let ssrfLookupOverride: SsrfLookup | undefined;
+
+/** Test seam: replace the fetch implementation used for metadata retrieval. */
+export const setCimdFetchImplForTesting = (impl: typeof fetch): void => {
+  fetchImpl = impl;
+};
+
+/** Test seam: replace DNS resolution used by the SSRF guard. */
+export const setCimdDnsLookupForTesting = (lookup?: SsrfLookup): void => {
+  ssrfLookupOverride = lookup;
+};
+
+export const clearCimdCacheForTesting = (): void => {
+  cache.clear();
+  inflight.clear();
+};
+
+interface CimdSettings {
+  enabled: boolean;
+  cacheTtlMs: number;
+}
+
+export const getCimdSettings = async (): Promise<CimdSettings> => {
+  try {
+    const systemConfig = await getSystemConfigDao().get();
+    const merged = { ...cloneDefaultOAuthServerConfig(), ...systemConfig?.oauthServer };
+    const ttl =
+      typeof merged.clientIdMetadata?.cacheTtlMs === 'number' &&
+      merged.clientIdMetadata.cacheTtlMs > 0
+        ? merged.clientIdMetadata.cacheTtlMs
+        : DEFAULT_CACHE_TTL_MS;
+    return { enabled: merged.clientIdMetadata?.enabled === true, cacheTtlMs: ttl };
+  } catch {
+    return { enabled: false, cacheTtlMs: DEFAULT_CACHE_TTL_MS };
+  }
+};
+
+const asStringArray = (value: unknown): string[] | undefined =>
+  Array.isArray(value) && value.every((v) => typeof v === 'string') ? (value as string[]) : undefined;
+
+/**
+ * Validate a fetched metadata document and map it onto an IOAuthClient.
+ * Returns undefined when the document is not a usable CIMD client.
+ */
+export const mapCimdDocument = (
+  clientIdUrl: string,
+  document: CimdDocument,
+): IOAuthClient | undefined => {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    return undefined;
+  }
+
+  // The document's client_id MUST be present and identical to the URL it was
+  // retrieved from (draft-ietf-oauth-client-id-metadata-document, section 4).
+  if (document.client_id !== clientIdUrl) {
+    return undefined;
+  }
+
+  const redirectUris = asStringArray(document.redirect_uris);
+  if (!redirectUris || redirectUris.length === 0 || !redirectUris.every((uri) => uri)) {
+    return undefined;
+  }
+
+  // Only public clients can be expressed via CIMD on this server; a document
+  // claiming a secret-based auth method cannot be honored safely.
+  const authMethod =
+    typeof document.token_endpoint_auth_method === 'string'
+      ? document.token_endpoint_auth_method
+      : 'none';
+  if (authMethod !== 'none') {
+    return undefined;
+  }
+
+  const applicationType =
+    document.application_type === 'native' ? ('native' as const) : ('web' as const);
+  const contacts = asStringArray(document.contacts);
+  const optionalUriField = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.length > 0 ? value : undefined;
+
+  return {
+    clientId: clientIdUrl,
+    name:
+      typeof document.client_name === 'string' && document.client_name.length > 0
+        ? document.client_name
+        : clientIdUrl,
+    redirectUris,
+    grants: ['authorization_code', 'refresh_token'],
+    metadata: {
+      application_type: applicationType,
+      ...(contacts ? { contacts } : {}),
+      ...(optionalUriField(document.logo_uri) ? { logo_uri: optionalUriField(document.logo_uri) } : {}),
+      ...(optionalUriField(document.client_uri) ? { client_uri: optionalUriField(document.client_uri) } : {}),
+      ...(optionalUriField(document.policy_uri) ? { policy_uri: optionalUriField(document.policy_uri) } : {}),
+      ...(optionalUriField(document.tos_uri) ? { tos_uri: optionalUriField(document.tos_uri) } : {}),
+      ...(optionalUriField(document.jwks_uri) ? { jwks_uri: optionalUriField(document.jwks_uri) } : {}),
+    },
+  };
+};
+
+const fetchCimdDocument = async (clientIdUrl: string): Promise<IOAuthClient | undefined> => {
+  await assertSafeUrl(clientIdUrl, {
+    allowInternal: false,
+    ...(ssrfLookupOverride ? { lookup: ssrfLookupOverride } : {}),
+  });
+
+  const validatingFetch = createRedirectValidatingFetch((url, init) => fetchImpl(url, init), false);
+  const response = await validatingFetch(clientIdUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(METADATA_FETCH_TIMEOUT_MS),
+    redirect: 'manual',
+  });
+
+  if (!response.ok) {
+    logger.warn('CIMD metadata document fetch failed', {
+      clientIdUrl,
+      status: response.status,
+    });
+    return undefined;
+  }
+
+  const contentLength = Number(response.headers.get('content-length') || '0');
+  if (contentLength > MAX_DOCUMENT_BYTES) {
+    logger.warn('CIMD metadata document exceeds size limit', { clientIdUrl });
+    return undefined;
+  }
+
+  let document: CimdDocument;
+  try {
+    const text = await response.text();
+    if (text.length > MAX_DOCUMENT_BYTES) {
+      logger.warn('CIMD metadata document exceeds size limit', { clientIdUrl });
+      return undefined;
+    }
+    document = JSON.parse(text) as CimdDocument;
+  } catch (error) {
+    logger.warn('CIMD metadata document is not valid JSON', { clientIdUrl, error });
+    return undefined;
+  }
+
+  const mapped = mapCimdDocument(clientIdUrl, document);
+  if (!mapped) {
+    logger.warn('CIMD metadata document failed validation', { clientIdUrl });
+  }
+  return mapped;
+};
+
+/**
+ * Resolve a URL-shaped client_id to a client by fetching (or caching) its
+ * metadata document. Returns undefined for anything that is not a valid,
+ * enabled CIMD identifier.
+ */
+export const resolveCimdClient = async (
+  clientId: string,
+  settings?: CimdSettings,
+): Promise<IOAuthClient | undefined> => {
+  const resolvedSettings = settings ?? (await getCimdSettings());
+  if (!resolvedSettings.enabled || !isCimdClientId(clientId)) {
+    return undefined;
+  }
+
+  const now = Date.now();
+  const cached = cache.get(clientId);
+  if (cached && cached.expiresAt > now) {
+    return cached.client;
+  }
+
+  const existingFetch = inflight.get(clientId);
+  if (existingFetch) {
+    return existingFetch;
+  }
+
+  const fetchPromise = fetchCimdDocument(clientId)
+    .then((client) => {
+      if (client) {
+        cache.set(clientId, { client, expiresAt: Date.now() + resolvedSettings.cacheTtlMs });
+      }
+      return client;
+    })
+    .catch((error) => {
+      logger.warn('Failed to resolve CIMD client', { clientId, error });
+      return undefined;
+    })
+    .finally(() => {
+      inflight.delete(clientId);
+    });
+
+  inflight.set(clientId, fetchPromise);
+  return fetchPromise;
+};
+
+/**
+ * Client lookup used across the authorization server surface: registered
+ * clients first, then CIMD resolution when enabled. Drop-in replacement for
+ * findOAuthClientById at every call site that must understand CIMD clients.
+ */
+export const findOAuthClientIncludingCimd = async (
+  clientId: string,
+): Promise<IOAuthClient | undefined> => {
+  const persisted = await findOAuthClientById(clientId);
+  if (persisted) {
+    return persisted;
+  }
+  return resolveCimdClient(clientId);
+};

--- a/src/services/oauthServerService.ts
+++ b/src/services/oauthServerService.ts
@@ -14,6 +14,7 @@ import {
 import crypto from 'crypto';
 import { safeCompare } from '../utils/safeCompare.js';
 import { cloneDefaultOAuthServerConfig } from '../constants/oauthServerDefaults.js';
+import { resolveCimdClient } from './cimdClientService.js';
 import { logger } from '../utils/logger.js';
 
 const { Request, Response } = OAuth2Server;
@@ -28,7 +29,24 @@ const oauthModel: OAuth2Server.AuthorizationCodeModel & OAuth2Server.RefreshToke
    * toggle only permits secret-less PUBLIC clients (GHSA-3m7m).
    */
   getClient: async (clientId: string, clientSecret?: string) => {
-    const client = await findOAuthClientById(clientId);
+    let client = await findOAuthClientById(clientId);
+
+    // CIMD fallback: URL-shaped client_ids resolve to public clients via their
+    // metadata document (opt-in). They never carry a secret, so the strict
+    // secret check below is a no-op for them.
+    if (!client) {
+      const cimdClient = await resolveCimdClient(clientId);
+      if (cimdClient) {
+        client = {
+          clientId: cimdClient.clientId,
+          name: cimdClient.name,
+          redirectUris: cimdClient.redirectUris,
+          grants: cimdClient.grants,
+          metadata: cimdClient.metadata,
+        };
+      }
+    }
+
     if (!client) {
       return false;
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -338,6 +338,13 @@ export interface OAuthServerConfig {
     allowedGrantTypes?: string[]; // Allowed grant types for dynamic registration (default: ['authorization_code', 'refresh_token'])
     requiresAuthentication?: boolean; // Whether initial registration requires authentication (default: false for public registration)
   };
+  clientIdMetadata?: {
+    // Client ID Metadata Documents (CIMD, draft-ietf-oauth-client-id-metadata-document):
+    // accept HTTPS-URL-shaped client_ids whose metadata is fetched from the URL itself.
+    // Opt-in (default false) because it makes the authorize endpoint fetch attacker-chosen URLs.
+    enabled?: boolean;
+    cacheTtlMs?: number; // Metadata document cache TTL in milliseconds (default: 3600000)
+  };
 }
 
 // Bearer authentication key configuration

--- a/src/utils/oauthIssuer.ts
+++ b/src/utils/oauthIssuer.ts
@@ -1,0 +1,78 @@
+/**
+ * RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) helpers.
+ *
+ * When MCPHub acts as an OAuth *client* toward upstream MCP servers, the
+ * authorization response redirect may carry an `iss` parameter. Per RFC 9207 /
+ * SEP-2468 the client must validate it against the issuer it sent the
+ * authorization request to before redeeming the code — this closes the
+ * authorization-server mix-up attack where a malicious AS's code is replayed
+ * at another AS's token endpoint under the same redirect URI.
+ */
+
+export interface AuthorizationResponseIssContext {
+  /** `iss` query parameter from the authorization response (absent on legacy servers). */
+  iss?: string;
+  /** The authorization URL MCPHub originally redirected the user to. */
+  authorizationUrl?: string;
+  /** Explicitly configured issuer for the upstream server, if any. */
+  configuredIssuer?: string;
+}
+
+export type IssValidationResult =
+  | { valid: true; checked: false }
+  | { valid: true; checked: true }
+  | { valid: false; checked: true; reason: string };
+
+const originOf = (url: string | undefined): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Expected `iss` values for an upstream authorization flow: the explicitly
+ * configured issuer plus the origin of the authorization endpoint actually used.
+ */
+export const expectedIssValues = (ctx: AuthorizationResponseIssContext): string[] => {
+  const candidates = [ctx.configuredIssuer, originOf(ctx.authorizationUrl)];
+  return [...new Set(candidates.filter((c): c is string => Boolean(c)))];
+};
+
+/**
+ * Validate the `iss` authorization-response parameter.
+ *
+ * - Absent `iss` → valid but unchecked (older servers do not send it).
+ * - Present `iss` with nothing to compare against → unchecked fail-safe pass,
+ *   since we cannot establish what the client expected (no mix-up possible
+ *   when only one AS is involved in a flow keyed by our own state parameter).
+ * - Present `iss` → must exactly match one of the expected values.
+ */
+export const validateAuthorizationIss = (
+  ctx: AuthorizationResponseIssContext,
+): IssValidationResult => {
+  const { iss } = ctx;
+
+  if (!iss) {
+    return { valid: true, checked: false };
+  }
+
+  const expected = expectedIssValues(ctx);
+  if (expected.length === 0) {
+    return { valid: true, checked: false };
+  }
+
+  if (expected.includes(iss)) {
+    return { valid: true, checked: true };
+  }
+
+  return {
+    valid: false,
+    checked: true,
+    reason: 'iss parameter does not match the expected authorization server issuer',
+  };
+};

--- a/tests/controllers/oauthCallbackController.test.ts
+++ b/tests/controllers/oauthCallbackController.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for RFC 9207 `iss` validation in the upstream OAuth callback:
+ * a mismatched issuer must be rejected BEFORE the authorization code is
+ * redeemed (mix-up attack mitigation).
+ */
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  getServerByName: jest.fn(),
+  getServerByOAuthState: jest.fn(),
+  connectClientWithDiagnostics: jest.fn(),
+  createTransportFromConfig: jest.fn(),
+  updateServerToolsCache: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthSettingsStore.js', () => ({
+  loadServerConfig: jest.fn(),
+}));
+
+jest.mock('../../src/config/index.js', () => ({
+  replaceEnvVars: jest.fn((value: unknown) => value),
+}));
+
+import { handleOAuthCallback } from '../../src/controllers/oauthCallbackController.js';
+import {
+  getServerByOAuthState,
+  createTransportFromConfig,
+} from '../../src/services/mcpService.js';
+import { loadServerConfig } from '../../src/services/oauthSettingsStore.js';
+
+const AUTHORIZATION_URL = 'https://as.example.com/authorize?client_id=mcphub';
+
+const createServerInfo = () => {
+  const finishAuth = jest.fn().mockResolvedValue(undefined);
+  return {
+    name: 'upstream-server',
+    status: 'oauth_required',
+    config: {
+      url: 'https://upstream.example.com/mcp',
+      oauth: { dynamicRegistration: { enabled: true } },
+    },
+    options: undefined,
+    transport: { finishAuth, close: jest.fn().mockResolvedValue(undefined) },
+    client: undefined,
+    tools: [],
+    oauth: {
+      authorizationUrl: AUTHORIZATION_URL,
+      state: 'state-123',
+    },
+  };
+};
+
+const createRequest = (query: Record<string, string>) =>
+  ({
+    query,
+    t: (key: string) => key,
+    protocol: 'http',
+    get: jest.fn().mockReturnValue('localhost:3000'),
+  }) as unknown as import('express').Request;
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    body: '',
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    send(html: string) {
+      this.body = html;
+      return this;
+    },
+  };
+  return res;
+};
+
+describe('oauthCallbackController iss validation', () => {
+  let serverInfo: ReturnType<typeof createServerInfo>;
+  let originalFinishAuth: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    serverInfo = createServerInfo();
+    originalFinishAuth = serverInfo.transport.finishAuth as jest.Mock;
+    (getServerByOAuthState as jest.Mock).mockReturnValue(serverInfo);
+    (loadServerConfig as jest.Mock).mockResolvedValue({
+      url: 'https://upstream.example.com/mcp',
+      oauth: {},
+    });
+    (createTransportFromConfig as jest.Mock).mockResolvedValue({
+      finishAuth: jest.fn(),
+    });
+  });
+
+  it('redeems the code when iss matches the authorization server origin', async () => {
+    const res = createResponse();
+
+    await handleOAuthCallback(
+      createRequest({ code: 'auth-code', state: 'state-123', iss: 'https://as.example.com' }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(originalFinishAuth).toHaveBeenCalledWith('auth-code');
+  });
+
+  it('rejects a mismatched iss without redeeming the code', async () => {
+    const res = createResponse();
+
+    await handleOAuthCallback(
+      createRequest({ code: 'auth-code', state: 'state-123', iss: 'https://evil.example.com' }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body)).toContain('iss parameter does not match');
+    expect(serverInfo.oauth?.state).toBe('state-123');
+    expect(originalFinishAuth).not.toHaveBeenCalled();
+  });
+
+  it('allows legacy servers that omit iss entirely', async () => {
+    const res = createResponse();
+
+    await handleOAuthCallback(
+      createRequest({ code: 'auth-code', state: 'state-123' }),
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(originalFinishAuth).toHaveBeenCalledWith('auth-code');
+  });
+});

--- a/tests/controllers/oauthServerController.test.ts
+++ b/tests/controllers/oauthServerController.test.ts
@@ -8,9 +8,19 @@ jest.mock('../../src/models/OAuth.js', () => ({
   findOAuthClientById: jest.fn(),
 }));
 
+jest.mock('../../src/services/cimdClientService.js', () => ({
+  findOAuthClientIncludingCimd: jest.fn(),
+  isCimdClientId: jest.fn((clientId: string) => clientId.startsWith('https://')),
+}));
+
+jest.mock('../../src/dao/index.js', () => ({
+  getSystemConfigDao: jest.fn(),
+}));
+
 import { postAuthorize } from '../../src/controllers/oauthServerController.js';
 import { getOAuthServer } from '../../src/services/oauthServerService.js';
-import { findOAuthClientById } from '../../src/models/OAuth.js';
+import { findOAuthClientIncludingCimd } from '../../src/services/cimdClientService.js';
+import { getSystemConfigDao } from '../../src/dao/index.js';
 
 type MockResponse = {
   status: jest.Mock;
@@ -31,6 +41,11 @@ const createResponse = (): MockResponse => {
 const createRequest = (overrides: Record<string, unknown> = {}) => ({
   body: {},
   query: {},
+  headers: {},
+  method: 'POST',
+  url: '/oauth/authorize',
+  protocol: 'https',
+  get: jest.fn().mockReturnValue('hub.example.com'),
   header: jest.fn().mockReturnValue(undefined),
   ...overrides,
 });
@@ -39,10 +54,19 @@ describe('oauthServerController postAuthorize redirect_uri validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    (findOAuthClientById as jest.Mock).mockResolvedValue({
-      clientId: 'trusted-client',
-      name: 'Trusted Client',
-      redirectUris: ['https://trusted.example.com/callback'],
+    (findOAuthClientIncludingCimd as jest.Mock).mockImplementation(
+      (clientId: string) =>
+        clientId === 'trusted-client'
+          ? Promise.resolve({
+              clientId: 'trusted-client',
+              name: 'Trusted Client',
+              redirectUris: ['https://trusted.example.com/callback'],
+            })
+          : Promise.resolve(undefined),
+    );
+
+    (getSystemConfigDao as jest.Mock).mockReturnValue({
+      get: async () => ({ install: { baseUrl: 'https://hub.example.com' } }),
     });
   });
 
@@ -71,7 +95,7 @@ describe('oauthServerController postAuthorize redirect_uri validation', () => {
     expect(res.redirect).not.toHaveBeenCalled();
   });
 
-  it('preserves denial redirects for registered redirect URIs', async () => {
+  it('preserves denial redirects for registered redirect URIs and adds RFC 9207 iss', async () => {
     (getOAuthServer as jest.Mock).mockReturnValue({
       authorize: jest.fn(),
     });
@@ -89,9 +113,86 @@ describe('oauthServerController postAuthorize redirect_uri validation', () => {
     await postAuthorize(req as any, res as any);
 
     expect(res.redirect).toHaveBeenCalledWith(
-      'https://trusted.example.com/callback?error=access_denied&state=state-123',
+      'https://trusted.example.com/callback?error=access_denied&iss=https%3A%2F%2Fhub.example.com&state=state-123',
     );
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('adds RFC 9207 iss to successful authorization redirects', async () => {
+    (getOAuthServer as jest.Mock).mockReturnValue({
+      authorize: jest.fn().mockResolvedValue({ authorizationCode: 'code-abc' }),
+    });
+
+    const req = createRequest({
+      user: { username: 'alice' },
+      body: {
+        allow: 'true',
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        state: 'state-123',
+      },
+    });
+    const res = createResponse();
+
+    await postAuthorize(req as any, res as any);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      'https://trusted.example.com/callback?code=code-abc&iss=https%3A%2F%2Fhub.example.com&state=state-123',
+    );
+  });
+
+  it('adds RFC 9207 iss to OAuth error redirects', async () => {
+    (getOAuthServer as jest.Mock).mockReturnValue({
+      authorize: jest.fn().mockRejectedValue(
+        Object.assign(new Error('Scope is invalid'), {
+          code: 400,
+          name: 'invalid_scope',
+        }),
+      ),
+    });
+
+    const req = createRequest({
+      user: {
+        username: 'alice',
+      },
+      body: {
+        allow: 'true',
+        client_id: 'trusted-client',
+        redirect_uri: 'https://trusted.example.com/callback',
+        state: 'state-123',
+      },
+    });
+    const res = createResponse();
+
+    await postAuthorize(req as any, res as any);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      'https://trusted.example.com/callback?error=invalid_scope&error_description=Scope+is+invalid&iss=https%3A%2F%2Fhub.example.com&state=state-123',
+    );
+  });
+
+  it('omits iss when no issuer can be resolved', async () => {
+    (getOAuthServer as jest.Mock).mockReturnValue({
+      authorize: jest.fn(),
+    });
+    (getSystemConfigDao as jest.Mock).mockReturnValue({
+      get: async () => ({}),
+    });
+
+    const req = createRequest({ get: jest.fn().mockReturnValue(undefined) });
+    req.body = {
+      allow: 'false',
+      client_id: 'trusted-client',
+      redirect_uri: 'https://trusted.example.com/callback',
+      state: 'state-123',
+    };
+    const res = createResponse();
+
+    await postAuthorize(req as any, res as any);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+      'https://trusted.example.com/callback?error=access_denied&state=state-123',
+    );
   });
 
   it('rejects OAuth error redirects when redirect_uri is not registered for the client', async () => {

--- a/tests/services/cimdClientService.test.ts
+++ b/tests/services/cimdClientService.test.ts
@@ -1,0 +1,195 @@
+import { getSystemConfigDao } from '../../src/dao/index.js';
+import {
+  clearCimdCacheForTesting,
+  getCimdSettings,
+  isCimdClientId,
+  mapCimdDocument,
+  resolveCimdClient,
+  setCimdDnsLookupForTesting,
+  setCimdFetchImplForTesting,
+} from '../../src/services/cimdClientService.js';
+
+jest.mock('../../src/models/OAuth.js', () => ({
+  findOAuthClientById: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/dao/index.js', () => ({
+  getSystemConfigDao: jest.fn(),
+}));
+
+const mockedGetSystemConfigDao = getSystemConfigDao as jest.Mock;
+
+const configureCimd = (enabled: boolean, cacheTtlMs?: number) => {
+  mockedGetSystemConfigDao.mockReturnValue({
+    get: async () => ({
+      oauthServer: {
+        clientIdMetadata: { enabled, ...(cacheTtlMs !== undefined ? { cacheTtlMs } : {}) },
+      },
+    }),
+  });
+};
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+
+describe('cimdClientService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearCimdCacheForTesting();
+    // Public, non-blocked address so the SSRF guard never performs real DNS.
+    setCimdDnsLookupForTesting(async () => ['93.184.216.34']);
+  });
+
+  describe('isCimdClientId', () => {
+    it('accepts only HTTPS URL identifiers', () => {
+      expect(isCimdClientId('https://client.example.com/metadata')).toBe(true);
+      expect(isCimdClientId('http://client.example.com/metadata')).toBe(false);
+      expect(isCimdClientId('registered-client-id')).toBe(false);
+    });
+  });
+
+  describe('getCimdSettings', () => {
+    it('is disabled by default', async () => {
+      configureCimd(false);
+      expect(await getCimdSettings()).toEqual({ enabled: false, cacheTtlMs: 3_600_000 });
+    });
+
+    it('fails closed when the config store errors', async () => {
+      mockedGetSystemConfigDao.mockImplementation(() => {
+        throw new Error('dao unavailable');
+      });
+      expect((await getCimdSettings()).enabled).toBe(false);
+    });
+  });
+
+  describe('mapCimdDocument', () => {
+    const url = 'https://client.example.com/oauth-metadata';
+
+    it('maps a valid public-client document', () => {
+      const client = mapCimdDocument(url, {
+        client_id: url,
+        client_name: 'Example Client',
+        redirect_uris: ['https://app.example.com/callback', 'http://127.0.0.1/callback'],
+        application_type: 'native',
+        contacts: ['dev@example.com'],
+        policy_uri: 'https://app.example.com/policy',
+      });
+
+      expect(client).toMatchObject({
+        clientId: url,
+        name: 'Example Client',
+        grants: ['authorization_code', 'refresh_token'],
+        redirectUris: ['https://app.example.com/callback', 'http://127.0.0.1/callback'],
+      });
+      expect(client?.metadata?.application_type).toBe('native');
+      expect(client?.clientSecret).toBeUndefined();
+    });
+
+    it('rejects documents whose client_id does not match the fetch URL', () => {
+      expect(
+        mapCimdDocument(url, {
+          client_id: 'https://other.example.com/metadata',
+          redirect_uris: ['https://app.example.com/callback'],
+        }),
+      ).toBeUndefined();
+    });
+
+    it('rejects documents without redirect URIs', () => {
+      expect(mapCimdDocument(url, { client_id: url })).toBeUndefined();
+      expect(
+        mapCimdDocument(url, { client_id: url, redirect_uris: [] }),
+      ).toBeUndefined();
+    });
+
+    it('rejects documents claiming secret-based authentication', () => {
+      expect(
+        mapCimdDocument(url, {
+          client_id: url,
+          redirect_uris: ['https://app.example.com/callback'],
+          token_endpoint_auth_method: 'client_secret_basic',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('rejects non-object payloads', () => {
+      expect(mapCimdDocument(url, undefined as never)).toBeUndefined();
+      expect(mapCimdDocument(url, ['not', 'an', 'object'] as never)).toBeUndefined();
+    });
+  });
+
+  describe('resolveCimdClient', () => {
+    const url = 'https://client.example.com/oauth-metadata';
+
+    it('returns undefined when disabled even for URL-shaped ids', async () => {
+      configureCimd(false);
+      await expect(resolveCimdClient(url)).resolves.toBeUndefined();
+    });
+
+    it('fetches and caches a valid metadata document', async () => {
+      configureCimd(true);
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse({
+          client_id: url,
+          client_name: 'Cached Client',
+          redirect_uris: ['https://app.example.com/callback'],
+        }),
+      );
+      setCimdFetchImplForTesting(fetchMock as unknown as typeof fetch);
+
+      const first = await resolveCimdClient(url);
+      expect(first?.name).toBe('Cached Client');
+      const second = await resolveCimdClient(url);
+      expect(second).toBe(first);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches after the cache TTL expires', async () => {
+      configureCimd(true, 1);
+      const fetchMock = jest.fn().mockResolvedValue(
+        jsonResponse({
+          client_id: url,
+          redirect_uris: ['https://app.example.com/callback'],
+        }),
+      );
+      setCimdFetchImplForTesting(fetchMock as unknown as typeof fetch);
+
+      await resolveCimdClient(url);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await resolveCimdClient(url);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not resolve invalid documents', async () => {
+      configureCimd(true);
+      setCimdFetchImplForTesting(
+        jest.fn().mockResolvedValue(jsonResponse({ client_id: url })) as unknown as typeof fetch,
+      );
+      await expect(resolveCimdClient(url)).resolves.toBeUndefined();
+    });
+
+    it('blocks SSRF targets before fetching', async () => {
+      configureCimd(true);
+      const fetchMock = jest.fn();
+      setCimdFetchImplForTesting(fetchMock as unknown as typeof fetch);
+
+      await expect(
+        resolveCimdClient('https://127.0.0.1/metadata.json'),
+      ).resolves.toBeUndefined();
+      await expect(resolveCimdClient('http://169.254.169.254/latest/meta-data')).resolves.toBeUndefined();
+      await expect(resolveCimdClient('https://10.0.0.5/metadata.json')).resolves.toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined on network failures without throwing', async () => {
+      configureCimd(true);
+      setCimdFetchImplForTesting(
+        jest.fn().mockRejectedValue(new Error('boom')) as unknown as typeof fetch,
+      );
+      await expect(resolveCimdClient(url)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/utils/oauthIssuer.test.ts
+++ b/tests/utils/oauthIssuer.test.ts
@@ -1,0 +1,83 @@
+import {
+  expectedIssValues,
+  validateAuthorizationIss,
+} from '../../src/utils/oauthIssuer.js';
+
+describe('oauthIssuer (RFC 9207 iss validation)', () => {
+  describe('expectedIssValues', () => {
+    it('derives the origin from the authorization URL', () => {
+      expect(
+        expectedIssValues({
+          authorizationUrl: 'https://as.example.com/authorize?client_id=x',
+        }),
+      ).toEqual(['https://as.example.com']);
+    });
+
+    it('includes the explicitly configured issuer', () => {
+      expect(
+        expectedIssValues({
+          configuredIssuer: 'https://auth.example.com',
+          authorizationUrl: 'https://auth.example.com/authorize',
+        }),
+      ).toEqual(['https://auth.example.com']);
+    });
+
+    it('deduplicates candidates', () => {
+      expect(
+        expectedIssValues({
+          configuredIssuer: 'https://as.example.com',
+          authorizationUrl: 'https://as.example.com/authorize',
+        }),
+      ).toEqual(['https://as.example.com']);
+    });
+
+    it('returns empty for no usable candidates', () => {
+      expect(expectedIssValues({})).toEqual([]);
+      expect(expectedIssValues({ authorizationUrl: 'not-a-url' })).toEqual([]);
+    });
+  });
+
+  describe('validateAuthorizationIss', () => {
+    it('passes without checking when iss is absent (legacy servers)', () => {
+      const result = validateAuthorizationIss({
+        authorizationUrl: 'https://as.example.com/authorize',
+      });
+      expect(result).toEqual({ valid: true, checked: false });
+    });
+
+    it('accepts an iss matching the authorization endpoint origin', () => {
+      const result = validateAuthorizationIss({
+        iss: 'https://as.example.com',
+        authorizationUrl: 'https://as.example.com/authorize',
+      });
+      expect(result).toEqual({ valid: true, checked: true });
+    });
+
+    it('accepts an iss matching the explicitly configured issuer', () => {
+      const result = validateAuthorizationIss({
+        iss: 'https://tenant.auth.example.com',
+        configuredIssuer: 'https://tenant.auth.example.com',
+        authorizationUrl: 'https://other.example.com/authorize',
+      });
+      expect(result).toEqual({ valid: true, checked: true });
+    });
+
+    it('rejects a mismatched iss before the code is redeemed', () => {
+      const result = validateAuthorizationIss({
+        iss: 'https://evil.example.com',
+        authorizationUrl: 'https://as.example.com/authorize',
+        configuredIssuer: 'https://as.example.com',
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.checked).toBe(true);
+        expect(result.reason).toContain('iss');
+      }
+    });
+
+    it('fails safe when iss is present but no expected issuer is known', () => {
+      const result = validateAuthorizationIss({ iss: 'https://somewhere.example.com' });
+      expect(result).toEqual({ valid: true, checked: false });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of the MCP `2026-07-28` staged upgrade path ([ADR-0003](docs/adr/0003-mcp-2026-07-28-staged-upgrade-path.md)): OAuth authorization hardening on the current SDK, with no wire-protocol change.

### RFC 9207 — Authorization Server Issuer Identification (SEP-2468)

- **AS side**: `/oauth/authorize` responses now include the `iss` parameter on all redirect paths (code success, user denial, and OAuth error redirects). The issuer resolves through the same chain as the RFC 8414 metadata endpoint's `issuer` field, so validating clients compare against a discoverable value. Resolution failure degrades gracefully (parameter omitted, flow unaffected).
- **Client side**: when MCPHub connects to upstream servers over OAuth, the callback controller validates a present `iss` query parameter against the expected issuer (explicitly configured issuer, or the origin of the stored authorization URL) **before** calling `finishAuth` to redeem the code. A mismatch is rejected with 400 and the code is never sent to any token endpoint — closing the authorization-server mix-up hole. Legacy servers that omit `iss` continue to work.

### Client ID Metadata Documents (CIMD, draft-ietf-oauth-client-id-metadata-document)

New opt-in client identity mechanism alongside DCR (which remains enabled and will be deprecated in a future MCP revision):

- Clients may present an HTTPS URL as their `client_id`; the authorization server fetches the metadata document from that URL.
- Fetches are SSRF-guarded (`assertSafeUrl` private-IP blocklist + manual redirect validation shared with upstream MCP connections), capped at 5 s / 256 KB, and cached with a configurable TTL plus in-flight deduplication.
- Document validation: `client_id` must exactly match the retrieval URL, non-empty `redirect_uris` required, only public clients supported (`token_endpoint_auth_method` absent or `none`). CIMD clients therefore carry no secret and fall under the existing PKCE-S256-for-public-clients policy (GHSA-3m7m).
- Wired into all three client-resolution surfaces: `GET /oauth/authorize`, redirect-uri validation for `POST /oauth/authorize`, and the token endpoint's `model.getClient`.
- Enabled via `systemConfig.oauthServer.clientIdMetadata.enabled` (default `false`, since it makes the authorize endpoint fetch attacker-chosen URLs).

## Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| Authorization response redirects | `code`/`error` + `state` only | also carry `iss=<issuer>` when resolvable |
| Upstream callback with mismatched `iss` | code redeemed by SDK unconditionally | 400 error page; code never redeemed |
| URL-shaped `client_id` at authorize/token | rejected (`invalid_client`) or charset-rejected | resolved via CIMD when enabled; unchanged behavior when disabled |

No breaking changes: DCR untouched, legacy `iss`-less AS flows untouched, CIMD off by default.

## Tests

Automated:

- New `tests/utils/oauthIssuer.test.ts` — expected-issuer derivation, match/mismatch/absent semantics (9 cases)
- New `tests/services/cimdClientService.test.ts` — document mapping/validation, cache TTL refetch, SSRF blocklist interception, fail-closed settings (13 cases)
- New `tests/controllers/oauthCallbackController.test.ts` — matching `iss` redeems, mismatched `iss` rejected pre-redemption, absent `iss` allowed
- Extended `tests/controllers/oauthServerController.test.ts` — `iss` asserted on success/denial/error redirects, omitted when issuer unresolved

Full gate: `pnpm lint` ✓ · `pnpm test:ci` ✓ (166 suites / 1189 tests) · `pnpm build` ✓

Manual: not run — no UI surface touched; consent/callback pages render through existing paths exercised by tests.

## References

- [MCP 2026-07-28 specification announcement](https://blog.modelcontextprotocol.io/posts/2026-07-28/)
- [SEP-2468 — RFC 9207 issuer validation](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468)
- [RFC 9207](https://www.rfc-editor.org/rfc/rfc9207)
- [draft-ietf-oauth-client-id-metadata-document](https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/)