### PR TITLE
fix(security): separate shared server use from config disclosure

### DIFF
--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -45,6 +45,11 @@ import {
   getUserDao,
 } from '../dao/DaoFactory.js';
 import { UserContextService } from '../services/userContextService.js';
+import { authorizationService } from '../services/authorizationService.js';
+import {
+  presentServerForPrincipal,
+  presentServerInfoForPrincipal,
+} from '../services/serverConfigPresenter.js';
 import { disconnectUpstreamOAuth } from '../services/upstreamOAuthDisconnectService.js';
 import type { UpstreamOAuthDisconnectScope } from '../services/upstreamOAuthDisconnectService.js';
 import { normalizeServerConfigForPersistence } from '../utils/serverConfigPersistence.js';
@@ -305,13 +310,23 @@ export const getAllServers = async (req: Request, res: Response): Promise<void> 
       serversInfo = await getServersInfo();
     }
 
+    // #1036 Phase 1: withhold OAuth session-recovery fields from principals
+    // who may not read the full server configuration (defense in depth; the
+    // config block on list entries is already narrowed to safe metadata).
+    const presentedServersInfo = serversInfo.map((info) =>
+      presentServerInfoForPrincipal(info, currentUser),
+    );
+    const presentedAllServers = allServers?.map((info) =>
+      presentServerInfoForPrincipal(info, currentUser),
+    );
+
     const response: ApiResponse & {
       pagination?: typeof pagination;
       allServers?: Omit<ServerInfo, 'client' | 'transport'>[];
     } = {
       success: true,
-      data: createSafeJSON(serversInfo),
-      ...(allServers && { allServers: createSafeJSON(allServers) }),
+      data: createSafeJSON(presentedServersInfo),
+      ...(presentedAllServers && { allServers: createSafeJSON(presentedAllServers) }),
       ...(pagination && { pagination }),
     };
     res.json(response);
@@ -1066,8 +1081,31 @@ export const getServerConfig = async (req: Request, res: Response): Promise<void
   try {
     const { name } = req.params;
 
-    const serverConfig = await loadAuthorizedServer(req, res, name);
-    if (!serverConfig) {
+    const serverDao = getServerDao();
+    const serverRecord = await serverDao.findById(name);
+    if (!serverRecord) {
+      res.status(404).json({
+        success: false,
+        message: 'Server not found',
+      });
+      return;
+    }
+
+    // #1036 Phase 1: config read and server use are separate decisions.
+    // Owner/admin get the full configuration; visibility-admitted shared users
+    // (public / group members) get a safe view without secret-bearing fields;
+    // everyone else is rejected exactly as before.
+    const principal = getRequestUser(req);
+    const canReadFullConfig = authorizationService.can(
+      'server.config.read',
+      serverRecord,
+      principal,
+    );
+    if (!canReadFullConfig && !authorizationService.can('server.invoke', serverRecord, principal)) {
+      res.status(403).json({
+        success: false,
+        message: 'Forbidden',
+      });
       return;
     }
 
@@ -1076,7 +1114,8 @@ export const getServerConfig = async (req: Request, res: Response): Promise<void
     const serverInfo = allServers.find((s) => s.name === name);
 
     // Extract config without the name field
-    const { name: serverName, ...config } = serverConfig;
+    const { name: serverName, ...config } = serverRecord;
+    const presented = presentServerForPrincipal(config, principal);
 
     // OpenAPI tools can carry circular $ref cycles left by SwaggerParser.dereference
     // (recursive schemas), which would make res.json throw. Mirror the list endpoint
@@ -1087,7 +1126,7 @@ export const getServerConfig = async (req: Request, res: Response): Promise<void
         name: serverName,
         status: serverInfo?.status || 'disconnected',
         tools: serverInfo?.tools || [],
-        config,
+        config: presented.data,
       }),
     };
 

--- a/src/services/authorizationService.ts
+++ b/src/services/authorizationService.ts
@@ -1,0 +1,55 @@
+import { IUser, ServerVisibility } from '../types/index.js';
+import { DataService } from './dataService.js';
+import { UserContextService } from './userContextService.js';
+
+// Phase 1 authorization boundary for issue #1036: server usage
+// (discover/invoke) is a separate decision from configuration disclosure
+// (config.read/manage). Discover/invoke delegate to the same visibility rules
+// that gate runtime tool routing (DataService.filterData), so there is a single
+// source of truth for who can see a server.
+export type ServerAuthorizationAction =
+  | 'server.discover'
+  | 'server.invoke'
+  | 'server.config.read'
+  | 'server.manage';
+
+// Minimal structural shape needed to authorize a server. Compatible with
+// ServerConfig, ServerInfo and DAO server records.
+export interface AuthorizableServer {
+  owner?: string;
+  visibility?: ServerVisibility;
+  sharedWithUsers?: string[];
+}
+
+export type RequestPrincipal = Pick<IUser, 'username'> & { isAdmin?: boolean } | null;
+
+// Records may predate owner tracking; those are administered by the 'admin'
+// account (same normalization as the share-candidates endpoint).
+const effectiveOwner = (server: AuthorizableServer): string => server.owner?.trim() || 'admin';
+
+const resolvePrincipal = (principal?: RequestPrincipal): RequestPrincipal =>
+  principal ?? UserContextService.getInstance().getCurrentUser();
+
+export class AuthorizationService {
+  can(
+    action: ServerAuthorizationAction,
+    server: AuthorizableServer,
+    principal?: RequestPrincipal,
+  ): boolean {
+    const user = resolvePrincipal(principal);
+    if (!user?.username) {
+      return false;
+    }
+
+    switch (action) {
+      case 'server.config.read':
+      case 'server.manage':
+        return Boolean(user.isAdmin) || user.username === effectiveOwner(server);
+      case 'server.discover':
+      case 'server.invoke':
+        return new DataService().filterData([server], user as IUser).length > 0;
+    }
+  }
+}
+
+export const authorizationService = new AuthorizationService();

--- a/src/services/authorizationService.ts
+++ b/src/services/authorizationService.ts
@@ -21,20 +21,26 @@ export interface AuthorizableServer {
   sharedWithUsers?: string[];
 }
 
-export type RequestPrincipal = Pick<IUser, 'username'> & { isAdmin?: boolean } | null;
+export type RequestPrincipal = Pick<IUser, 'username'> & { isAdmin?: boolean };
 
 // Records may predate owner tracking; those are administered by the 'admin'
 // account (same normalization as the share-candidates endpoint).
 const effectiveOwner = (server: AuthorizableServer): string => server.owner?.trim() || 'admin';
 
