### PR TITLE
fix: send declared request bodies on DELETE OpenAPI tool calls

### DIFF
--- a/src/clients/__tests__/openapi-request-body.test.ts
+++ b/src/clients/__tests__/openapi-request-body.test.ts
@@ -1,0 +1,132 @@
+import { OpenAPIClient } from '../openapi.js';
+import type { ServerConfig } from '../../types/index.js';
+
+type TestClient = OpenAPIClient & {
+  tools: Array<{
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    operationId: string;
+    method: string;
+    path: string;
+    parameters?: unknown[];
+    requestBody?: Record<string, unknown> | null;
+  }>;
+  httpClient: {
+    request: jest.Mock;
+  };
+};
+
+const jsonRequestBody = {
+  required: true,
+  content: {
+    'application/json': {
+      schema: { type: 'array', items: { type: 'string' } },
+    },
+  },
+};
+
+function createClient(tools: TestClient['tools']): TestClient {
+  const config: ServerConfig = {
+    type: 'openapi',
+    openapi: {
+      schema: {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      },
+    },
+  };
+
+  const client = new OpenAPIClient(config) as TestClient;
+  client.tools = tools;
+  client.httpClient = {
+    request: jest.fn().mockResolvedValue({ data: { ok: true } }),
+  };
+  return client;
+}
+
+describe('OpenAPIClient - request body handling (#1084)', () => {
+  test('sends the request body on DELETE when the operation declares one', async () => {
+    const client = createClient([
+      {
+        name: 'delete_objects',
+        description: 'Bulk delete objects',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'delete_objects',
+        method: 'delete',
+        path: '/objects',
+        requestBody: jsonRequestBody,
+      },
+    ]);
+
+    await client.callTool('delete_objects', { body: ['id-1', 'id-2'] });
+
+    expect(client.httpClient.request).toHaveBeenCalledTimes(1);
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.method).toBe('delete');
+    expect(requestConfig.url).toBe('/objects');
+    expect(requestConfig.data).toEqual(['id-1', 'id-2']);
+  });
+
+  test('does not attach a body on DELETE when the spec declares none', async () => {
+    const client = createClient([
+      {
+        name: 'delete_object',
+        description: 'Delete object by id',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'delete_object',
+        method: 'delete',
+        path: '/objects/{id}',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: null,
+      },
+    ]);
+
+    await client.callTool('delete_object', { id: 'id-1', body: ['unexpected'] });
+
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.method).toBe('delete');
+    expect(requestConfig.url).toBe('/objects/id-1');
+    expect(requestConfig.data).toBeUndefined();
+  });
+
+  test('still attaches the request body on POST operations', async () => {
+    const client = createClient([
+      {
+        name: 'create_object',
+        description: 'Create object',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'create_object',
+        method: 'post',
+        path: '/objects',
+        requestBody: jsonRequestBody,
+      },
+    ]);
+
+    await client.callTool('create_object', { body: { name: 'x' } });
+
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.method).toBe('post');
+    expect(requestConfig.data).toEqual({ name: 'x' });
+  });
+
+  test('sends a declared body even when its value is falsy but present', async () => {
+    const client = createClient([
+      {
+        name: 'replace_flags',
+        description: 'Replace flags',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'replace_flags',
+        method: 'put',
+        path: '/flags',
+        requestBody: jsonRequestBody,
+      },
+    ]);
+
+    await client.callTool('replace_flags', { body: [] });
+
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.data).toEqual([]);
+  });
+});

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -703,8 +703,13 @@ export class OpenAPIClient {
         params: queryParams,
       };
 
-      // Add request body if applicable
-      if (args.body && ['post', 'put', 'patch'].includes(tool.method)) {
+      // Add request body if applicable. Key off the operation's own spec rather
+      // than a method allowlist: some APIs declare required bodies on DELETE
+      // (bulk deletes), and RFC 9110 §9.3.5 permits content when the origin
+      // server has indicated support for it — which a requestBody declaration
+      // in its OpenAPI document is. Keeps schema advertisement and sending
+      // symmetric (#1084).
+      if (args.body !== undefined && tool.requestBody) {
         requestConfig.data = args.body;
       }
 


### PR DESCRIPTION
Fixes #1084

## Problem

`callTool()` attached `args.body` only for `post`/`put`/`patch` (method allowlist), so `DELETE` operations silently dropped it — even when the OpenAPI spec declared a required `requestBody`. Meanwhile `generateInputSchema()` advertises `body` (marked `required`) for *any* operation with an `application/json` requestBody, regardless of method.

Result: tools advertised a required `body` argument that was never sent. Upstreams with bulk-delete endpoints (`DELETE /api/<collection>` + array of ids, typical of springdoc) rejected every call with `Required request body is missing`, making objects un-deletable through MCPHub.

## Fix

Key the send side off the operation's own spec instead of the method allowlist:

```ts
if (args.body !== undefined && tool.requestBody) {
  requestConfig.data = args.body;
}
```

- `tool.requestBody` is already carried on `OpenAPIToolInfo`, so no new plumbing.
- RFC 9110 §9.3.5 permits content in DELETE "unless it is made directly to an origin server that has previously indicated … that such a request has a purpose and will be adequately supported" — a `requestBody` declaration in the origin's own OpenAPI document is exactly that indication.
- Keeps MCPHub from sending bodies the spec did not declare (the minimal allowlist variant would not).
- `!== undefined` also fixes the previous truthy check dropping falsy-but-valid bodies (e.g. empty arrays).

## Testing

New suite `src/clients/__tests__/openapi-request-body.test.ts`:

- ✅ sends the body on DELETE when the operation declares one (regression — failed before the fix)
- ✅ does not attach a body on DELETE when the spec declares none
- ✅ still attaches bodies on POST
- ✅ sends falsy-but-defined bodies (empty array)

Pre-commit gate: `pnpm lint` ✓ · `pnpm test:ci` ✓ (167 suites, 1193 tests) · `pnpm build` ✓