### PR TITLE
fix(frontend): show specific password rule errors instead of generic message

### DIFF
--- a/frontend/src/components/AddUserForm.tsx
+++ b/frontend/src/components/AddUserForm.tsx
@@ -2,6 +2,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUserData } from '@/hooks/useUserData';
 import { UserFormData } from '@/types';
+import {
+  validatePasswordStrength,
+  mapBackendPasswordErrors,
+} from '../utils/passwordValidation';
 
 interface AddUserFormProps {
   onAdd: () => void;
@@ -12,6 +16,7 @@ const AddUserForm = ({ onAdd, onCancel }: AddUserFormProps) => {
   const { t } = useTranslation();
   const { createUser } = useUserData();
   const [error, setError] = useState<string | null>(null);
+  const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [formData, setFormData] = useState<UserFormData>({
@@ -24,6 +29,7 @@ const AddUserForm = ({ onAdd, onCancel }: AddUserFormProps) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setPasswordErrors([]);
 
     if (!formData.username.trim()) {
       setError(t('users.usernameRequired'));
@@ -35,8 +41,10 @@ const AddUserForm = ({ onAdd, onCancel }: AddUserFormProps) => {
       return;
     }
 
-    if (formData.password.length < 6) {
-      setError(t('users.passwordTooShort'));
+    const validation = validatePasswordStrength(formData.password);
+    if (!validation.isValid) {
+      setError(t('auth.passwordStrengthError'));
+      setPasswordErrors(validation.errors.map((key) => t(`auth.${key}`)));
       return;
     }
 
@@ -46,6 +54,9 @@ const AddUserForm = ({ onAdd, onCancel }: AddUserFormProps) => {
       const result = await createUser(formData);
       if (result?.success) {
         onAdd();
+      } else if (result?.errors?.length) {
+        setError(result.message || t('auth.passwordStrengthError'));
+        setPasswordErrors(mapBackendPasswordErrors(result.errors).map((key) => t(key)));
       } else {
         setError(result?.message || t('users.createError'));
       }
@@ -73,6 +84,13 @@ const AddUserForm = ({ onAdd, onCancel }: AddUserFormProps) => {
           {error && (
             <div className="bg-red-50 border-l-4 border-red-500 text-red-700 p-4 mb-6 rounded-md">
               <p className="text-sm font-medium">{error}</p>
+              {passwordErrors.length > 0 && (
+                <ul className="list-disc list-inside mt-2 space-y-1 text-sm">
+                  {passwordErrors.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
 
@@ -124,8 +142,11 @@ const AddUserForm = ({ onAdd, onCancel }: AddUserFormProps) => {
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent form-input transition-all duration-200"
                 required
                 disabled={isSubmitting}
-                minLength={6}
+                minLength={8}
               />
+              <p className="mt-1 text-xs text-gray-500">
+                {t('auth.passwordStrengthHint')}
+              </p>
             </div>
 
             <div className="flex items-center pt-2">

--- a/frontend/src/components/ChangePasswordForm.tsx
+++ b/frontend/src/components/ChangePasswordForm.tsx
@@ -35,7 +35,6 @@ const ChangePasswordForm: React.FC<ChangePasswordFormProps> = ({ onSuccess, onCa
       }
     }
   };
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
@@ -47,6 +46,8 @@ const ChangePasswordForm: React.FC<ChangePasswordFormProps> = ({ onSuccess, onCa
       setPasswordErrors(validation.errors);
       return;
     }
+
+    setPasswordErrors([]);
 
     // Validate passwords match
     if (formData.newPassword !== confirmPassword) {
@@ -85,7 +86,14 @@ const ChangePasswordForm: React.FC<ChangePasswordFormProps> = ({ onSuccess, onCa
         <form onSubmit={handleSubmit}>
           {error && (
             <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-              {error}
+              <p>{error}</p>
+              {passwordErrors.length > 0 && (
+                <ul className="list-disc list-inside mt-2 space-y-1">
+                  {passwordErrors.map((errorKey) => (
+                    <li key={errorKey}>{t(`auth.${errorKey}`)}</li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
 

--- a/frontend/src/components/EditUserForm.tsx
+++ b/frontend/src/components/EditUserForm.tsx
@@ -2,6 +2,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUserData } from '@/hooks/useUserData';
 import { User, UserUpdateData } from '@/types';
+import {
+  validatePasswordStrength,
+  mapBackendPasswordErrors,
+} from '../utils/passwordValidation';
 
 interface EditUserFormProps {
   user: User;
@@ -13,6 +17,7 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
   const { t } = useTranslation();
   const { updateUser } = useUserData();
   const [error, setError] = useState<string | null>(null);
+  const [passwordErrors, setPasswordErrors] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [formData, setFormData] = useState({
@@ -25,6 +30,7 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    setPasswordErrors([]);
 
     // Validate passwords match if changing password
     if (formData.newPassword && formData.newPassword !== formData.confirmPassword) {
@@ -32,9 +38,13 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
       return;
     }
 
-    if (formData.newPassword && formData.newPassword.length < 6) {
-      setError(t('users.passwordTooShort'));
-      return;
+    if (formData.newPassword) {
+      const validation = validatePasswordStrength(formData.newPassword);
+      if (!validation.isValid) {
+        setError(t('auth.passwordStrengthError'));
+        setPasswordErrors(validation.errors.map((key) => t(`auth.${key}`)));
+        return;
+      }
     }
 
     setIsSubmitting(true);
@@ -52,6 +62,9 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
       const result = await updateUser(user.username, updateData);
       if (result?.success) {
         onEdit();
+      } else if (result?.errors?.length) {
+        setError(result.message || t('auth.passwordStrengthError'));
+        setPasswordErrors(mapBackendPasswordErrors(result.errors).map((key) => t(key)));
       } else {
         setError(result?.message || t('users.updateError'));
       }
@@ -81,6 +94,13 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
           {error && (
             <div className="bg-red-50 border-l-4 border-red-500 text-red-700 p-4 mb-6 rounded-md">
               <p className="text-sm font-medium">{error}</p>
+              {passwordErrors.length > 0 && (
+                <ul className="list-disc list-inside mt-2 space-y-1 text-sm">
+                  {passwordErrors.map((message) => (
+                    <li key={message}>{message}</li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
 
@@ -141,8 +161,11 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
                     placeholder={t('users.newPasswordPlaceholder')}
                     className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent form-input transition-all duration-200"
                     disabled={isSubmitting}
-                    minLength={6}
+                    minLength={8}
                   />
+                  <p className="mt-1 text-xs text-gray-500">
+                    {t('auth.passwordStrengthHint')}
+                  </p>
                 </div>
 
                 {formData.newPassword && (
@@ -162,7 +185,7 @@ const EditUserForm = ({ user, onEdit, onCancel }: EditUserFormProps) => {
                       placeholder={t('users.confirmPasswordPlaceholder')}
                       className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent form-input transition-all duration-200"
                       disabled={isSubmitting}
-                      minLength={6}
+                      minLength={8}
                     />
                   </div>
                 )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -432,6 +432,7 @@ export interface ApiResponse<T = any> {
   success: boolean;
   message?: string;
   data?: T;
+  errors?: string[];
 }
 
 // Bearer authentication key configuration (frontend view model)

--- a/frontend/src/utils/passwordValidation.ts
+++ b/frontend/src/utils/passwordValidation.ts
@@ -36,3 +36,15 @@ export const validatePasswordStrength = (password: string): PasswordValidationRe
     errors,
   };
 };
+
+// Maps backend validation error messages (English) to i18n keys.
+// Unknown messages are passed through unchanged so they can still be displayed.
+const backendErrorKeyMap: Record<string, string> = {
+  'Password must be at least 8 characters long': 'auth.passwordMinLength',
+  'Password must contain at least one letter': 'auth.passwordRequireLetter',
+  'Password must contain at least one number': 'auth.passwordRequireNumber',
+  'Password must contain at least one special character': 'auth.passwordRequireSpecial',
+};
+
+export const mapBackendPasswordErrors = (errors: string[]): string[] =>
+  errors.map((error) => backendErrorKeyMap[error] ?? error);


### PR DESCRIPTION
## Summary

The Add/Edit User and Change Password forms showed only a vague "Password does not meet security requirements" error. They now list exactly which rules failed.

## Changes

- **AddUserForm / EditUserForm**: client-side validation with the same rules as the backend (min 8 chars, at least one letter, one number, one special character); the error banner lists each failed requirement using the existing `auth.password*` i18n keys (all 4 locales)
- Added a persistent requirements hint under the password fields
- Raised HTML `minLength` from 6 to 8 to match the backend policy
- Backend validation failures (which return an `errors` array of English messages) are now surfaced: `ApiResponse` gains `errors?: string[]`, and a new `mapBackendPasswordErrors` helper maps known backend messages to i18n keys (unknown messages pass through)
- **ChangePasswordForm**: the error banner now also lists the specific failed rules instead of only the generic line

## Testing

- `pnpm lint` and `pnpm frontend:build` pass
- Manual: submitting a weak password (e.g. `123456`) in Add New User now shows the generic message plus a bulleted list of the failed rules, localized

## Screenshots

Before: single vague error line.
After: error line + bulleted list of unmet requirements, in the user's locale.