-const resolvePrincipal = (principal?: RequestPrincipal): RequestPrincipal =>
-  principal ?? UserContextService.getInstance().getCurrentUser();
+// Principal resolution semantics:
+//   undefined -> fall back to the ambient UserContext
+//   null      -> anonymous (explicitly unauthenticated, never falls back)
+//   user      -> that exact principal
+const resolvePrincipal = (
+  principal?: RequestPrincipal | null,
+): RequestPrincipal | null | undefined =>
+  principal === undefined ? UserContextService.getInstance().getCurrentUser() : principal;
 
 export class AuthorizationService {
   can(
     action: ServerAuthorizationAction,
     server: AuthorizableServer,
-    principal?: RequestPrincipal,
+    principal?: RequestPrincipal | null,
   ): boolean {
     const user = resolvePrincipal(principal);
     if (!user?.username) {

--- a/src/services/serverConfigPresenter.ts
+++ b/src/services/serverConfigPresenter.ts
@@ -75,9 +75,25 @@ export const presentServerForPrincipal = <T extends object>(
   return { view: 'safe', data: presentSafeServerConfig(config as ServerConfigLike) as T };
 };
 
+// Generic placeholder for runtime connection errors shown to principals who
+// may not read the full configuration. Upstream/transport error text can
+// contain connection URLs, tokens, or internal paths, and heuristic redaction
+// cannot guarantee arbitrary secrets are removed — so the raw value is
+// withheld entirely (fail closed). `status` stays untouched so shared users
+// can still tell connected/connecting/disconnected/oauth_required apart.
+export const SAFE_RUNTIME_ERROR_MESSAGE = 'Server connection failed';
+
+const presentSafeRuntimeError = (error: unknown): unknown => {
+  if (error === null || error === undefined) {
+    return error;
+  }
+  return SAFE_RUNTIME_ERROR_MESSAGE;
+};
+
 // Present a ServerInfo-shaped list entry: runtime metadata stays, but OAuth
-// session fields and the embedded connection config are reduced to their safe
-// subsets for principals who may not read the full configuration.
+// session fields, the embedded connection config, and raw runtime error text
+// are reduced to their safe subsets for principals who may not read the full
+// configuration.
 export const presentServerInfoForPrincipal = <T extends object>(
   info: T,
   principal?: RequestPrincipal | null,
@@ -94,6 +110,10 @@ export const presentServerInfoForPrincipal = <T extends object>(
 
   if (entry.config && typeof entry.config === 'object') {
     entry.config = presentSafeServerConfig(entry.config as ServerConfigLike);
+  }
+
+  if ('error' in entry) {
+    entry.error = presentSafeRuntimeError(entry.error);
   }
 
   return entry as T;

--- a/src/services/serverConfigPresenter.ts
+++ b/src/services/serverConfigPresenter.ts
@@ -1,8 +1,10 @@
 import { authorizationService, RequestPrincipal } from './authorizationService.js';
 
 // Safe server representation for issue #1036 Phase 1: shared users may see a
-// server's metadata but never its secret-bearing configuration. Redaction is
-// enforced here (server-side); the dashboard is never the security boundary.
+// server's metadata but never its connection configuration. The restricted
+// view is an explicit ALLOWLIST — newly added ServerConfig fields are withheld
+// by default until they are reviewed and added here. Redaction is enforced
+// server-side; the dashboard is never the security boundary.
 
 type ServerConfigLike = Record<string, unknown>;
 
@@ -11,10 +13,20 @@ export interface PresentedServer<T> {
   data: T;
 }
 
-// Connection/authentication fields whose raw values must never reach an
-// unauthorized reader. `args` is included because stdio arguments routinely
-// carry tokens on the command line.
-const SECRET_BEARING_FIELDS = ['env', 'headers', 'args', 'oauth', 'proxy'] as const;
+// Metadata a shared user legitimately needs. Everything else — including
+// url, command, args, env, headers, oauth, proxy, openapi, options and any
+// unrecognized future field — is withheld.
+const SAFE_SERVER_CONFIG_FIELDS = [
+  'name',
+  'description',
+  'type',
+  'visibility',
+  'owner',
+  'enabled',
+  'tools',
+  'prompts',
+  'resources',
+] as const;
 
 // OAuth session-recovery fields exposed on ServerInfo list entries; only the
 // connected/clientIdConfigured indicators are safe for non-config-readers.
@@ -25,36 +37,16 @@ const clone = <T>(value: T): T =>
     ? structuredClone(value)
     : (JSON.parse(JSON.stringify(value)) as T);
 
-const stripOpenApiSecrets = (openapi: Record<string, unknown>): Record<string, unknown> => {
-  const { security: _security, ...rest } = openapi;
-  return rest;
-};
-
 const presentSafeServerConfig = (config: ServerConfigLike): ServerConfigLike => {
-  const safe = clone(config);
-  let hadSecrets = false;
-
-  for (const field of SECRET_BEARING_FIELDS) {
-    if (safe[field] !== undefined && safe[field] !== null) {
-      hadSecrets = true;
+  const safe: Record<string, unknown> = {};
+  for (const field of SAFE_SERVER_CONFIG_FIELDS) {
+    if (config[field] !== undefined && config[field] !== null) {
+      safe[field] = clone(config[field]);
     }
-    delete safe[field];
   }
-
-  if (safe.openapi && typeof safe.openapi === 'object') {
-    const openapi = safe.openapi as Record<string, unknown>;
-    if ('security' in openapi) {
-      hadSecrets = true;
-    }
-    safe.openapi = stripOpenApiSecrets(openapi);
-  }
-
   // Explicit marker so callers (and the dashboard) can tell a restricted view
   // apart from "this server genuinely has no credentials".
-  if (hadSecrets || !('configRestricted' in safe)) {
-    return { ...safe, configRestricted: true };
-  }
-  return safe;
+  return { ...safe, configRestricted: true };
 };
 
 const presentSafeServerInfoOauth = (
@@ -75,7 +67,7 @@ const presentSafeServerInfoOauth = (
 // the server at all (403 handling stays with them).
 export const presentServerForPrincipal = <T extends object>(
   config: T,
-  principal?: RequestPrincipal,
+  principal?: RequestPrincipal | null,
 ): PresentedServer<T> => {
   if (authorizationService.can('server.config.read', config as ServerConfigLike, principal)) {
     return { view: 'full', data: clone(config) };
@@ -83,23 +75,26 @@ export const presentServerForPrincipal = <T extends object>(
   return { view: 'safe', data: presentSafeServerConfig(config as ServerConfigLike) as T };
 };
 
-// Present a ServerInfo-shaped list entry: metadata stays, but OAuth session
-// fields are withheld from principals who may not read the full config.
+// Present a ServerInfo-shaped list entry: runtime metadata stays, but OAuth
+// session fields and the embedded connection config are reduced to their safe
+// subsets for principals who may not read the full configuration.
 export const presentServerInfoForPrincipal = <T extends object>(
   info: T,
-  principal?: RequestPrincipal,
+  principal?: RequestPrincipal | null,
 ): T => {
   if (authorizationService.can('server.config.read', info as ServerConfigLike, principal)) {
     return info;
   }
 
-  const oauth = (info as ServerConfigLike).oauth;
-  if (!oauth || typeof oauth !== 'object') {
-    return info;
+  const entry = { ...(info as ServerConfigLike) };
+
+  if (entry.oauth && typeof entry.oauth === 'object') {
+    entry.oauth = presentSafeServerInfoOauth(entry.oauth as Record<string, unknown>);
   }
 
-  return {
-    ...(info as ServerConfigLike),
-    oauth: presentSafeServerInfoOauth(oauth as Record<string, unknown>),
-  } as T;
+  if (entry.config && typeof entry.config === 'object') {
+    entry.config = presentSafeServerConfig(entry.config as ServerConfigLike);
+  }
+
+  return entry as T;
 };

--- a/src/services/serverConfigPresenter.ts
+++ b/src/services/serverConfigPresenter.ts
@@ -1,0 +1,105 @@
+import { authorizationService, RequestPrincipal } from './authorizationService.js';
+
+// Safe server representation for issue #1036 Phase 1: shared users may see a
+// server's metadata but never its secret-bearing configuration. Redaction is
+// enforced here (server-side); the dashboard is never the security boundary.
+
+type ServerConfigLike = Record<string, unknown>;
+
+export interface PresentedServer<T> {
+  view: 'full' | 'safe';
+  data: T;
+}
+
+// Connection/authentication fields whose raw values must never reach an
+// unauthorized reader. `args` is included because stdio arguments routinely
+// carry tokens on the command line.
+const SECRET_BEARING_FIELDS = ['env', 'headers', 'args', 'oauth', 'proxy'] as const;
+
+// OAuth session-recovery fields exposed on ServerInfo list entries; only the
+// connected/clientIdConfigured indicators are safe for non-config-readers.
+const SAFE_SERVER_INFO_OAUTH_KEYS = ['connected', 'clientIdConfigured'] as const;
+
+const clone = <T>(value: T): T =>
+  typeof structuredClone === 'function'
+    ? structuredClone(value)
+    : (JSON.parse(JSON.stringify(value)) as T);
+
+const stripOpenApiSecrets = (openapi: Record<string, unknown>): Record<string, unknown> => {
+  const { security: _security, ...rest } = openapi;
+  return rest;
+};
+
+const presentSafeServerConfig = (config: ServerConfigLike): ServerConfigLike => {
+  const safe = clone(config);
+  let hadSecrets = false;
+
+  for (const field of SECRET_BEARING_FIELDS) {
+    if (safe[field] !== undefined && safe[field] !== null) {
+      hadSecrets = true;
+    }
+    delete safe[field];
+  }
+
+  if (safe.openapi && typeof safe.openapi === 'object') {
+    const openapi = safe.openapi as Record<string, unknown>;
+    if ('security' in openapi) {
+      hadSecrets = true;
+    }
+    safe.openapi = stripOpenApiSecrets(openapi);
+  }
+
+  // Explicit marker so callers (and the dashboard) can tell a restricted view
+  // apart from "this server genuinely has no credentials".
+  if (hadSecrets || !('configRestricted' in safe)) {
+    return { ...safe, configRestricted: true };
+  }
+  return safe;
+};
+
+const presentSafeServerInfoOauth = (
+  oauth: Record<string, unknown>,
+): Record<string, unknown> => {
+  const safeOauth: Record<string, unknown> = {};
+  for (const key of SAFE_SERVER_INFO_OAUTH_KEYS) {
+    if (oauth[key] !== undefined) {
+      safeOauth[key] = oauth[key];
+    }
+  }
+  return safeOauth;
+};
+
+// Present a raw ServerConfig/DAO record for a principal: full deep copy when
+// the principal may read configuration, otherwise the safe view. The input is
+// never mutated. Callers decide independently whether the principal may see
+// the server at all (403 handling stays with them).
+export const presentServerForPrincipal = <T extends object>(
+  config: T,
+  principal?: RequestPrincipal,
+): PresentedServer<T> => {
+  if (authorizationService.can('server.config.read', config as ServerConfigLike, principal)) {
+    return { view: 'full', data: clone(config) };
+  }
+  return { view: 'safe', data: presentSafeServerConfig(config as ServerConfigLike) as T };
+};
+
+// Present a ServerInfo-shaped list entry: metadata stays, but OAuth session
+// fields are withheld from principals who may not read the full config.
+export const presentServerInfoForPrincipal = <T extends object>(
+  info: T,
+  principal?: RequestPrincipal,
+): T => {
+  if (authorizationService.can('server.config.read', info as ServerConfigLike, principal)) {
+    return info;
+  }
+
+  const oauth = (info as ServerConfigLike).oauth;
+  if (!oauth || typeof oauth !== 'object') {
+    return info;
+  }
+
+  return {
+    ...(info as ServerConfigLike),
+    oauth: presentSafeServerInfoOauth(oauth as Record<string, unknown>),
+  } as T;
+};

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -2073,6 +2073,7 @@ describe('serverController - getAllServers OAuth session scrub (#1036)', () => {
         description: 'Org web search',
         command: 'npx',
       },
+      error: 'Failed to connect to https://mcp.example.com/mcp?token=mcphub-runtime-secret',
     };
     mockGetServersInfo
       .mockResolvedValueOnce([entry])
@@ -2091,22 +2092,26 @@ describe('serverController - getAllServers OAuth session scrub (#1036)', () => {
     expect(body).not.toContain('mcphub-phase1-oauth-state');
     expect(body).not.toContain('authorizationUrl');
     expect(body).not.toContain('"command"');
+    expect(body).not.toContain('mcphub-runtime-secret');
+    expect(body).toContain('Server connection failed');
     expect(body).toContain('clientIdConfigured');
     const data = json.mock.calls[0][0];
     expect(data.data[0].oauth.state).toBeUndefined();
     expect(data.allServers[0].oauth.state).toBeUndefined();
     expect(data.data[0].config.type).toBe('streamable-http');
     expect(data.data[0].config.command).toBeUndefined();
+    expect(data.data[0].error).toBe('Server connection failed');
   });
 
-  it('keeps OAuth session fields for admins', async () => {
+  it('keeps OAuth session fields and raw errors for admins', async () => {
     mockGetCurrentUser.mockReturnValue({ username: 'admin', isAdmin: true });
     const entry = {
       name: 'org-search',
       owner: 'bob',
-      status: 'connected',
+      status: 'disconnected',
       tools: [],
       oauth: { state: 'owner-state', connected: false },
+      error: 'Failed to connect to https://mcp.example.com/mcp?token=mcphub-runtime-secret',
     };
     mockGetServersInfo.mockResolvedValueOnce([entry]).mockResolvedValueOnce([entry]);
 
@@ -2120,5 +2125,8 @@ describe('serverController - getAllServers OAuth session scrub (#1036)', () => {
     await getAllServers(req, res);
 
     expect(json.mock.calls[0][0].data[0].oauth.state).toBe('owner-state');
+    expect(json.mock.calls[0][0].data[0].error).toBe(
+      'Failed to connect to https://mcp.example.com/mcp?token=mcphub-runtime-secret',
+    );
   });
 });

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -1863,6 +1863,9 @@ describe('serverController - getServerConfig shared use / private config (#1036)
     proxy: { server: 'proxy.example.com', password: 'mcphub-phase1-proxy-password' },
     enabled: true,
     tools: { search: { enabled: true } },
+    // Unrecognized ServerConfig field simulating a future addition — the
+    // allowlisted safe view must withhold it.
+    futureSetting: 'mcphub-phase1-unrecognized-secret',
   };
 
   const SENTINELS = [
@@ -1871,6 +1874,7 @@ describe('serverController - getServerConfig shared use / private config (#1036)
     'mcphub-phase1-client-secret',
     'mcphub-phase1-refresh-token',
     'mcphub-phase1-proxy-password',
+    'mcphub-phase1-unrecognized-secret',
   ];
 
   const runGetServerConfig = async (user: { username: string; isAdmin?: boolean } | null) => {
@@ -1911,15 +1915,18 @@ describe('serverController - getServerConfig shared use / private config (#1036)
     for (const sentinel of SENTINELS) {
       expect(body).not.toContain(sentinel);
     }
+    // Allowlisted metadata survives; raw connection config does not.
     expect(body).toContain('Org web search');
-    expect(body).toContain('https://mcp.example.com/mcp');
     const data = json.mock.calls[0][0].data;
     expect(data.config.env).toBeUndefined();
     expect(data.config.headers).toBeUndefined();
     expect(data.config.args).toBeUndefined();
     expect(data.config.oauth).toBeUndefined();
     expect(data.config.proxy).toBeUndefined();
-    expect(data.config.security).toBeUndefined();
+    expect(data.config.openapi).toBeUndefined();
+    expect(data.config.url).toBeUndefined();
+    expect(data.config.options).toBeUndefined();
+    expect(data.config.futureSetting).toBeUndefined();
     expect(data.config.configRestricted).toBe(true);
     expect(data.tools).toEqual([{ name: 'search', description: 'Search' }]);
   });
@@ -2061,6 +2068,11 @@ describe('serverController - getAllServers OAuth session scrub (#1036)', () => {
         clientIdConfigured: true,
         connected: false,
       },
+      config: {
+        type: 'streamable-http',
+        description: 'Org web search',
+        command: 'npx',
+      },
     };
     mockGetServersInfo
       .mockResolvedValueOnce([entry])
@@ -2078,10 +2090,13 @@ describe('serverController - getAllServers OAuth session scrub (#1036)', () => {
     const body = JSON.stringify(json.mock.calls[0][0]);
     expect(body).not.toContain('mcphub-phase1-oauth-state');
     expect(body).not.toContain('authorizationUrl');
+    expect(body).not.toContain('"command"');
     expect(body).toContain('clientIdConfigured');
     const data = json.mock.calls[0][0];
     expect(data.data[0].oauth.state).toBeUndefined();
     expect(data.allServers[0].oauth.state).toBeUndefined();
+    expect(data.data[0].config.type).toBe('streamable-http');
+    expect(data.data[0].config.command).toBeUndefined();
   });
 
   it('keeps OAuth session fields for admins', async () => {

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -1836,3 +1836,274 @@ describe('serverController - disconnectServerOAuth', () => {
     });
   });
 });
+
+// Issue #1036 Phase 1: shared users may read a safe configuration view of
+// public/group servers, but secret-bearing fields must never appear in any
+// serialized response. Owner/admin keep the full view; unrelated users and
+// every write path stay owner/admin-gated.
+describe('serverController - getServerConfig shared use / private config (#1036)', () => {
+  const secretServer = {
+    name: 'org-search',
+    type: 'streamable-http',
+    url: 'https://mcp.example.com/mcp',
+    description: 'Org web search',
+    owner: 'bob',
+    env: { UPSTREAM_API_KEY: 'mcphub-phase1-api-key' },
+    headers: { Authorization: 'Bearer mcphub-phase1-secret' },
+    args: ['--token', 'mcphub-phase1-secret'],
+    oauth: {
+      clientId: 'client-123',
+      clientSecret: 'mcphub-phase1-client-secret',
+      refreshToken: 'mcphub-phase1-refresh-token',
+    },
+    openapi: {
+      url: 'https://api.example.com/openapi.json',
+      security: { type: 'apiKey', apiKey: { name: 'X-Key', in: 'header', value: 'k' } },
+    },
+    proxy: { server: 'proxy.example.com', password: 'mcphub-phase1-proxy-password' },
+    enabled: true,
+    tools: { search: { enabled: true } },
+  };
+
+  const SENTINELS = [
+    'Bearer mcphub-phase1-secret',
+    'mcphub-phase1-api-key',
+    'mcphub-phase1-client-secret',
+    'mcphub-phase1-refresh-token',
+    'mcphub-phase1-proxy-password',
+  ];
+
+  const runGetServerConfig = async (user: { username: string; isAdmin?: boolean } | null) => {
+    mockGetServersInfo.mockResolvedValue([
+      {
+        name: 'org-search',
+        status: 'connected',
+        tools: [{ name: 'search', description: 'Search' }],
+      },
+    ]);
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'org-search' },
+      ...(user ? { user } : {}),
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+    await getServerConfig(req, res);
+    return { json, status };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockReturnValue(undefined);
+  });
+
+  it('gives a shared user a safe view of a public server with no sentinel secrets', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      ...secretServer,
+      visibility: 'public',
+    });
+
+    const { json, status } = await runGetServerConfig({ username: 'alice', isAdmin: false });
+
+    expect(status).not.toHaveBeenCalledWith(403);
+    expect(json).toHaveBeenCalledTimes(1);
+    const body = JSON.stringify(json.mock.calls[0][0]);
+    for (const sentinel of SENTINELS) {
+      expect(body).not.toContain(sentinel);
+    }
+    expect(body).toContain('Org web search');
+    expect(body).toContain('https://mcp.example.com/mcp');
+    const data = json.mock.calls[0][0].data;
+    expect(data.config.env).toBeUndefined();
+    expect(data.config.headers).toBeUndefined();
+    expect(data.config.args).toBeUndefined();
+    expect(data.config.oauth).toBeUndefined();
+    expect(data.config.proxy).toBeUndefined();
+    expect(data.config.security).toBeUndefined();
+    expect(data.config.configRestricted).toBe(true);
+    expect(data.tools).toEqual([{ name: 'search', description: 'Search' }]);
+  });
+
+  it('gives an explicitly shared group member the same safe view', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      ...secretServer,
+      visibility: 'group',
+      sharedWithUsers: ['alice'],
+    });
+
+    const { json, status } = await runGetServerConfig({ username: 'alice', isAdmin: false });
+
+    expect(status).not.toHaveBeenCalledWith(403);
+    const body = JSON.stringify(json.mock.calls[0][0]);
+    for (const sentinel of SENTINELS) {
+      expect(body).not.toContain(sentinel);
+    }
+  });
+
+  it('still rejects a group server from a user who is not in the allowlist', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      ...secretServer,
+      visibility: 'group',
+      sharedWithUsers: ['charlie'],
+    });
+
+    const { status } = await runGetServerConfig({ username: 'alice', isAdmin: false });
+
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it('keeps the full configuration available to the owner', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      ...secretServer,
+      visibility: 'public',
+    });
+
+    const { json } = await runGetServerConfig({ username: 'bob', isAdmin: false });
+
+    const data = json.mock.calls[0][0].data;
+    expect(data.config).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer mcphub-phase1-secret' },
+        env: { UPSTREAM_API_KEY: 'mcphub-phase1-api-key' },
+        oauth: expect.objectContaining({ clientSecret: 'mcphub-phase1-client-secret' }),
+      }),
+    );
+  });
+
+  it('keeps the full configuration available to admins', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      ...secretServer,
+      visibility: 'public',
+    });
+
+    const { json } = await runGetServerConfig({ username: 'admin', isAdmin: true });
+
+    expect(json.mock.calls[0][0].data.config.oauth).toBeDefined();
+  });
+});
+
+describe('serverController - updateServer write-path stays owner/admin-only (#1036)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a shared user from writing a public server so secrets cannot be overwritten', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      name: 'org-search',
+      type: 'streamable-http',
+      url: 'https://mcp.example.com/mcp',
+      owner: 'bob',
+      visibility: 'public',
+      headers: { Authorization: 'Bearer mcphub-phase1-secret' },
+    });
+
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    const req = {
+      params: { name: 'org-search' },
+      body: {
+        config: {
+          type: 'streamable-http',
+          url: 'https://mcp.example.com/mcp',
+          headers: { Authorization: 'Bearer tampered' },
+          visibility: 'public',
+        },
+      },
+      user: { username: 'alice', isAdmin: false },
+    } as unknown as Request;
+    const res = { json, status } as unknown as Response;
+
+    await updateServer(req, res);
+
+    expect(status).toHaveBeenCalledWith(403);
+    expect(mockServerDao.update).not.toHaveBeenCalled();
+    expect(mockAddOrUpdateServer).not.toHaveBeenCalled();
+  });
+});
+
+describe('serverController - getAllServers OAuth session scrub (#1036)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockServerDao.findAllPaginated.mockResolvedValue({
+      data: [],
+      page: 1,
+      limit: 5,
+      total: 1,
+      totalPages: 1,
+    });
+    mockServerDao.findVisibleToUserPaginated.mockResolvedValue({
+      data: [],
+      page: 1,
+      limit: 5,
+      total: 1,
+      totalPages: 1,
+    });
+    mockServerDao.findByOwnerPaginated.mockResolvedValue({
+      data: [],
+      page: 1,
+      limit: 5,
+      total: 1,
+      totalPages: 1,
+    });
+  });
+
+  it('strips OAuth authorizationUrl/state from list entries for non-owner users in both collections', async () => {
+    mockGetCurrentUser.mockReturnValue({ username: 'alice', isAdmin: false });
+    const entry = {
+      name: 'org-search',
+      owner: 'bob',
+      visibility: 'public',
+      status: 'connected',
+      tools: [],
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize?state=mcphub-phase1-oauth-state',
+        state: 'mcphub-phase1-oauth-state',
+        clientIdConfigured: true,
+        connected: false,
+      },
+    };
+    mockGetServersInfo
+      .mockResolvedValueOnce([entry])
+      .mockResolvedValueOnce([{ ...entry, oauth: { ...entry.oauth } }]);
+
+    const json = jest.fn();
+    const req = {
+      query: { page: '1', limit: '5' },
+      user: { username: 'alice', isAdmin: false },
+    } as unknown as Request;
+    const res = { json } as unknown as Response;
+
+    await getAllServers(req, res);
+
+    const body = JSON.stringify(json.mock.calls[0][0]);
+    expect(body).not.toContain('mcphub-phase1-oauth-state');
+    expect(body).not.toContain('authorizationUrl');
+    expect(body).toContain('clientIdConfigured');
+    const data = json.mock.calls[0][0];
+    expect(data.data[0].oauth.state).toBeUndefined();
+    expect(data.allServers[0].oauth.state).toBeUndefined();
+  });
+
+  it('keeps OAuth session fields for admins', async () => {
+    mockGetCurrentUser.mockReturnValue({ username: 'admin', isAdmin: true });
+    const entry = {
+      name: 'org-search',
+      owner: 'bob',
+      status: 'connected',
+      tools: [],
+      oauth: { state: 'owner-state', connected: false },
+    };
+    mockGetServersInfo.mockResolvedValueOnce([entry]).mockResolvedValueOnce([entry]);
+
+    const json = jest.fn();
+    const req = {
+      query: { page: '1', limit: '5' },
+      user: { username: 'admin', isAdmin: true },
+    } as unknown as Request;
+    const res = { json } as unknown as Response;
+
+    await getAllServers(req, res);
+
+    expect(json.mock.calls[0][0].data[0].oauth.state).toBe('owner-state');
+  });
+});

