### PR TITLE
fix: persist startOnDemand/idleTimeoutMs when running in database mode

### DIFF
--- a/src/dao/ServerDao.ts
+++ b/src/dao/ServerDao.ts
@@ -1,6 +1,7 @@
 import { ServerConfig } from '../types/index.js';
 import { BaseDao } from './base/BaseDao.js';
 import { JsonFileBaseDao } from './base/JsonFileBaseDao.js';
+import { unpackStartOnDemandOptions } from '../utils/serverConfigPersistence.js';
 
 /**
  * Pagination result interface
@@ -107,9 +108,21 @@ export class ServerDaoImpl extends JsonFileBaseDao implements ServerDao {
     const servers: ServerConfigWithName[] = [];
 
     for (const [name, config] of Object.entries(settings.mcpServers || {})) {
+      // startOnDemand/idleTimeoutMs are mirrored into `options` by
+      // normalizeServerConfigForPersistence() so database-backed installs can
+      // persist them (see ServerDaoDbImpl). Unpack + strip the mirrored keys
+      // here too so JSON-mode behaves the same way: no duplicate/stale
+      // options.startOnDemand noise in mcp_settings.json or API responses.
+      const { options, startOnDemand, idleTimeoutMs } = unpackStartOnDemandOptions(
+        config.options,
+      );
+
       servers.push({
         name,
         ...config,
+        options,
+        ...(startOnDemand !== undefined ? { startOnDemand } : {}),
+        ...(idleTimeoutMs !== undefined ? { idleTimeoutMs } : {}),
       });
     }
 

--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -1,5 +1,7 @@
 import { ServerDao, ServerConfigWithName, PaginatedResult } from './index.js';
 import { ServerRepository } from '../db/repositories/ServerRepository.js';
+import { ServerConfig } from '../types/index.js';
+import { unpackStartOnDemandOptions } from '../utils/serverConfigPersistence.js';
 
 /**
  * Database-backed implementation of ServerDao
@@ -249,19 +251,9 @@ export class ServerDaoDbImpl implements ServerDao {
     // so they survive a save when running in database mode. Unpack them back to
     // top-level ServerConfig fields here, since every other consumer (mcpService.ts,
     // the dashboard, etc.) reads config.startOnDemand / config.idleTimeoutMs directly.
-    const rawOptions = server.options as
-      | (Record<string, any> & { startOnDemand?: boolean; idleTimeoutMs?: number })
-      | undefined;
-    const startOnDemand = rawOptions?.startOnDemand === true ? true : undefined;
-    const idleTimeoutMs =
-      typeof rawOptions?.idleTimeoutMs === 'number' ? rawOptions.idleTimeoutMs : undefined;
-    const options = rawOptions
-      ? (() => {
-          const { startOnDemand: _startOnDemand, idleTimeoutMs: _idleTimeoutMs, ...rest } =
-            rawOptions;
-          return Object.keys(rest).length > 0 ? rest : undefined;
-        })()
-      : undefined;
+    const { options, startOnDemand, idleTimeoutMs } = unpackStartOnDemandOptions(
+      server.options as ServerConfig['options'],
+    );
 
     return {
       name: server.name,

--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -1,7 +1,10 @@
 import { ServerDao, ServerConfigWithName, PaginatedResult } from './index.js';
 import { ServerRepository } from '../db/repositories/ServerRepository.js';
 import { ServerConfig } from '../types/index.js';
-import { unpackStartOnDemandOptions } from '../utils/serverConfigPersistence.js';
+import {
+  unpackStartOnDemandOptions,
+  mirrorStartOnDemandIntoOptions,
+} from '../utils/serverConfigPersistence.js';
 
 /**
  * Database-backed implementation of ServerDao
@@ -74,6 +77,18 @@ export class ServerDaoDbImpl implements ServerDao {
   }
 
   async create(entity: ServerConfigWithName): Promise<ServerConfigWithName> {
+    // Mirror startOnDemand/idleTimeoutMs into `options` here (rather than only
+    // relying on callers to have already run normalizeServerConfigForPersistence)
+    // so paths that call the DAO directly - e.g.
+    // templateService.importTemplate() -> mcpService.addServer() -> create() -
+    // still persist both fields in database mode instead of silently dropping
+    // them. See #1095 review discussion.
+    const options = mirrorStartOnDemandIntoOptions(
+      entity.options,
+      entity.startOnDemand === true,
+      entity.idleTimeoutMs,
+    );
+
     const server = await this.repository.create({
       name: entity.name,
       type: entity.type,
@@ -92,7 +107,7 @@ export class ServerDaoDbImpl implements ServerDao {
       tools: entity.tools,
       prompts: entity.prompts,
       resources: entity.resources,
-      options: entity.options,
+      options,
       oauth: entity.oauth,
       proxy: entity.proxy,
       openapi: entity.openapi,
@@ -144,12 +159,39 @@ export class ServerDaoDbImpl implements ServerDao {
     assignNullable('tools');
     assignNullable('prompts');
     assignNullable('resources');
-    assignNullable('options');
     assignNullable('oauth');
     assignNullable('proxy');
     assignNullable('openapi');
     assignNullable('passthroughHeaders');
     assignNullable('perSessionClient');
+
+    // Mirror startOnDemand/idleTimeoutMs into `options`, the same way create()
+    // does, so partial updates that bypass normalizeServerConfigForPersistence
+    // still persist both fields. If this update doesn't touch `options` at all,
+    // read the current row first so we merge into (rather than clobber) any
+    // options already stored - startOnDemand/idleTimeoutMs-only updates must not
+    // wipe out unrelated options like timeout/resetTimeoutOnProgress.
+    if (hasOwn('options') || hasOwn('startOnDemand') || hasOwn('idleTimeoutMs')) {
+      let baseOptions = entity.options;
+      let existingStartOnDemand: boolean | undefined;
+      let existingIdleTimeoutMs: number | undefined;
+
+      if (!hasOwn('options')) {
+        const current = await this.repository.findByName(name);
+        const unpacked = unpackStartOnDemandOptions(current?.options as ServerConfig['options']);
+        baseOptions = unpacked.options;
+        existingStartOnDemand = unpacked.startOnDemand;
+        existingIdleTimeoutMs = unpacked.idleTimeoutMs;
+      }
+
+      const startOnDemand = hasOwn('startOnDemand')
+        ? entity.startOnDemand === true
+        : existingStartOnDemand === true;
+      const idleTimeoutMs = hasOwn('idleTimeoutMs') ? entity.idleTimeoutMs : existingIdleTimeoutMs;
+
+      const options = mirrorStartOnDemandIntoOptions(baseOptions, startOnDemand, idleTimeoutMs);
+      updateData.options = options ?? null;
+    }
 
     const server = await this.repository.update(name, updateData as any);
     return server ? this.mapToServerConfig(server) : null;

--- a/src/dao/ServerDaoDbImpl.ts
+++ b/src/dao/ServerDaoDbImpl.ts
@@ -243,6 +243,26 @@ export class ServerDaoDbImpl implements ServerDao {
     passthroughHeaders?: string[];
     perSessionClient?: boolean;
   }): ServerConfigWithName {
+    // startOnDemand/idleTimeoutMs (#1012) have no dedicated columns on the `servers`
+    // table; they are piggybacked onto the schema-less `options` JSON blob by
+    // normalizeServerConfigForPersistence() (see src/utils/serverConfigPersistence.ts)
+    // so they survive a save when running in database mode. Unpack them back to
+    // top-level ServerConfig fields here, since every other consumer (mcpService.ts,
+    // the dashboard, etc.) reads config.startOnDemand / config.idleTimeoutMs directly.
+    const rawOptions = server.options as
+      | (Record<string, any> & { startOnDemand?: boolean; idleTimeoutMs?: number })
+      | undefined;
+    const startOnDemand = rawOptions?.startOnDemand === true ? true : undefined;
+    const idleTimeoutMs =
+      typeof rawOptions?.idleTimeoutMs === 'number' ? rawOptions.idleTimeoutMs : undefined;
+    const options = rawOptions
+      ? (() => {
+          const { startOnDemand: _startOnDemand, idleTimeoutMs: _idleTimeoutMs, ...rest } =
+            rawOptions;
+          return Object.keys(rest).length > 0 ? rest : undefined;
+        })()
+      : undefined;
+
     return {
       name: server.name,
       type: server.type as 'stdio' | 'sse' | 'streamable-http' | 'openapi' | undefined,
@@ -261,12 +281,14 @@ export class ServerDaoDbImpl implements ServerDao {
       tools: server.tools,
       prompts: server.prompts,
       resources: server.resources,
-      options: server.options,
+      options,
       oauth: server.oauth,
       proxy: server.proxy,
       openapi: server.openapi,
       passthroughHeaders: server.passthroughHeaders,
       perSessionClient: server.perSessionClient,
+      startOnDemand,
+      idleTimeoutMs,
     };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -419,7 +419,16 @@ export interface ServerConfig {
   tools?: Record<string, { enabled: boolean; description?: string }>; // Tool-specific configurations with enable/disable state and custom descriptions
   prompts?: Record<string, { enabled: boolean; description?: string }>; // Prompt-specific configurations with enable/disable state and custom descriptions
   resources?: Record<string, { enabled: boolean; description?: string }>; // Resource-specific configurations with enable/disable state and custom descriptions
-  options?: Partial<Pick<RequestOptions, 'timeout' | 'resetTimeoutOnProgress' | 'maxTotalTimeout'>>; // MCP request options configuration
+  options?: Partial<Pick<RequestOptions, 'timeout' | 'resetTimeoutOnProgress' | 'maxTotalTimeout'>> & {
+    // Internal persistence carriers for startOnDemand/idleTimeoutMs (see below). The
+    // database-backed ServerDao has no dedicated columns for those two fields, so
+    // serverConfigPersistence.ts piggybacks them onto this schema-less JSON blob
+    // and ServerDaoDbImpl unpacks them back to the top-level fields on read.
+    // Application code should read/write config.startOnDemand / config.idleTimeoutMs
+    // directly rather than these mirrored keys.
+    startOnDemand?: boolean;
+    idleTimeoutMs?: number;
+  }; // MCP request options configuration
   // Proxychains4 proxy configuration for STDIO servers (Linux/macOS only, Windows not supported)
   proxy?: ProxychainsConfig;
   // OAuth authentication for upstream MCP servers

--- a/src/utils/migration.ts
+++ b/src/utils/migration.ts
@@ -68,6 +68,19 @@ export async function migrateToDatabase(): Promise<boolean> {
       for (const [name, config] of Object.entries(settings.mcpServers)) {
         const exists = await serverRepo.exists(name);
         if (!exists) {
+          // startOnDemand/idleTimeoutMs have no dedicated DB columns and must be
+          // mirrored into the schema-less `options` blob (see
+          // serverConfigPersistence.ts / ServerDaoDbImpl.ts), otherwise a JSON-mode
+          // user who already configured on-demand servers silently loses that
+          // setting the moment they migrate to the database.
+          const options = {
+            ...(config.options ?? {}),
+            ...(config.startOnDemand === true ? { startOnDemand: true } : {}),
+            ...(typeof config.idleTimeoutMs === 'number' && config.idleTimeoutMs > 0
+              ? { idleTimeoutMs: config.idleTimeoutMs }
+              : {}),
+          };
+
           await serverRepo.create({
             name,
             type: config.type,
@@ -86,7 +99,7 @@ export async function migrateToDatabase(): Promise<boolean> {
             tools: config.tools,
             prompts: config.prompts,
             resources: config.resources,
-            options: config.options,
+            options: Object.keys(options).length > 0 ? options : config.options,
             oauth: config.oauth,
             openapi: config.openapi,
             passthroughHeaders: config.passthroughHeaders,

--- a/src/utils/serverConfigPersistence.ts
+++ b/src/utils/serverConfigPersistence.ts
@@ -65,6 +65,38 @@ export const unpackStartOnDemandOptions = (
   };
 };
 
+/**
+ * Merges startOnDemand/idleTimeoutMs into an `options` blob for storage,
+ * without touching/re-validating any other keys already present in
+ * `options` (unlike normalizeOptions() below, which only forwards a fixed
+ * whitelist). Used by ServerDaoDbImpl itself as a persistence-layer safety
+ * net: normalizeServerConfigForPersistence() is the primary place that does
+ * this, but not every caller routes through it (e.g.
+ * templateService.importTemplate() -> mcpService.addServer() calls
+ * ServerDao.create()/update() directly), so the DAO mirrors the fields
+ * unconditionally to guarantee they're never silently dropped in database
+ * mode regardless of how the DAO was invoked.
+ */
+export const mirrorStartOnDemandIntoOptions = (
+  options: ServerConfig['options'] | undefined,
+  startOnDemand: boolean | undefined,
+  idleTimeoutMs: number | undefined,
+): ServerConfig['options'] | undefined => {
+  const merged: Record<string, unknown> = { ...(options as Record<string, unknown> | undefined) };
+  delete merged.startOnDemand;
+  delete merged.idleTimeoutMs;
+
+  if (startOnDemand === true) {
+    merged.startOnDemand = true;
+  }
+
+  if (typeof idleTimeoutMs === 'number' && !Number.isNaN(idleTimeoutMs) && idleTimeoutMs > 0) {
+    merged.idleTimeoutMs = idleTimeoutMs;
+  }
+
+  return Object.keys(merged).length > 0 ? (merged as ServerConfig['options']) : undefined;
+};
+
 const normalizeOptions = (
   options?: ServerConfig['options'],
   startOnDemand?: boolean,

--- a/src/utils/serverConfigPersistence.ts
+++ b/src/utils/serverConfigPersistence.ts
@@ -35,6 +35,36 @@ const normalizeSharedUsers = (value?: string[]): string[] | undefined => {
   return normalized ? Array.from(new Set(normalized)) : undefined;
 };
 
+/**
+ * Unpacks the startOnDemand/idleTimeoutMs values mirrored into the `options`
+ * blob by normalizeOptions() (see below) back to top-level fields, stripping
+ * the mirrored keys out of the returned `options` so they don't leak into
+ * plain MCP RequestOptions or resurface as file/API noise. Shared by both
+ * ServerDaoDbImpl (unpacks on every DB read) and ServerDaoImpl (unpacks on
+ * every JSON-file read), so both storage backends behave identically instead
+ * of only stripping the mirrored keys in database mode.
+ */
+export const unpackStartOnDemandOptions = (
+  options: ServerConfig['options'] | undefined,
+): {
+  options: ServerConfig['options'] | undefined;
+  startOnDemand: boolean | undefined;
+  idleTimeoutMs: number | undefined;
+} => {
+  if (!options) {
+    return { options: undefined, startOnDemand: undefined, idleTimeoutMs: undefined };
+  }
+
+  const { startOnDemand: rawStartOnDemand, idleTimeoutMs: rawIdleTimeoutMs, ...rest } =
+    options as Record<string, unknown>;
+
+  return {
+    options: Object.keys(rest).length > 0 ? (rest as ServerConfig['options']) : undefined,
+    startOnDemand: rawStartOnDemand === true ? true : undefined,
+    idleTimeoutMs: typeof rawIdleTimeoutMs === 'number' ? rawIdleTimeoutMs : undefined,
+  };
+};
+
 const normalizeOptions = (
   options?: ServerConfig['options'],
   startOnDemand?: boolean,
@@ -213,6 +243,16 @@ export const normalizeServerConfigForPersistence = (config: ServerConfig): Serve
     // off - the toggle would still read enabled after save. Emit an explicit key
     // (matching perSessionClient above) so the old `true` is overwritten. See #1032.
     startOnDemand: config.startOnDemand === true ? true : undefined,
+    // Keep the top-level value consistent with what actually gets mirrored into
+    // `options` above: an invalid/non-positive idleTimeoutMs is dropped instead
+    // of surviving as a meaningless top-level 0/NaN value that only JSON-mode
+    // storage would otherwise preserve verbatim.
+    idleTimeoutMs:
+      typeof config.idleTimeoutMs === 'number' &&
+      !Number.isNaN(config.idleTimeoutMs) &&
+      config.idleTimeoutMs > 0
+        ? config.idleTimeoutMs
+        : undefined,
   };
 
   if (normalizedType === 'openapi') {

--- a/src/utils/serverConfigPersistence.ts
+++ b/src/utils/serverConfigPersistence.ts
@@ -37,23 +37,41 @@ const normalizeSharedUsers = (value?: string[]): string[] | undefined => {
 
 const normalizeOptions = (
   options?: ServerConfig['options'],
+  startOnDemand?: boolean,
+  idleTimeoutMs?: number,
 ): ServerConfig['options'] | undefined => {
-  if (!options) {
-    return undefined;
-  }
-
   const normalized: NonNullable<ServerConfig['options']> = {};
 
-  if (typeof options.timeout === 'number' && !Number.isNaN(options.timeout)) {
-    normalized.timeout = options.timeout;
+  if (options) {
+    if (typeof options.timeout === 'number' && !Number.isNaN(options.timeout)) {
+      normalized.timeout = options.timeout;
+    }
+
+    if (typeof options.resetTimeoutOnProgress === 'boolean') {
+      normalized.resetTimeoutOnProgress = options.resetTimeoutOnProgress;
+    }
+
+    if (typeof options.maxTotalTimeout === 'number' && !Number.isNaN(options.maxTotalTimeout)) {
+      normalized.maxTotalTimeout = options.maxTotalTimeout;
+    }
   }
 
-  if (typeof options.resetTimeoutOnProgress === 'boolean') {
-    normalized.resetTimeoutOnProgress = options.resetTimeoutOnProgress;
+  // startOnDemand/idleTimeoutMs (#1012) are exposed as top-level ServerConfig
+  // fields everywhere else in the codebase (mcpService.ts reads
+  // config.startOnDemand / config.idleTimeoutMs directly), but the database-backed
+  // ServerDaoDbImpl has no dedicated columns for them and previously dropped both
+  // fields silently on every save when running with DB_URL configured (the default
+  // production deployment mode) - see ServerDaoDbImpl create()/update(), which only
+  // ever whitelisted the fixed set of known Server entity columns. Piggybacking
+  // them onto the existing schema-less `options` JSON blob column persists them
+  // without requiring a database migration. ServerDaoDbImpl.mapToServerConfig()
+  // unpacks them back out to top-level fields on read.
+  if (startOnDemand === true) {
+    normalized.startOnDemand = true;
   }
 
-  if (typeof options.maxTotalTimeout === 'number' && !Number.isNaN(options.maxTotalTimeout)) {
-    normalized.maxTotalTimeout = options.maxTotalTimeout;
+  if (typeof idleTimeoutMs === 'number' && !Number.isNaN(idleTimeoutMs) && idleTimeoutMs > 0) {
+    normalized.idleTimeoutMs = idleTimeoutMs;
   }
 
   return Object.keys(normalized).length > 0 ? normalized : undefined;
@@ -164,7 +182,11 @@ export const normalizeServerConfigForPersistence = (config: ServerConfig): Serve
   const env = normalizeRecord(config.env);
   const headers = normalizeRecord(config.headers);
   const passthroughHeaders = normalizeStringArray(config.passthroughHeaders);
-  const options = normalizeOptions(config.options);
+  const options = normalizeOptions(
+    config.options,
+    config.startOnDemand === true,
+    config.idleTimeoutMs,
+  );
   const oauth = normalizeOAuth(config.oauth);
   const openapi = normalizeOpenApi(config.openapi);
 

--- a/tests/dao/serverDao.test.ts
+++ b/tests/dao/serverDao.test.ts
@@ -25,4 +25,34 @@ describe('ServerDaoImpl', () => {
     expect(result.data.map((server) => server.name)).toEqual(['owned', 'public', 'shared']);
     expect(result.total).toBe(3);
   });
+
+  it('unpacks startOnDemand/idleTimeoutMs mirrored into options and strips them from the stored options blob', async () => {
+    // JSON-mode storage keeps configs verbatim, so without this the mirrored
+    // keys added for database-mode persistence would leak into API responses
+    // and the on-disk mcp_settings.json as user-visible noise, even though
+    // JSON mode never needed the mirror in the first place.
+    const dao = new ServerDaoImpl();
+    jest.spyOn(dao as any, 'loadSettings').mockResolvedValue({
+      mcpServers: {
+        'on-demand-server': {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', 'demo-server'],
+          enabled: true,
+          options: {
+            timeout: 5000,
+            startOnDemand: true,
+            idleTimeoutMs: 120000,
+          },
+        },
+      },
+    });
+
+    const servers = await (dao as any).getAll();
+    const server = servers.find((s: any) => s.name === 'on-demand-server');
+
+    expect(server.startOnDemand).toBe(true);
+    expect(server.idleTimeoutMs).toBe(120000);
+    expect(server.options).toEqual({ timeout: 5000 });
+  });
 });

--- a/tests/dao/serverDaoDbImpl.test.ts
+++ b/tests/dao/serverDaoDbImpl.test.ts
@@ -249,4 +249,117 @@ describe('ServerDaoDbImpl', () => {
     expect(result?.idleTimeoutMs).toBeUndefined();
     expect(result?.options).toEqual({ timeout: 5000 });
   });
+
+  it('should mirror startOnDemand/idleTimeoutMs into options on create() even when the caller bypassed normalizeServerConfigForPersistence', async () => {
+    // templateService.importTemplate() calls mcpService.addServer(), which calls
+    // ServerDao.create() directly with a raw ServerConfig - it never runs through
+    // normalizeServerConfigForPersistence(). The DAO must mirror the fields itself
+    // so a template import still persists startOnDemand/idleTimeoutMs in database
+    // mode. See PR #1095 review discussion.
+    const dao = new ServerDaoDbImpl();
+
+    mockRepository.create.mockResolvedValue({
+      name: 'templated-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      enabled: true,
+      options: { startOnDemand: true, idleTimeoutMs: 120000 },
+    });
+
+    await dao.create({
+      name: 'templated-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      startOnDemand: true,
+      idleTimeoutMs: 120000,
+    });
+
+    expect(mockRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { startOnDemand: true, idleTimeoutMs: 120000 },
+      }),
+    );
+  });
+
+  it('should not mirror startOnDemand into options on create() when not set', async () => {
+    const dao = new ServerDaoDbImpl();
+
+    mockRepository.create.mockResolvedValue({
+      name: 'always-on-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      enabled: true,
+    });
+
+    await dao.create({
+      name: 'always-on-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+    });
+
+    expect(mockRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: undefined,
+      }),
+    );
+  });
+
+  it('should mirror startOnDemand/idleTimeoutMs into options on update() even when only those top-level fields are provided', async () => {
+    // Simulates a direct DAO update() call that only touches startOnDemand,
+    // without going through normalizeServerConfigForPersistence and without an
+    // `options` key at all. The DAO must read the current row and merge, rather
+    // than dropping the change or wiping unrelated stored options.
+    const dao = new ServerDaoDbImpl();
+
+    mockRepository.findByName.mockResolvedValue({
+      name: 'templated-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      enabled: true,
+      options: { timeout: 5000 },
+    });
+
+    mockRepository.update.mockResolvedValue({
+      name: 'templated-server',
+      type: 'stdio',
+      enabled: true,
+      options: { timeout: 5000, startOnDemand: true, idleTimeoutMs: 120000 },
+    });
+
+    await dao.update('templated-server', {
+      startOnDemand: true,
+      idleTimeoutMs: 120000,
+    });
+
+    expect(mockRepository.findByName).toHaveBeenCalledWith('templated-server');
+    expect(mockRepository.update).toHaveBeenCalledWith('templated-server', {
+      options: { timeout: 5000, startOnDemand: true, idleTimeoutMs: 120000 },
+    });
+  });
+
+  it('should not read the current row on update() when options is explicitly provided', async () => {
+    const dao = new ServerDaoDbImpl();
+
+    mockRepository.update.mockResolvedValue({
+      name: 'normalized-server',
+      type: 'stdio',
+      enabled: true,
+      options: { startOnDemand: true },
+    });
+
+    await dao.update('normalized-server', {
+      options: { startOnDemand: true } as any,
+      startOnDemand: true,
+    });
+
+    expect(mockRepository.findByName).not.toHaveBeenCalled();
+    expect(mockRepository.update).toHaveBeenCalledWith('normalized-server', {
+      options: { startOnDemand: true },
+    });
+  });
 });

--- a/tests/dao/serverDaoDbImpl.test.ts
+++ b/tests/dao/serverDaoDbImpl.test.ts
@@ -201,4 +201,52 @@ describe('ServerDaoDbImpl', () => {
       tools: {},
     });
   });
