### PR TITLE
fix: encode OpenAPI path parameters before URL substitution

### DIFF
--- a/src/clients/__tests__/openapi-path-params.test.ts
+++ b/src/clients/__tests__/openapi-path-params.test.ts
@@ -1,0 +1,170 @@
+import { OpenAPIClient } from '../openapi.js';
+import type { ServerConfig } from '../../types/index.js';
+
+type TestClient = OpenAPIClient & {
+  tools: Array<{
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    operationId: string;
+    method: string;
+    path: string;
+    parameters?: unknown[];
+  }>;
+  httpClient: {
+    request: jest.Mock;
+  };
+};
+
+function createClient(tools: TestClient['tools']): TestClient {
+  const config: ServerConfig = {
+    type: 'openapi',
+    openapi: {
+      schema: {
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {},
+      },
+    },
+  };
+
+  const client = new OpenAPIClient(config) as TestClient;
+  client.tools = tools;
+  client.httpClient = {
+    request: jest.fn().mockResolvedValue({ data: { ok: true } }),
+  };
+  return client;
+}
+
+const pathParam = (name: string) => ({
+  name,
+  in: 'path',
+  required: true,
+  schema: { type: 'string' },
+});
+
+describe('OpenAPIClient - path parameter encoding (#1083)', () => {
+  test('encodes URL-significant characters so the value cannot change the endpoint', async () => {
+    const client = createClient([
+      {
+        name: 'get_record',
+        description: 'Get a record by id',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'get_record',
+        method: 'get',
+        path: '/records/{id}',
+        parameters: [pathParam('id')],
+      },
+    ]);
+
+    const cases: Array<[unknown, string]> = [
+      ['../../admin/config', '/records/..%2F..%2Fadmin%2Fconfig'],
+      ['a?x=1', '/records/a%3Fx%3D1'],
+      ['a#frag', '/records/a%23frag'],
+      ['a b', '/records/a%20b'],
+      ['100%', '/records/100%25'],
+      [42, '/records/42'],
+    ];
+
+    for (const [id, expectedUrl] of cases) {
+      await client.callTool('get_record', { id });
+      const requestConfig = client.httpClient.request.mock.calls.at(-1)[0];
+      expect(requestConfig.url).toBe(expectedUrl);
+    }
+  });
+
+  test('encodes array values part by part, joining with literal commas', async () => {
+    const client = createClient([
+      {
+        name: 'list_by_tags',
+        description: 'List records by tags',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'list_by_tags',
+        method: 'get',
+        path: '/records/tags/{tags}',
+        parameters: [pathParam('tags')],
+      },
+    ]);
+
+    await client.callTool('list_by_tags', { tags: ['a/b', 'c'] });
+
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.url).toBe('/records/tags/a%2Fb,c');
+  });
+
+  test('encodes object values as comma-joined key,value pairs', async () => {
+    const client = createClient([
+      {
+        name: 'find_user',
+        description: 'Find a user',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'find_user',
+        method: 'get',
+        path: '/users/{filter}',
+        parameters: [pathParam('filter')],
+      },
+    ]);
+
+    await client.callTool('find_user', { filter: { role: 'admin' } });
+
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.url).toBe('/users/role,admin');
+  });
+
+  test('substitutes every path parameter when several are present', async () => {
+    const client = createClient([
+      {
+        name: 'get_tenant_record',
+        description: 'Get a record within a tenant',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'get_tenant_record',
+        method: 'get',
+        path: '/tenants/{tenant}/records/{id}',
+        parameters: [pathParam('tenant'), pathParam('id')],
+      },
+    ]);
+
+    await client.callTool('get_tenant_record', { tenant: 'acme/eu', id: 'r?1' });
+
+    const requestConfig = client.httpClient.request.mock.calls[0][0];
+    expect(requestConfig.url).toBe('/tenants/acme%2Feu/records/r%3F1');
+  });
+
+  test('fails fast instead of sending an unsubstituted placeholder upstream', async () => {
+    const client = createClient([
+      {
+        name: 'get_record',
+        description: 'Get a record by id',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'get_record',
+        method: 'get',
+        path: '/records/{id}',
+        parameters: [pathParam('id')],
+      },
+    ]);
+
+    await expect(client.callTool('get_record', {})).rejects.toThrow(
+      "Required path parameter 'id' is missing",
+    );
+    expect(client.httpClient.request).not.toHaveBeenCalled();
+  });
+
+  test('treats a null value as a missing path parameter', async () => {
+    const client = createClient([
+      {
+        name: 'get_record',
+        description: 'Get a record by id',
+        inputSchema: { type: 'object', properties: {}, required: [] },
+        operationId: 'get_record',
+        method: 'get',
+        path: '/records/{id}',
+        parameters: [pathParam('id')],
+      },
+    ]);
+
+    await expect(client.callTool('get_record', { id: null })).rejects.toThrow(
+      "Required path parameter 'id' is missing",
+    );
+    expect(client.httpClient.request).not.toHaveBeenCalled();
+  });
+});

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -24,7 +24,22 @@ export interface OpenAPIToolInfo {
 type OpenAPIOAuth2Config = NonNullable<OpenAPISecurityConfig['oauth2']>;
 
 interface OpenAPIClientOptions {
-  persistOAuth2Token?: (oauth2: OpenAPIOAuth2Config) => Promise<void> | void;
+  persistOAuth2Token?: (oauth2: OpenAPISecurityConfig['oauth2']) => Promise<void> | void;
+}
+
+// Encodes a substituted path parameter following OpenAPI's default
+// `style: simple, explode: false`: primitives whole, arrays and objects part
+// by part, joined with literal commas (#1083).
+function encodePathParameterValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => encodeURIComponent(String(item))).join(',');
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([key, val]) => `${encodeURIComponent(key)},${encodeURIComponent(String(val))}`)
+      .join(',');
+  }
+  return encodeURIComponent(String(value));
 }
 
 export class OpenAPIClient {
@@ -680,9 +695,14 @@ export class OpenAPIClient {
 
       for (const param of pathParams) {
         const value = args[param.name];
-        if (value !== undefined) {
-          url = url.replace(`{${param.name}}`, String(value));
+        if (value === undefined || value === null) {
+          // Path parameters are required by the OpenAPI spec; fail fast rather
+          // than sending a request whose `{placeholder}` can only 404 (#1083).
+          throw new Error(`Required path parameter '${param.name}' is missing`);
         }
+        // Values come from model output, so encode them to keep URL-significant
+        // characters ('/', '?', '#', '%') from changing the endpoint (#1083).
+        url = url.replace(`{${param.name}}`, encodePathParameterValue(value));
       }
 
       // Build query parameters


### PR DESCRIPTION
## Summary

Fixes #1083. Path parameter values in `OpenAPIClient.callTool` were substituted into the request URL verbatim (`String(value)`), so a value containing URL-significant characters could change which endpoint on the intended host receives the request:

- `id = "../../admin/config"` → dot segments resolved before the request leaves the client, hitting `/api/admin/config` instead of the record endpoint
- `id = "a?x=1"` → `?` truncates the path and turns the remainder into a query string
- `id = "a#frag"`, stray `%` → same class of problem

Path parameter values come from model output, so this is reachable via ordinary prompt injection. The existing SSRF guard (`assertSafeUrl`) validates the resolved **host** only and cannot catch path-level redirection.

## Changes

- `src/clients/openapi.ts`
  - Percent-encode each substituted path parameter with `encodeURIComponent`, matching OpenAPI's default `style: simple, explode: false` for primitives.
  - Arrays and objects (simple style): encode each part individually, join with literal commas (`a/b,c` → `a%2Fb,c`; `{role: 'admin'}` → `role,admin`).
  - Fail fast with ``Required path parameter '<name>' is missing`` when a value is not supplied (or is `null`), instead of sending a request whose `{placeholder}` gets percent-encoded to `%7Bid%7D` and can only 404.
- `src/clients/__tests__/openapi-path-params.test.ts` — regression tests covering traversal payloads, `?`/`#`/space/`%`, numeric ids, array/object values, multi-parameter paths, and missing-value fail-fast.

## Behavior change

Only malicious or malformed path parameter values are affected; well-formed ids resolve to identical URLs (`42` → `/records/42`). Requests that previously went out with an unsubstituted `{placeholder}` now throw before any upstream call.

## Tests

- New suite `openapi-path-params.test.ts` (6 tests) — red before the fix, green after.
- Full gate: `pnpm lint` ✓, `pnpm test:ci` (168 suites / 1199 tests) ✓, `pnpm build` ✓