--- a/tests/services/authorizationService.test.ts
+++ b/tests/services/authorizationService.test.ts
@@ -1,0 +1,118 @@
+import { AuthorizationService } from '../../src/services/authorizationService.js';
+import { UserContextService } from '../../src/services/userContextService.js';
+
+jest.mock('../../src/services/userContextService.js', () => ({
+  UserContextService: {
+    getInstance: jest.fn(() => ({
+      getCurrentUser: mockGetCurrentUser,
+    })),
+  },
+}));
+
+const mockGetCurrentUser = jest.fn();
+
+const admin = { username: 'admin', isAdmin: true };
+const bob = { username: 'bob', isAdmin: false };
+const alice = { username: 'alice', isAdmin: false };
+
+describe('AuthorizationService (#1036 Phase 1)', () => {
+  let service: AuthorizationService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockReturnValue(null);
+    service = new AuthorizationService();
+  });
+
+  describe('server.config.read', () => {
+    const server = { owner: 'bob', visibility: 'public' as const };
+
+    it('allows admins', () => {
+      expect(service.can('server.config.read', server, admin)).toBe(true);
+    });
+
+    it('allows the owner', () => {
+      expect(service.can('server.config.read', server, bob)).toBe(true);
+    });
+
+    it('denies a shared regular user even on a public server', () => {
+      expect(service.can('server.config.read', server, alice)).toBe(false);
+    });
+
+    it('denies an unrelated user', () => {
+      expect(service.can('server.config.read', server, alice)).toBe(false);
+    });
+
+    it('denies anonymous callers', () => {
+      expect(service.can('server.config.read', server, null)).toBe(false);
+    });
+  });
+
+  describe('server.manage', () => {
+    it('mirrors config.read semantics (owner allow, shared user deny)', () => {
+      const server = { owner: 'bob', visibility: 'group' as const, sharedWithUsers: ['alice'] };
+      expect(service.can('server.manage', server, bob)).toBe(true);
+      expect(service.can('server.manage', server, alice)).toBe(false);
+      expect(service.can('server.manage', server, admin)).toBe(true);
+    });
+
+    it('normalizes a missing/blank owner to the admin account', () => {
+      const orphan = { owner: '  ', visibility: 'private' as const };
+      expect(service.can('server.manage', orphan, admin)).toBe(true);
+      expect(service.can('server.manage', orphan, bob)).toBe(false);
+      const legacy = { visibility: 'private' as const };
+      expect(service.can('server.manage', legacy, admin)).toBe(true);
+    });
+  });
+
+  describe('server.discover / server.invoke', () => {
+    it('follows filterData visibility semantics for public servers', () => {
+      const server = { owner: 'bob', visibility: 'public' as const };
+      expect(service.can('server.discover', server, alice)).toBe(true);
+      expect(service.can('server.invoke', server, alice)).toBe(true);
+    });
+
+    it('admits explicitly shared group members and rejects unshared ones', () => {
+      const server = {
+        owner: 'bob',
+        visibility: 'group' as const,
+        sharedWithUsers: ['alice'],
+      };
+      expect(service.can('server.invoke', server, alice)).toBe(true);
+
+      const unshared = { ...server, sharedWithUsers: ['charlie'] };
+      expect(service.can('server.invoke', unshared, alice)).toBe(false);
+    });
+
+    it('treats rows without visibility as private (fail closed)', () => {
+      const legacy = { owner: 'bob' };
+      expect(service.can('server.invoke', legacy, alice)).toBe(false);
+      expect(service.can('server.invoke', legacy, bob)).toBe(true);
+    });
+
+    it('denies anonymous callers even for public servers', () => {
+      const server = { owner: 'bob', visibility: 'public' as const };
+      expect(service.can('server.invoke', server, null)).toBe(false);
+    });
+  });
+
+  describe('principal resolution', () => {
+    it('falls back to the ambient user context when no principal is passed', () => {
+      mockGetCurrentUser.mockReturnValue(bob);
+      expect(
+        service.can('server.config.read', { owner: undefined, visibility: 'private' }),
+      ).toBe(false);
+      mockGetCurrentUser.mockReturnValue(admin);
+      expect(
+        service.can('server.config.read', { owner: undefined, visibility: 'private' }),
+      ).toBe(true);
+    });
+
+    it('prefers an explicit principal over the ambient context', () => {
+      mockGetCurrentUser.mockReturnValue(admin);
+      expect(
+        service.can('server.config.read', { owner: 'bob', visibility: 'public' }, alice),
+      ).toBe(false);
+    });
+  });
+});