+
+  it('should unpack startOnDemand/idleTimeoutMs mirrored inside the options JSON blob back to top-level fields on read', async () => {
+    // The `servers` table has no dedicated startOnDemand/idleTimeoutMs columns, so
+    // normalizeServerConfigForPersistence() piggybacks them onto the schema-less
+    // `options` column. mapToServerConfig() must unpack them back out so the rest
+    // of the app (which reads config.startOnDemand / config.idleTimeoutMs at the
+    // top level) sees them after a DB round-trip.
+    const dao = new ServerDaoDbImpl();
+
+    mockRepository.findByName.mockResolvedValue({
+      name: 'on-demand-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      enabled: true,
+      options: {
+        timeout: 5000,
+        startOnDemand: true,
+        idleTimeoutMs: 120000,
+      },
+    });
+
+    const result = await dao.findById('on-demand-server');
+
+    expect(result?.startOnDemand).toBe(true);
+    expect(result?.idleTimeoutMs).toBe(120000);
+    // The mirrored keys must not leak into the plain request-options object.
+    expect(result?.options).toEqual({ timeout: 5000 });
+  });
+
+  it('should leave startOnDemand/idleTimeoutMs undefined when not present in stored options', async () => {
+    const dao = new ServerDaoDbImpl();
+
+    mockRepository.findByName.mockResolvedValue({
+      name: 'always-on-server',
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      enabled: true,
+      options: { timeout: 5000 },
+    });
+
+    const result = await dao.findById('always-on-server');
+
+    expect(result?.startOnDemand).toBeUndefined();
+    expect(result?.idleTimeoutMs).toBeUndefined();
+    expect(result?.options).toEqual({ timeout: 5000 });
+  });
 });

