### PR TITLE
fix(security): enforce privileged config check on template import

### DIFF
--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -53,6 +53,7 @@ import {
 import { disconnectUpstreamOAuth } from '../services/upstreamOAuthDisconnectService.js';
 import type { UpstreamOAuthDisconnectScope } from '../services/upstreamOAuthDisconnectService.js';
 import { normalizeServerConfigForPersistence } from '../utils/serverConfigPersistence.js';
+import { isPrivilegedServerConfig } from '../utils/serverConfigValidation.js';
 import { setCachedSystemConfig } from '../utils/systemConfigCache.js';
 import { DEFAULT_INSTALL_BASE_URL, withResolvedInstallBaseUrl } from '../utils/installBaseUrl.js';
 import { previewOpenApiToolStats } from '../services/openApiToolStatsService.js';
@@ -80,15 +81,6 @@ const canAccessServer = (user: RequestUser | null, server: ServerRecord): boolea
   }
 
   return server.owner === user.username;
-};
-
-const isPrivilegedServerConfig = (config: ServerConfig): boolean => {
-  return Boolean(
-    config.type === 'stdio' ||
-      config.command ||
-      (Array.isArray(config.args) && config.args.length > 0) ||
-      (!config.url && !config.openapi?.url && !config.openapi?.schema),
-  );
 };
 
 const loadAuthorizedServer = async (

--- a/src/controllers/templateController.ts
+++ b/src/controllers/templateController.ts
@@ -96,7 +96,7 @@ export const importConfigTemplate = async (req: Request, res: Response): Promise
     const currentUser = (req as any).user;
     const owner = currentUser?.username || 'admin';
 
-    const result = await importTemplate(template, owner);
+    const result = await importTemplate(template, owner, currentUser);
 
     const statusCode = result.success ? 200 : 400;
     res.status(statusCode).json({

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -11,6 +11,7 @@ import {
 } from '../types/index.js';
 import { getServerDao, getGroupDao } from '../dao/index.js';
 import type { ServerConfigWithName } from '../dao/ServerDao.js';
+import { isPrivilegedServerConfig } from '../utils/serverConfigValidation.js';
 import { createGroup } from './groupService.js';
 import { addServer } from './mcpService.js';
 import { getDataService } from './services.js';
@@ -535,10 +536,16 @@ function validateTemplate(data: unknown): data is ConfigTemplate {
 /**
  * Import a configuration template.
  * Creates servers and groups that don't already exist.
+ *
+ * Non-admin callers cannot import privileged (stdio/command-carrying) server
+ * configs; each such server is reported as a failed detail item and skipped.
+ * No `requestingUser` means a trusted system caller — legacy unrestricted
+ * behavior, mirroring `exportTemplate`.
  */
 export async function importTemplate(
   template: unknown,
   owner?: string,
+  requestingUser?: IUser,
 ): Promise<TemplateImportResult> {
   if (!validateTemplate(template)) {
     return {
@@ -567,6 +574,16 @@ export async function importTemplate(
     if (existingServerNames.has(name)) {
       details.push({ type: 'server', name, action: 'skipped', message: 'Server already exists' });
       serversSkipped++;
+      continue;
+    }
+
+    if (requestingUser && !requestingUser.isAdmin && isPrivilegedServerConfig(config)) {
+      details.push({
+        type: 'server',
+        name,
+        action: 'failed',
+        message: 'Only admins can import stdio-based server configurations',
+      });
       continue;
     }
 

--- a/src/utils/serverConfigValidation.ts
+++ b/src/utils/serverConfigValidation.ts
@@ -1,0 +1,16 @@
+import { ServerConfig } from '../types/index.js';
+
+/**
+ * A config is privileged when it can execute arbitrary host commands:
+ * `stdio` servers spawn `command`/`args` locally as the MCPHub process, and
+ * any config without a remote target (url or OpenAPI definition) is treated
+ * as stdio-shaped. Only admins may create or modify such servers.
+ */
+export const isPrivilegedServerConfig = (config: ServerConfig): boolean => {
+  return Boolean(
+    config.type === 'stdio' ||
+      config.command ||
+      (Array.isArray(config.args) && config.args.length > 0) ||
+      (!config.url && !config.openapi?.url && !config.openapi?.schema),
+  );
+};

--- a/tests/services/templateService-import-privilege.test.ts
+++ b/tests/services/templateService-import-privilege.test.ts
@@ -1,0 +1,129 @@
+// Regression tests for #1094: template import must enforce the same
+// privileged-config policy as createServer/updateServer so a non-admin
+// cannot import a stdio server config (arbitrary command execution).
+
+const mockServerDao = { findAll: jest.fn(), findById: jest.fn() };
+const mockGroupDao = { findAll: jest.fn(), findById: jest.fn(), findByName: jest.fn() };
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: () => mockServerDao,
+  getGroupDao: () => mockGroupDao,
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  createGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  addServer: jest.fn(),
+}));
+
+import { importTemplate } from '../../src/services/templateService.js';
+import { addServer } from '../../src/services/mcpService.js';
+
+const alice = { username: 'alice', password: 'x', isAdmin: false };
+const admin = { username: 'admin', password: 'x', isAdmin: true };
+
+const templateWith = (servers: Record<string, unknown>) => ({
+  version: '1.0',
+  name: 'T',
+  createdAt: new Date().toISOString(),
+  servers,
+  groups: [],
+  requiredEnvVars: [],
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockServerDao.findAll.mockResolvedValue([]);
+  mockGroupDao.findByName.mockResolvedValue(null);
+});
+
+describe('template import privileged-config policy (#1094)', () => {
+  it('non-admin import of a stdio server is rejected before persistence', async () => {
+    const result = await importTemplate(
+      templateWith({ evil: { type: 'stdio', command: 'touch', args: ['/tmp/pwned'] } }),
+      'alice',
+      alice,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.serversCreated).toBe(0);
+    expect(result.details).toEqual([
+      {
+        type: 'server',
+        name: 'evil',
+        action: 'failed',
+        message: 'Only admins can import stdio-based server configurations',
+      },
+    ]);
+    expect(addServer).not.toHaveBeenCalled();
+  });
+
+  it('non-admin import of a command-carrying config without stdio type is rejected too', async () => {
+    const result = await importTemplate(
+      templateWith({ sneaky: { command: 'sh', args: ['-c', 'id'] } }),
+      'alice',
+      alice,
+    );
+
+    expect(result.serversCreated).toBe(0);
+    expect(addServer).not.toHaveBeenCalled();
+  });
+
+  it('non-admin import of a remote server still succeeds', async () => {
+    const result = await importTemplate(
+      templateWith({ remote: { type: 'sse', url: 'http://example.com/sse' } }),
+      'alice',
+      alice,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.serversCreated).toBe(1);
+    expect(addServer).toHaveBeenCalledWith(
+      'remote',
+      expect.objectContaining({ type: 'sse', url: 'http://example.com/sse', owner: 'alice' }),
+    );
+  });
+
+  it('non-admin mixed template rejects only the privileged server', async () => {
+    const result = await importTemplate(
+      templateWith({
+        bad: { type: 'stdio', command: 'touch', args: ['/tmp/pwned'] },
+        good: { type: 'sse', url: 'http://example.com/sse' },
+      }),
+      'alice',
+      alice,
+    );
+
+    expect(result.serversCreated).toBe(1);
+    expect(result.details.find((d) => d.name === 'bad')?.action).toBe('failed');
+    expect(result.details.find((d) => d.name === 'good')?.action).toBe('created');
+    expect(addServer).toHaveBeenCalledTimes(1);
+    expect(addServer).toHaveBeenCalledWith('good', expect.anything());
+  });
+
+  it('admin can still import stdio servers', async () => {
+    const result = await importTemplate(
+      templateWith({ local: { type: 'stdio', command: 'npx', args: ['-y', 'mcp-server'] } }),
+      'admin',
+      admin,
+    );
+
+    expect(result.success).toBe(true);
+    expect(addServer).toHaveBeenCalledWith(
+      'local',
+      expect.objectContaining({ command: 'npx', owner: 'admin' }),
+    );
+  });
+
+  it('no requestingUser keeps the legacy unrestricted behavior (system callers)', async () => {
+    const result = await importTemplate(
+      templateWith({ local: { type: 'stdio', command: 'npx' } }),
+      'admin',
+    );
+
+    expect(result.success).toBe(true);
+    expect(addServer).toHaveBeenCalledWith('local', expect.objectContaining({ command: 'npx' }));
+  });
+});

--- a/tests/utils/serverConfigValidation.test.ts
+++ b/tests/utils/serverConfigValidation.test.ts
@@ -1,0 +1,36 @@
+import { isPrivilegedServerConfig } from '../../src/utils/serverConfigValidation.js';
+import { ServerConfig } from '../../src/types/index.js';
+
+const config = (partial: Partial<ServerConfig>): ServerConfig => partial as ServerConfig;
+
+describe('isPrivilegedServerConfig', () => {
+  it('flags explicit stdio type', () => {
+    expect(isPrivilegedServerConfig(config({ type: 'stdio', url: 'http://x' }))).toBe(true);
+  });
+
+  it('flags command-carrying configs even without a stdio type', () => {
+    expect(isPrivilegedServerConfig(config({ command: 'npx' }))).toBe(true);
+    expect(isPrivilegedServerConfig(config({ args: ['-y', 'mcp-server'] }))).toBe(true);
+  });
+
+  it('flags configs without any remote target (implicit stdio shape)', () => {
+    expect(isPrivilegedServerConfig(config({}))).toBe(true);
+  });
+
+  it('allows url-based servers without command or stdio type', () => {
+    expect(isPrivilegedServerConfig(config({ url: 'http://example.com/sse' }))).toBe(false);
+    expect(isPrivilegedServerConfig(config({ type: 'sse', url: 'http://x' }))).toBe(false);
+    expect(isPrivilegedServerConfig(config({ type: 'streamable-http', url: 'http://x' }))).toBe(
+      false,
+    );
+  });
+
+  it('allows OpenAPI servers backed by url or inline schema', () => {
+    expect(isPrivilegedServerConfig(config({ openapi: { url: 'https://x/openapi.json' } }))).toBe(
+      false,
+    );
+    expect(isPrivilegedServerConfig(config({ openapi: { schema: { openapi: '3.1.0' } } }))).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1094.

`POST /api/templates/import` persisted template server configs straight to the DAO without the `isPrivilegedServerConfig` check enforced by `createServer`, `batchCreateServers`, and `updateServer`. Any authenticated non-admin could import a `stdio` server with arbitrary `command`/`args`, own it, and enable it via `POST /api/servers/:name/toggle` — `StdioClientTransport` then spawns the command as the MCPHub process (RCE). Because imported servers default to `enabled: true`, the command also runs automatically on the next backend restart even without the toggle call. Deployments with Better Auth social login turn this into an unauthenticated-to-RCE chain (`isAdmin` defaults to `false` for new users).

### Changes

- Extract `isPrivilegedServerConfig` from `serverController.ts` into `src/utils/serverConfigValidation.ts` and reuse it in the controller (single source of truth).
- `importTemplate` gains a `requestingUser?: IUser` parameter, following the same convention as `exportTemplate` / `exportGroupTemplate` (no user = trusted system caller, legacy behavior preserved).
- For non-admin callers, privileged configs are rejected per-item before persistence: each is reported as a `failed` entry in the existing `TemplateImportResult.details`, and legitimate (remote/openapi) servers in the same template still import.
- `importConfigTemplate` passes the authenticated user through.

## Behavior change

- Non-admin `POST /api/templates/import` with a stdio/command-carrying server entry now returns per-item `failed` details ("Only admins can import stdio-based server configurations") instead of creating the server. Mixed templates import their non-privileged entries as before. Admin and CLI/system behavior unchanged.

## Tests

All pre-commit gates pass: `pnpm lint`, `pnpm test:ci` (178 suites / 1301 tests), `pnpm build`.

- New `tests/services/templateService-import-privilege.test.ts`:
  - non-admin stdio import rejected before persistence (`addServer` never called)
  - command-carrying config without an explicit `stdio` type also rejected
  - non-admin import of a remote (`sse`) server still succeeds, owner preserved
  - mixed template: only the privileged entry fails, the rest import
  - admin import of stdio unchanged
  - no `requestingUser` keeps legacy unrestricted behavior (system callers)
- New `tests/utils/serverConfigValidation.test.ts`: branch coverage of the shared predicate (stdio type, command/args, no-remote-target shape, url/openapi allowances).
- Existing `templateService` and `templateService-export-auth` suites pass unchanged.

Not yet exercised end-to-end in a running dev instance; a manual check worth doing before release: import a stdio template as a non-admin user (expect per-item failure, no server created, no spawn in logs) and as admin (expect unchanged behavior).

## Security notes

The issue is public and contains full reproduction details, so there is nothing left to embargo; once this merges and ships, #1094 can be closed with credit to @Captaince for the well-documented report.