--- a/tests/services/authorizationService.test.ts
+++ b/tests/services/authorizationService.test.ts
@@ -94,6 +94,16 @@ describe('AuthorizationService (#1036 Phase 1)', () => {
       const server = { owner: 'bob', visibility: 'public' as const };
       expect(service.can('server.invoke', server, null)).toBe(false);
     });
+
+    it('an explicitly null principal stays anonymous even when the ambient context is admin', () => {
+      // Regression: `??` used to coalesce explicit null into the ambient
+      // UserContext, so an unauthenticated request could inherit an ambient
+      // admin identity. null must mean anonymous, never fallback.
+      mockGetCurrentUser.mockReturnValue(admin);
+      const server = { owner: 'bob', visibility: 'public' as const };
+      expect(service.can('server.config.read', server, null)).toBe(false);
+      expect(service.can('server.invoke', server, null)).toBe(false);
+    });
   });
 
   describe('principal resolution', () => {

--- a/tests/services/serverConfigPresenter.test.ts
+++ b/tests/services/serverConfigPresenter.test.ts
@@ -220,5 +220,63 @@ describe('serverConfigPresenter (#1036 Phase 1)', () => {
       expect(body).not.toContain('oauth-state-value');
       expect(body).not.toContain('"command"');
     });
+
+    describe.each([
+      {
+        label: 'credential-bearing URL',
+        rawError: 'Failed to connect to https://mcp.example.com/mcp?token=mcphub-runtime-secret',
+      },
+      {
+        label: 'bearer token header',
+        rawError: 'Authorization: Bearer mcphub-runtime-bearer rejected by upstream',
+      },
+      {
+        label: 'arbitrary secret no sanitizer would necessarily match',
+        rawError: 'connection failed for mcphub-arbitrary-runtime-secret',
+      },
+    ])('runtime error redaction ($label)', ({ rawError }) => {
+      const errored = { ...info, status: 'disconnected', error: rawError };
+
+      it('replaces the raw error with a generic message for restricted users', () => {
+        const presented = presentServerInfoForPrincipal(errored, alice) as Record<
+          string,
+          unknown
+        >;
+        // The raw upstream text must not survive heuristic redaction — only
+        // the generic placeholder may appear.
+        expect(presented.error).toBe('Server connection failed');
+        // Runtime metadata stays so shared users can see connection state.
+        expect(presented.status).toBe('disconnected');
+      });
+
+      it('never leaks the raw error in serialized output', () => {
+        const body = JSON.stringify(presentServerInfoForPrincipal(errored, alice));
+        for (const sentinel of [
+          'mcphub-runtime-secret',
+          'mcphub-runtime-bearer',
+          'mcphub-arbitrary-runtime-secret',
+          rawError,
+        ]) {
+          expect(body).not.toContain(sentinel);
+        }
+        expect(body).toContain('Server connection failed');
+      });
+
+      it('keeps the original error for owner and admin', () => {
+        for (const principal of [bob, admin]) {
+          const presented = presentServerInfoForPrincipal(errored, principal) as Record<
+            string,
+            unknown
+          >;
+          expect(presented.error).toBe(rawError);
+        }
+      });
+
+      it('preserves a null error state as null', () => {
+        const clean = { ...info, error: null };
+        const presented = presentServerInfoForPrincipal(clean, alice) as Record<string, unknown>;
+        expect(presented.error).toBeNull();
+      });
+    });
   });
 });