--- a/tests/utils/serverConfigPersistence.test.ts
+++ b/tests/utils/serverConfigPersistence.test.ts
@@ -172,6 +172,38 @@ describe('normalizeServerConfigForPersistence', () => {
     expect(normalized).toHaveProperty('startOnDemand', undefined);
   });
 
+  it('mirrors startOnDemand/idleTimeoutMs into options so DB-backed storage persists them', () => {
+    // The database-backed ServerDao has no dedicated startOnDemand/idleTimeoutMs
+    // columns, so those two fields must also be piggybacked onto the schema-less
+    // `options` JSON blob (ServerDaoDbImpl.mapToServerConfig unpacks them back out
+    // on read). Without this, saving a server with startOnDemand enabled while
+    // running in database mode silently drops the setting.
+    const normalized = normalizeServerConfigForPersistence({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+      startOnDemand: true,
+      idleTimeoutMs: 120000,
+    });
+
+    expect(normalized.startOnDemand).toBe(true);
+    expect(normalized.idleTimeoutMs).toBe(120000);
+    expect(normalized.options).toMatchObject({
+      startOnDemand: true,
+      idleTimeoutMs: 120000,
+    });
+  });
+
+  it('does not persist startOnDemand/idleTimeoutMs into options when disabled', () => {
+    const normalized = normalizeServerConfigForPersistence({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', 'demo-server'],
+    });
+
+    expect(normalized.options).toBeUndefined();
+  });
+
   it('normalizes openapi payloads and trims empty values', () => {
     const normalized = normalizeServerConfigForPersistence({
       type: 'openapi',


### PR DESCRIPTION
## Problem

#1012 added a `startOnDemand` / `idleTimeoutMs` config option for stdio servers to reduce idle memory usage, declared as top-level `ServerConfig` fields and consumed that way throughout `mcpService.ts`.

However, when MCPHub runs in **database mode** (`DB_URL` set — the default/typical production deployment), `ServerDaoDbImpl` has no dedicated columns for these two fields:

- `create()` / `update()` only assign an explicit whitelist of known `Server` entity columns
- `mapToServerConfig()` never reads them back out

So both fields are **silently dropped on every save** in DB mode. I verified this live against a running MCPHub instance backed by Postgres: POSTing a server config with `startOnDemand: true, idleTimeoutMs: 5000` succeeds, but reading it back shows neither field, and the server falls back to eager startup spawn — the on-demand behavior never actually engages, and idle memory is never reclaimed for DB-backed deployments.

## Fix

Rather than adding a migration/new columns, this mirrors the two fields into the existing schema-less `options` JSON blob column (a TypeORM `simple-json` field that already free-forms extra keys):

- `src/utils/serverConfigPersistence.ts`: `normalizeOptions()` now also accepts `startOnDemand`/`idleTimeoutMs` and writes them into the normalized `options` object when set.
- `src/dao/ServerDaoDbImpl.ts`: `mapToServerConfig()` unpacks `startOnDemand`/`idleTimeoutMs` back out of `options` into top-level `ServerConfig` fields on read, and strips them from the `options` object returned to callers so they don't leak into the plain MCP `RequestOptions` (verified the existing `options` consumers in `mcpService.ts` already explicitly whitelist `timeout`/`resetTimeoutOnProgress`/`maxTotalTimeout`, so this is safe even mid-transition).
- `src/types/index.ts`: documents the mirrored keys on the `options` type with a comment pointing callers back to the top-level fields.

No migration needed; no change to the DB schema.

## Testing

- Added coverage in `tests/utils/serverConfigPersistence.test.ts` (mirrors into `options` when enabled; leaves `options` untouched when not) and `tests/dao/serverDaoDbImpl.test.ts` (unpacks mirrored keys back to top-level fields on read; leaves them `undefined` when absent).
- Full suite: `npx jest` — 174 suites / 1250 tests passing.
- `npx tsc --noEmit` clean, `npx eslint` clean on all changed files.

Closes the gap left by #1012 for anyone running MCPHub with `DB_URL` configured.