### PR TITLE
fix: serialize OpenAPI array query params per spec default (#1080)

### DIFF
--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -94,6 +94,9 @@ export class OpenAPIClient {
       baseURL: this.baseUrl,
       timeout: config.options?.timeout || 30000,
       maxRedirects: 0,
+      // Serialize array query params per OpenAPI's default `style: form, explode: true`
+      // (`id=a&id=b`) instead of axios's bracket form `id[]=a&id[]=b` (#1080).
+      paramsSerializer: { indexes: null },
       headers: {
         'Content-Type': 'application/json',
         ...config.headers,


### PR DESCRIPTION
## Summary

Configures the OpenAPI client's axios instance with `paramsSerializer: { indexes: null }` so array query parameters are serialized per OpenAPI's declared default (`style: form, explode: true`):

- Before: `id[]=a&id[]=b` (axios bracket form)
- After: `id=a&id=b` (OpenAPI form)

As analyzed in #1080, this is a spec-conformance fix rather than a confirmed live break: lenient binders (e.g. Spring) accept the bracket form. Strictly-parsing backends see a parameter named `id[]` instead of `id` and fail to bind.

Note: full conformance for non-default styles (`spaceDelimited`, `pipeDelimited`, `deepObject`) is out of scope for this change; `style`/`explode` remain unread (#1080 tracks that broader gap).

Fixes #1080

## Test plan

- [x] `pnpm lint` passes
- [x] All 69 OpenAPI client tests pass (`npx jest src/clients`)
- [x] Wire-level verification from the issue: local HTTP server + pinned axios shows `GET /things/findByIds?id=a&id=b` with `indexes: null`