--- a/tests/services/serverConfigPresenter.test.ts
+++ b/tests/services/serverConfigPresenter.test.ts
@@ -16,12 +16,15 @@ const mockGetCurrentUser = jest.fn();
 
 // Sentinel secrets from the Phase 1 plan. Every safe-view assertion below
 // checks the SERIALIZED output so a nested leak cannot slip through.
+// `futureSetting` simulates an unrecognized ServerConfig field added in a
+// future release — the allowlist must withhold it too.
 const SENTINELS = [
   'Bearer mcphub-phase1-secret',
   'mcphub-phase1-api-key',
   'mcphub-phase1-client-secret',
   'mcphub-phase1-refresh-token',
   'mcphub-phase1-proxy-password',
+  'mcphub-phase1-future-secret',
 ];
 
 const admin = { username: 'admin', isAdmin: true };
@@ -40,7 +43,7 @@ const buildRawServerConfig = (): Record<string, unknown> => ({
   passthroughHeaders: ['X-Request-Id'],
   owner: 'bob',
   visibility: 'public',
-  sharedWithUsers: undefined,
+  sharedWithUsers: ['alice'],
   enabled: true,
   options: { timeout: 30000 },
   oauth: {
@@ -65,6 +68,9 @@ const buildRawServerConfig = (): Record<string, unknown> => ({
   enableKeepAlive: true,
   keepAliveInterval: 60000,
   tools: { search: { enabled: true } },
+  // Unrecognized field a future MCPHub version might add. The restricted view
+  // is allowlist-based, so this must never leak to shared users.
+  futureSetting: 'mcphub-phase1-future-secret',
 });
 
 describe('serverConfigPresenter (#1036 Phase 1)', () => {
@@ -88,42 +94,51 @@ describe('serverConfigPresenter (#1036 Phase 1)', () => {
       expect((raw as Record<string, unknown>).description).toBe('Org web search');
     });
 
-    it('gives shared users a safe view with no secret-bearing fields', () => {
+    it('gives shared users an allowlisted view with no connection configuration', () => {
       const raw = buildRawServerConfig();
 
       const presented = presentServerForPrincipal(raw, alice);
 
       expect(presented.view).toBe('safe');
       const data = presented.data as Record<string, unknown>;
-      expect(data.env).toBeUndefined();
-      expect(data.headers).toBeUndefined();
-      expect(data.args).toBeUndefined();
-      expect(data.oauth).toBeUndefined();
-      expect(data.proxy).toBeUndefined();
-      expect(data.openapi).toEqual({
-        url: 'https://api.example.com/openapi.json',
-        version: '3.1.0',
+      expect(data).toEqual({
+        name: 'org-search',
+        description: 'Org web search',
+        type: 'streamable-http',
+        visibility: 'public',
+        owner: 'bob',
+        enabled: true,
+        tools: { search: { enabled: true } },
+        configRestricted: true,
       });
-      expect(data.configRestricted).toBe(true);
     });
 
-    it('keeps harmless metadata in the safe view', () => {
-      const presented = presentServerForPrincipal(buildRawServerConfig(), alice);
-      const data = presented.data as Record<string, unknown>;
-
-      expect(data.name).toBe('org-search');
-      expect(data.type).toBe('streamable-http');
-      expect(data.url).toBe('https://mcp.example.com/mcp');
-      expect(data.description).toBe('Org web search');
-      expect(data.visibility).toBe('public');
-      expect(data.owner).toBe('bob');
-      expect(data.enabled).toBe(true);
-      expect(data.passthroughHeaders).toEqual(['X-Request-Id']);
-      expect(data.options).toEqual({ timeout: 30000 });
-      expect(data.tools).toEqual({ search: { enabled: true } });
+    it('withholds url, command and every other raw config field from shared users', () => {
+      const body = JSON.stringify(presentServerForPrincipal(buildRawServerConfig(), alice));
+      for (const withheld of [
+        'https://mcp.example.com/mcp',
+        '"command"',
+        '"args"',
+        '"env"',
+        '"headers"',
+        '"oauth"',
+        '"proxy"',
+        '"openapi"',
+        '"options"',
+        '"passthroughHeaders"',
+        '"sharedWithUsers"',
+        '"perSessionClient"',
+        '"startOnDemand"',
+        '"idleTimeoutMs"',
+        '"enableKeepAlive"',
+        '"keepAliveInterval"',
+        '"futureSetting"',
+      ]) {
+        expect(body).not.toContain(withheld);
+      }
     });
 
-    it('serializes the safe view without any sentinel secret', () => {
+    it('serializes the safe view without any sentinel secret, including unknown fields', () => {
       const body = JSON.stringify(presentServerForPrincipal(buildRawServerConfig(), alice));
       for (const sentinel of SENTINELS) {
         expect(body).not.toContain(sentinel);
@@ -133,25 +148,26 @@ describe('serverConfigPresenter (#1036 Phase 1)', () => {
       expect(body).not.toContain('pkce-secret');
     });
 
-    it('fails closed for anonymous principals', () => {
-      const presented = presentServerForPrincipal(buildRawServerConfig(), null);
-      expect(presented.view).toBe('safe');
-      expect(
-        (presented.data as Record<string, unknown>).headers,
-      ).toBeUndefined();
-    });
+    it('an explicitly null principal stays anonymous even when the ambient context is admin', () => {
+      mockGetCurrentUser.mockReturnValue(admin);
 
-    it('marks servers without any credentials as restricted too, for uniform handling', () => {
-      const plain = { name: 'plain', type: 'sse', url: 'https://x.example.com/sse' };
-      const presented = presentServerForPrincipal(plain, alice);
+      const presented = presentServerForPrincipal(buildRawServerConfig(), null);
+
       expect(presented.view).toBe('safe');
-      expect((presented.data as Record<string, unknown>).configRestricted).toBe(true);
+      const body = JSON.stringify(presented.data);
+      for (const sentinel of SENTINELS) {
+        expect(body).not.toContain(sentinel);
+      }
     });
 
     it('falls back to the ambient user context when no principal is passed', () => {
       mockGetCurrentUser.mockReturnValue(admin);
       const presented = presentServerForPrincipal({ owner: 'bob', visibility: 'private' });
       expect(presented.view).toBe('full');
+
+      mockGetCurrentUser.mockReturnValue(alice);
+      const restricted = presentServerForPrincipal({ owner: 'bob', visibility: 'private' });
+      expect(restricted.view).toBe('safe');
     });
   });
 
@@ -161,11 +177,17 @@ describe('serverConfigPresenter (#1036 Phase 1)', () => {
       owner: 'bob',
       status: 'connected',
       tools: [{ name: 'search' }],
+      createTime: 1234567890,
       oauth: {
         authorizationUrl: 'https://auth.example.com/authorize?state=oauth-state-value',
         state: 'oauth-state-value',
         clientIdConfigured: true,
         connected: false,
+      },
+      config: {
+        type: 'streamable-http',
+        description: 'Org web search',
+        command: 'npx',
       },
     };
 
@@ -184,9 +206,19 @@ describe('serverConfigPresenter (#1036 Phase 1)', () => {
       expect(presented.status).toBe('connected');
     });
 
-    it('never leaks the OAuth state value in serialized output', () => {
+    it('reduces the embedded connection config to the safe allowlist', () => {
+      const presented = presentServerInfoForPrincipal(info, alice) as Record<string, unknown>;
+      const config = presented.config as Record<string, unknown>;
+      expect(config.type).toBe('streamable-http');
+      expect(config.description).toBe('Org web search');
+      expect(config.command).toBeUndefined();
+      expect(config.configRestricted).toBe(true);
+    });
+
+    it('never leaks the OAuth state or command values in serialized output', () => {
       const body = JSON.stringify([presentServerInfoForPrincipal(info, alice)]);
       expect(body).not.toContain('oauth-state-value');
+      expect(body).not.toContain('"command"');
     });
   });
 });

--- a/tests/services/serverConfigPresenter.test.ts
+++ b/tests/services/serverConfigPresenter.test.ts
@@ -1,0 +1,192 @@
+import {
+  presentServerForPrincipal,
+  presentServerInfoForPrincipal,
+} from '../../src/services/serverConfigPresenter.js';
+import { UserContextService } from '../../src/services/userContextService.js';
+
+jest.mock('../../src/services/userContextService.js', () => ({
+  UserContextService: {
+    getInstance: jest.fn(() => ({
+      getCurrentUser: mockGetCurrentUser,
+    })),
+  },
+}));
+
+const mockGetCurrentUser = jest.fn();
+
+// Sentinel secrets from the Phase 1 plan. Every safe-view assertion below
+// checks the SERIALIZED output so a nested leak cannot slip through.
+const SENTINELS = [
+  'Bearer mcphub-phase1-secret',
+  'mcphub-phase1-api-key',
+  'mcphub-phase1-client-secret',
+  'mcphub-phase1-refresh-token',
+  'mcphub-phase1-proxy-password',
+];
+
+const admin = { username: 'admin', isAdmin: true };
+const bob = { username: 'bob', isAdmin: false };
+const alice = { username: 'alice', isAdmin: false };
+
+const buildRawServerConfig = (): Record<string, unknown> => ({
+  name: 'org-search',
+  type: 'streamable-http',
+  url: 'https://mcp.example.com/mcp',
+  command: undefined,
+  args: ['--token', 'mcphub-phase1-secret'],
+  description: 'Org web search',
+  env: { UPSTREAM_API_KEY: 'mcphub-phase1-api-key' },
+  headers: { Authorization: 'Bearer mcphub-phase1-secret' },
+  passthroughHeaders: ['X-Request-Id'],
+  owner: 'bob',
+  visibility: 'public',
+  sharedWithUsers: undefined,
+  enabled: true,
+  options: { timeout: 30000 },
+  oauth: {
+    clientId: 'client-123',
+    clientSecret: 'mcphub-phase1-client-secret',
+    accessToken: 'at-secret',
+    refreshToken: 'mcphub-phase1-refresh-token',
+    pendingAuthorization: { state: 'oauth-state-value', codeVerifier: 'pkce-secret' },
+  },
+  proxy: { server: 'proxy.example.com', password: 'mcphub-phase1-proxy-password' },
+  openapi: {
+    url: 'https://api.example.com/openapi.json',
+    version: '3.1.0',
+    security: {
+      type: 'apiKey',
+      apiKey: { name: 'X-Key', in: 'header', value: 'mcphub-phase1-api-key' },
+    },
+  },
+  perSessionClient: false,
+  startOnDemand: false,
+  idleTimeoutMs: 300000,
+  enableKeepAlive: true,
+  keepAliveInterval: 60000,
+  tools: { search: { enabled: true } },
+});
+
+describe('serverConfigPresenter (#1036 Phase 1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentUser.mockReturnValue(null);
+  });
+
+  describe('presentServerForPrincipal', () => {
+    it('returns a full deep copy to admins and owners without mutating the input', () => {
+      const raw = buildRawServerConfig();
+      const snapshot = JSON.stringify(raw);
+
+      const presented = presentServerForPrincipal(raw, bob);
+
+      expect(presented.view).toBe('full');
+      expect(presented.data).toEqual(raw);
+      expect(JSON.stringify(raw)).toBe(snapshot);
+      // Deep copy: mutating the presented data must not touch the source
+      (presented.data as Record<string, unknown>).description = 'tampered';
+      expect((raw as Record<string, unknown>).description).toBe('Org web search');
+    });
+
+    it('gives shared users a safe view with no secret-bearing fields', () => {
+      const raw = buildRawServerConfig();
+
+      const presented = presentServerForPrincipal(raw, alice);
+
+      expect(presented.view).toBe('safe');
+      const data = presented.data as Record<string, unknown>;
+      expect(data.env).toBeUndefined();
+      expect(data.headers).toBeUndefined();
+      expect(data.args).toBeUndefined();
+      expect(data.oauth).toBeUndefined();
+      expect(data.proxy).toBeUndefined();
+      expect(data.openapi).toEqual({
+        url: 'https://api.example.com/openapi.json',
+        version: '3.1.0',
+      });
+      expect(data.configRestricted).toBe(true);
+    });
+
+    it('keeps harmless metadata in the safe view', () => {
+      const presented = presentServerForPrincipal(buildRawServerConfig(), alice);
+      const data = presented.data as Record<string, unknown>;
+
+      expect(data.name).toBe('org-search');
+      expect(data.type).toBe('streamable-http');
+      expect(data.url).toBe('https://mcp.example.com/mcp');
+      expect(data.description).toBe('Org web search');
+      expect(data.visibility).toBe('public');
+      expect(data.owner).toBe('bob');
+      expect(data.enabled).toBe(true);
+      expect(data.passthroughHeaders).toEqual(['X-Request-Id']);
+      expect(data.options).toEqual({ timeout: 30000 });
+      expect(data.tools).toEqual({ search: { enabled: true } });
+    });
+
+    it('serializes the safe view without any sentinel secret', () => {
+      const body = JSON.stringify(presentServerForPrincipal(buildRawServerConfig(), alice));
+      for (const sentinel of SENTINELS) {
+        expect(body).not.toContain(sentinel);
+      }
+      expect(body).not.toContain('at-secret');
+      expect(body).not.toContain('oauth-state-value');
+      expect(body).not.toContain('pkce-secret');
+    });
+
+    it('fails closed for anonymous principals', () => {
+      const presented = presentServerForPrincipal(buildRawServerConfig(), null);
+      expect(presented.view).toBe('safe');
+      expect(
+        (presented.data as Record<string, unknown>).headers,
+      ).toBeUndefined();
+    });
+
+    it('marks servers without any credentials as restricted too, for uniform handling', () => {
+      const plain = { name: 'plain', type: 'sse', url: 'https://x.example.com/sse' };
+      const presented = presentServerForPrincipal(plain, alice);
+      expect(presented.view).toBe('safe');
+      expect((presented.data as Record<string, unknown>).configRestricted).toBe(true);
+    });
+
+    it('falls back to the ambient user context when no principal is passed', () => {
+      mockGetCurrentUser.mockReturnValue(admin);
+      const presented = presentServerForPrincipal({ owner: 'bob', visibility: 'private' });
+      expect(presented.view).toBe('full');
+    });
+  });
+
+  describe('presentServerInfoForPrincipal', () => {
+    const info = {
+      name: 'org-search',
+      owner: 'bob',
+      status: 'connected',
+      tools: [{ name: 'search' }],
+      oauth: {
+        authorizationUrl: 'https://auth.example.com/authorize?state=oauth-state-value',
+        state: 'oauth-state-value',
+        clientIdConfigured: true,
+        connected: false,
+      },
+    };
+
+    it('leaves entries intact for config readers', () => {
+      expect(presentServerInfoForPrincipal(info, bob)).toBe(info);
+      expect(presentServerInfoForPrincipal(info, admin)).toBe(info);
+    });
+
+    it('strips OAuth session fields but keeps indicators for other users', () => {
+      const presented = presentServerInfoForPrincipal(info, alice) as Record<string, unknown>;
+      const oauth = presented.oauth as Record<string, unknown>;
+      expect(oauth.authorizationUrl).toBeUndefined();
+      expect(oauth.state).toBeUndefined();
+      expect(oauth.clientIdConfigured).toBe(true);
+      expect(oauth.connected).toBe(false);
+      expect(presented.status).toBe('connected');
+    });
+
+    it('never leaks the OAuth state value in serialized output', () => {
+      const body = JSON.stringify([presentServerInfoForPrincipal(info, alice)]);
+      expect(body).not.toContain('oauth-state-value');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of #1036 (**Shared Use / Private Config**): authorized shared users can now use a public/group-shared MCP server while receiving only a safe configuration view — never secret-bearing fields.

Core invariant: `server.invoke != server.config.read`.

### What changed

- **`AuthorizationService`** (`src/services/authorizationService.ts`) — explicit authorization boundary with four actions (`server.discover/invoke/config.read/manage`). `config.read`/`manage`: admin or owner only (missing/blank owner normalizes to `admin`). `discover`/`invoke` delegate to the existing `DataService.filterData` visibility semantics (single source of truth, #817/#1037 behavior unchanged). Anonymous callers are denied everywhere.
- **Safe presenter** (`src/services/serverConfigPresenter.ts`) — `presentServerForPrincipal` returns a full deep copy to config-readers, otherwise a safe view that explicit allowlisted safe view; all connection configuration and unknown future fields are withheld by default, and marks itself `configRestricted: true`. `presentServerInfoForPrincipal` strips OAuth session-recovery fields (`authorizationUrl`/`state`) from list entries for non-config-readers.
- **`getServerConfig` (`GET /api/servers/:name`)** — owner/admin keep the full view; visibility-admitted shared users now get the safe view instead of `403 Forbidden`; unrelated users are still rejected. #959 circular-schema handling preserved.
- **`getAllServers` (`GET /api/servers`)** — both `data` and paginated `allServers` collections pass through the presenter (defense in depth; OAuth state scrubbed for non-owners).

Redaction is enforced server-side; the dashboard is never the boundary.

### Explicit non-goals (deferred phases)

- tool-level RBAC / allow-deny
- per-user dynamic credentials / credential templates
- external secret stores (Vault etc.)
- generic policy engine / RBAC-ABAC framework
- no new persisted fields → no DB migration

## Endpoint audit (Task 4)

| Surface | Status |
| --- | --- |
| `GET /api/servers/:name` | patched: safe view for shared users, full for owner/admin |
| `GET /api/servers` (+pagination) | patched: OAuth session fields scrubbed for non-owners |
| `GET /api/settings` | verified safe (non-admin gets empty `mcpServers`) |
| `GET /api/config/json` export | verified safe (`requireAdmin`) |
| Group config endpoints (`/groups/:id/server-configs*`) | verified safe — entries whitelisted to name/alias/tools/prompts/resources by `normalizeGroupServers`, no credential fields |
| Write paths (`PUT /servers/:name` etc.) | verified owner/admin-gated via `loadAuthorizedServer`; regression test added |

## Tests

New suites:
- `tests/services/authorizationService.test.ts` — action matrix incl. fail-closed anonymous/legacy rows
- `tests/services/serverConfigPresenter.test.ts` — sentinel-secret assertions on **serialized** output (`Bearer mcphub-phase1-secret`, `mcphub-phase1-api-key`, `mcphub-phase1-client-secret`, `mcphub-phase1-refresh-token`, `mcphub-phase1-proxy-password`)
- `tests/controllers/serverController.test.ts` — shared-user safe view (public + group member), unrelated-user 403, owner/admin full view, write-path 403 so redacted values cannot overwrite real secrets, pagination scrub of both collections

All passing: `pnpm lint && pnpm test:ci && pnpm build` (168 suites / 1220 tests).

## Manual validation plan

Early-build checklist for the ~300-user Keycloak deployment from #1036 (org-key shared server, group-scoped server, OIDC/Claude Code/CherryStudio compatibility) is tracked in the issue; keeping #1036 open as the coordination thread until SAXEM1997 validates.

Closes nothing yet — refs #1036