### PR TITLE
feat: validate server names against the MCP tool-name charset (#1076)

### DIFF
--- a/frontend/src/components/RegistryServerDetail.tsx
+++ b/frontend/src/components/RegistryServerDetail.tsx
@@ -8,6 +8,7 @@ import {
   ServerConfig,
 } from '@/types';
 import ServerForm from './ServerForm';
+import { slugifyServerName } from '@/utils/serverName';
 
 interface RegistryServerDetailProps {
   serverEntry: RegistryServerEntry;
@@ -146,7 +147,10 @@ const RegistryServerDetail: React.FC<RegistryServerDetailProps> = ({
 
       const command = getCommand(pkg.registryType);
       return {
-        name: server.name,
+        // Registry names are reverse-DNS (`io.github.user/weather`); the `/`
+        // is not part of the MCP tool-name charset, so slugify it. The field
+        // stays editable in the form.
+        name: slugifyServerName(server.name),
         status: 'disconnected' as const,
         config: {
           type: 'stdio' as const,
@@ -170,7 +174,7 @@ const RegistryServerDetail: React.FC<RegistryServerDetailProps> = ({
       const transportType = remote.type === 'sse' ? ('sse' as const) : ('streamable-http' as const);
 
       return {
-        name: server.name,
+        name: slugifyServerName(server.name),
         status: 'disconnected' as const,
         config: {
           type: transportType,

--- a/frontend/src/components/ServerForm.tsx
+++ b/frontend/src/components/ServerForm.tsx
@@ -15,6 +15,11 @@ import {
   isOpenApiSourceReady,
   shouldAutoAnalyzeOpenApiSource,
 } from '../utils/openApiSourceAnalysis';
+import {
+  isValidServerName,
+  SERVER_NAME_MAX_LENGTH,
+  SERVER_NAME_PATTERN,
+} from '../utils/serverName';
 
 interface ServerFormProps {
   onSubmit: (payload: any) => void;
@@ -32,6 +37,11 @@ const ServerForm = ({
   formError = null,
 }: ServerFormProps) => {
   const { t } = useTranslation();
+
+  // Native `pattern`/`maxLength` on the name field are enforced on create and
+  // on edit of an already-valid name. Editing a legacy (invalid) name without
+  // changing it stays allowed, mirroring the backend create/rename-only rule.
+  const enforceNamePattern = !initialData?.name || isValidServerName(initialData.name);
 
   // Determine the initial server type from the initialData
   const getInitialServerType = () => {
@@ -496,6 +506,16 @@ const ServerForm = ({
     e.preventDefault();
     setError(null);
 
+    // Server names become part of downstream tool identifiers, so they must
+    // satisfy the MCP tool-name charset. Mirror the backend rule: enforce on
+    // create and on rename, but let a no-op edit of a legacy (invalid) name
+    // through so existing working installations can still be maintained.
+    const isNameChanging = !initialData?.name || formData.name !== initialData.name;
+    if (isNameChanging && !isValidServerName(formData.name)) {
+      setError(t('server.nameInvalid'));
+      return;
+    }
+
     try {
       const payload = buildServerPayload({
         formData,
@@ -546,8 +566,14 @@ const ServerForm = ({
                 onChange={handleInputChange}
                 className="w-full py-2 px-3 form-input"
                 placeholder="e.g.: time-mcp"
+                pattern={enforceNamePattern ? SERVER_NAME_PATTERN.source : undefined}
+                maxLength={enforceNamePattern ? SERVER_NAME_MAX_LENGTH : undefined}
+                title={t('server.nameInvalid')}
                 required
               />
+              <p className="text-xs text-[var(--hub-ink-3)] mt-1">
+                {t('server.nameInvalid')}
+              </p>
             </div>
 
             <div className="md:col-span-2">

--- a/frontend/src/pages/MarketPage.tsx
+++ b/frontend/src/pages/MarketPage.tsx
@@ -14,6 +14,7 @@ import { useCloudData } from '@/hooks/useCloudData';
 import { useRegistryData } from '@/hooks/useRegistryData';
 import { useToast } from '@/contexts/ToastContext';
 import { apiPost } from '@/utils/fetchInterceptor';
+import { slugifyServerName } from '@/utils/serverName';
 import MarketServerCard from '@/components/MarketServerCard';
 import MarketServerDetail from '@/components/MarketServerDetail';
 import CloudServerCard from '@/components/CloudServerCard';
@@ -214,7 +215,9 @@ const MarketPage: React.FC = () => {
   const handleRegistryInstall = async (server: RegistryServerData, config: ServerConfig) => {
     try {
       setInstalling(true);
-      const payload = { name: server.name, config };
+      // Registry names are reverse-DNS (`io.github.user/weather`); the `/` is
+      // not part of the MCP tool-name charset, so slugify before creating.
+      const payload = { name: slugifyServerName(server.name), config };
       const result = await apiPost('/servers', payload);
       if (!result.success) {
         showToast(result?.message || t('server.addError'), 'error');

--- a/frontend/src/utils/serverName.ts
+++ b/frontend/src/utils/serverName.ts
@@ -1,0 +1,38 @@
+/**
+ * Frontend server-name helpers.
+ *
+ * Server names become part of downstream tool identifiers
+ * (`${serverName}-${toolName}`), so the MCP tool-name charset applies to them
+ * indirectly. These helpers mirror the backend rule in
+ * `src/utils/serverNameValidation.ts`.
+ */
+
+export const SERVER_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export const SERVER_NAME_MAX_LENGTH = 128;
+
+export const isValidServerName = (name: string): boolean => {
+  const trimmed = name.trim();
+  return (
+    trimmed.length > 0 &&
+    trimmed.length <= SERVER_NAME_MAX_LENGTH &&
+    SERVER_NAME_PATTERN.test(trimmed) &&
+    !trimmed.includes('..')
+  );
+};
+
+/**
+ * Turn an arbitrary string (e.g. an official Registry reverse-DNS name like
+ * `io.github.user/weather`) into a charset-safe server name. Characters
+ * outside `[A-Za-z0-9._-]` become `-`; consecutive dots collapse; leading /
+ * trailing hyphens are trimmed and the result is length-capped. Falls back to
+ * `'server'` for an empty result.
+ */
+export const slugifyServerName = (name: string): string => {
+  const slugged = name
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, SERVER_NAME_MAX_LENGTH);
+  return slugged || 'server';
+};

--- a/locales/en.json
+++ b/locales/en.json
@@ -124,6 +124,7 @@
     "tools": "Tools",
     "prompts": "Prompts",
     "name": "Server Name",
+    "nameInvalid": "Server name can only contain letters, numbers, dots, underscores, and hyphens (no spaces or special characters)",
     "description": "Server Note",
     "descriptionPlaceholder": "Optional note to describe this server",
     "url": "Server URL",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -124,6 +124,7 @@
     "tools": "Outils",
     "prompts": "Invites",
     "name": "Nom du serveur",
+    "nameInvalid": "Le nom du serveur ne peut contenir que des lettres, chiffres, points, underscores et traits d'union (ni espaces ni caractères spéciaux)",
     "description": "Note du serveur",
     "descriptionPlaceholder": "Optionnel : décrivez l'utilité de ce serveur",
     "url": "URL du serveur",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -124,6 +124,7 @@
     "tools": "Araçlar",
     "prompts": "İstekler",
     "name": "Sunucu Adı",
+    "nameInvalid": "Sunucu adı yalnızca harf, rakam, nokta, alt çizgi ve tire içerebilir (boşluk veya özel karakter içeremez)",
     "description": "Sunucu Notu",
     "descriptionPlaceholder": "İsteğe bağlı: Bu sunucunun ne işe yaradığını yazın",
     "url": "Sunucu URL'si",

--- a/locales/zh.json
+++ b/locales/zh.json
@@ -124,6 +124,7 @@
     "tools": "工具",
     "prompts": "提示词",
     "name": "服务器名称",
+    "nameInvalid": "服务器名称只能包含字母、数字、点、下划线和连字符（不能包含空格或特殊字符）",
     "description": "服务器注释",
     "descriptionPlaceholder": "可选：记录这个服务器的用途说明",
     "url": "服务器 URL",

--- a/src/controllers/mcpbController.ts
+++ b/src/controllers/mcpbController.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import AdmZip from 'adm-zip';
 import { ApiResponse } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import { validateServerName } from '../utils/serverNameValidation.js';
 
 // Configure multer for file uploads
 const storage = multer.diskStorage({
@@ -43,30 +44,18 @@ const upload = multer({
 export const uploadMiddleware = upload.single('mcpbFile');
 
 const MCPB_UPLOAD_DIR = path.join('data', 'uploads', 'mcpb');
-const MCPB_SERVER_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 const getMcpbUploadDir = (): string => path.join(process.cwd(), MCPB_UPLOAD_DIR);
 
 const validateMcpbServerName = (serverName: unknown): string => {
-  if (typeof serverName !== 'string') {
-    throw new Error('Invalid manifest: missing name');
-  }
-
-  const normalizedServerName = serverName.trim();
-  if (!normalizedServerName) {
-    throw new Error('Invalid manifest: missing name');
-  }
-
-  if (
-    !MCPB_SERVER_NAME_PATTERN.test(normalizedServerName) ||
-    normalizedServerName.includes('..') ||
-    normalizedServerName.includes(path.posix.sep) ||
-    normalizedServerName.includes(path.win32.sep)
-  ) {
+  // Reuse the shared server-name rule (charset + `..`/path-separator safety)
+  // while keeping the MCPB-specific error wording.
+  const validation = validateServerName(serverName);
+  if (!validation.valid) {
     throw new Error('Invalid manifest: name contains unsafe characters');
   }
 
-  return normalizedServerName;
+  return validation.normalized as string;
 };
 
 const resolveMcpbServerExtractDir = (baseDir: string, serverName: string): string => {

--- a/src/controllers/serverController.ts
+++ b/src/controllers/serverController.ts
@@ -54,6 +54,7 @@ import { disconnectUpstreamOAuth } from '../services/upstreamOAuthDisconnectServ
 import type { UpstreamOAuthDisconnectScope } from '../services/upstreamOAuthDisconnectService.js';
 import { normalizeServerConfigForPersistence } from '../utils/serverConfigPersistence.js';
 import { isPrivilegedServerConfig } from '../utils/serverConfigValidation.js';
+import { validateServerName } from '../utils/serverNameValidation.js';
 import { setCachedSystemConfig } from '../utils/systemConfigCache.js';
 import { DEFAULT_INSTALL_BASE_URL, withResolvedInstallBaseUrl } from '../utils/installBaseUrl.js';
 import { previewOpenApiToolStats } from '../services/openApiToolStatsService.js';
@@ -511,13 +512,15 @@ export const previewOpenApiToolStatsHandler = async (
 export const createServer = async (req: Request, res: Response): Promise<void> => {
   try {
     const { name, config } = req.body as AddServerRequest;
-    if (!name || typeof name !== 'string') {
+    const nameValidation = validateServerName(name);
+    if (!nameValidation.valid) {
       res.status(400).json({
         success: false,
-        message: 'Server name is required',
+        message: nameValidation.message,
       });
       return;
     }
+    const serverName = nameValidation.normalized as string;
 
     if (!config || typeof config !== 'object') {
       res.status(400).json({
@@ -612,13 +615,13 @@ export const createServer = async (req: Request, res: Response): Promise<void> =
 
     assignServerOwner(req, normalizedConfig);
 
-    const result = await addServer(name, normalizedConfig);
+    const result = await addServer(serverName, normalizedConfig);
     if (result.success) {
       res.json({
         success: true,
         message: 'Server added successfully',
       });
-      notifyToolChanged(name, { reportEmbeddingProgress: true }).catch((error) => {
+      notifyToolChanged(serverName, { reportEmbeddingProgress: true }).catch((error) => {
         logger.error('Failed to trigger embedding sync for created server:', error);
       });
     } else {
@@ -661,9 +664,10 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
     const validateServerConfig = (
       name: string,
       config: ServerConfig,
-    ): { valid: boolean; message?: string } => {
-      if (!name || typeof name !== 'string') {
-        return { valid: false, message: 'Server name is required and must be a string' };
+    ): { valid: boolean; message?: string; normalizedName?: string } => {
+      const nameValidation = validateServerName(name);
+      if (!nameValidation.valid) {
+        return { valid: false, message: nameValidation.message };
       }
 
       if (!config || typeof config !== 'object') {
@@ -729,7 +733,7 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
         return { valid: false, message: 'Headers are not supported for stdio server type' };
       }
 
-      return { valid: true };
+      return { valid: true, normalizedName: nameValidation.normalized };
     };
 
     // Process each server
@@ -756,6 +760,8 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
         continue;
       }
 
+      const serverName = validation.normalizedName ?? name;
+
       try {
         // Set default keep-alive interval for SSE servers if not specified
         const normalizedConfig = normalizeServerConfigForPersistence(config);
@@ -769,7 +775,7 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
 
         if (isPrivilegedServerConfig(normalizedConfig) && currentUser?.isAdmin !== true) {
           results.push({
-            name,
+            name: serverName,
             success: false,
             message: 'Only admins can create or modify stdio-based servers',
           });
@@ -783,16 +789,16 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
           : defaultOwner;
 
         // Attempt to add server
-        const result = await addServer(name, normalizedConfig);
+        const result = await addServer(serverName, normalizedConfig);
         if (result.success) {
           results.push({
-            name,
+            name: serverName,
             success: true,
           });
           successCount++;
         } else {
           results.push({
-            name,
+            name: serverName,
             success: false,
             message: result.message || 'Failed to add server',
           });
@@ -800,7 +806,7 @@ export const batchCreateServers = async (req: Request, res: Response): Promise<v
         }
       } catch (error) {
         results.push({
-          name,
+          name: serverName,
           success: false,
           message: error instanceof Error ? error.message : 'Internal server error',
         });
@@ -998,21 +1004,35 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
     // Check if server name is being changed
     const isRenaming = newName && newName !== name;
 
+    // Final server name used for the rest of the update flow (the new name when
+    // renaming, otherwise the original name).
+    let finalName = name;
+
     // If renaming, validate the new name and update references
     if (isRenaming) {
       const serverDao = getServerDao();
-
-      // Check if new name already exists
-      if (await serverDao.exists(newName)) {
+      const nameValidation = validateServerName(newName);
+      if (!nameValidation.valid) {
         res.status(400).json({
           success: false,
-          message: `Server name '${newName}' already exists`,
+          message: nameValidation.message,
+        });
+        return;
+      }
+      const targetName = nameValidation.normalized as string;
+      finalName = targetName;
+
+      // Check if new name already exists
+      if (await serverDao.exists(targetName)) {
+        res.status(400).json({
+          success: false,
+          message: `Server name '${targetName}' already exists`,
         });
         return;
       }
 
       // Rename the server
-      const renamed = await serverDao.rename(name, newName);
+      const renamed = await serverDao.rename(name, targetName);
       if (!renamed) {
         res.status(404).json({
           success: false,
@@ -1030,11 +1050,11 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
 
       // Update references in groups
       const groupDao = getGroupDao();
-      await groupDao.updateServerName(name, newName);
+      await groupDao.updateServerName(name, targetName);
 
       // Update references in bearer keys
       const bearerKeyDao = getBearerKeyDao();
-      await bearerKeyDao.updateServerName(name, newName);
+      await bearerKeyDao.updateServerName(name, targetName);
 
       // Drop embeddings stored under the old name so search_tools does not
       // advertise phantom tools; addOrUpdateServer below regenerates them
@@ -1048,9 +1068,6 @@ export const updateServer = async (req: Request, res: Response): Promise<void> =
         });
       }
     }
-
-    // Use the final server name (new name if renaming, otherwise original name)
-    const finalName = isRenaming ? newName : name;
 
     // Fast path: if no connection-relevant field changed, persist and update
     // in-memory access metadata without tearing down the runtime. This covers

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -41,6 +41,7 @@ import {
 } from '../types/index.js';
 import { expandEnvVars, replaceEnvVars, getNameSeparator } from '../config/index.js';
 import config from '../config/index.js';
+import { validateServerName } from '../utils/serverNameValidation.js';
 import { getGroup } from './sseService.js';
 import { getServerConfigInGroup, normalizeGroupServers } from './groupService.js';
 import { removeServerToolEmbeddings, saveToolsAsVectorEmbeddings } from './vectorSearchService.js';
@@ -1571,6 +1572,18 @@ export const initializeClientsFromSettings = async (
   try {
     for (const conf of allServers) {
       const { name } = conf;
+
+      // Names loaded from disk are not rejected (that would break existing
+      // configs on upgrade), but a strict client may drop the whole tools/list
+      // if the server name produces a non-conforming downstream tool name.
+      if (isInit) {
+        const nameValidation = validateServerName(name);
+        if (!nameValidation.valid) {
+          logger.warn(
+            `Server name '${name}' does not match the MCP tool-name charset (${nameValidation.message}); downstream tool names may be rejected by strict clients`,
+          );
+        }
+      }
 
       // Expand environment variables in all configuration values
       const expandedConf = replaceEnvVars(conf as any) as ServerConfigWithName;

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -12,6 +12,7 @@ import {
 import { getServerDao, getGroupDao } from '../dao/index.js';
 import type { ServerConfigWithName } from '../dao/ServerDao.js';
 import { isPrivilegedServerConfig } from '../utils/serverConfigValidation.js';
+import { validateServerName } from '../utils/serverNameValidation.js';
 import { createGroup } from './groupService.js';
 import { addServer } from './mcpService.js';
 import { getDataService } from './services.js';
@@ -588,10 +589,24 @@ export async function importTemplate(
       continue;
     }
 
-    if (requestingUser && !requestingUser.isAdmin && isPrivilegedServerConfig(config)) {
+    // Server names become part of downstream tool identifiers, so they must
+    // satisfy the same charset rule as every other create path.
+    const nameValidation = validateServerName(name);
+    if (!nameValidation.valid) {
       details.push({
         type: 'server',
         name,
+        action: 'failed',
+        message: nameValidation.message || 'Invalid server name',
+      });
+      continue;
+    }
+    const serverName = nameValidation.normalized as string;
+
+    if (requestingUser && !requestingUser.isAdmin && isPrivilegedServerConfig(config)) {
+      details.push({
+        type: 'server',
+        name: serverName,
         action: 'failed',
         message: 'Only admins can import stdio-based server configurations',
       });
@@ -604,13 +619,13 @@ export async function importTemplate(
         enabled: config.enabled ?? true,
         owner: owner || 'admin',
       };
-      await addServer(name, serverConfig);
-      details.push({ type: 'server', name, action: 'created' });
+      await addServer(serverName, serverConfig);
+      details.push({ type: 'server', name: serverName, action: 'created' });
       serversCreated++;
     } catch (error) {
       details.push({
         type: 'server',
-        name,
+        name: serverName,
         action: 'failed',
         message: error instanceof Error ? error.message : 'Unknown error',
       });

--- a/src/utils/serverNameValidation.ts
+++ b/src/utils/serverNameValidation.ts
@@ -1,0 +1,73 @@
+/**
+ * Server name validation.
+ *
+ * Server names are embedded into downstream tool/prompt identifiers as
+ * `${serverName}${nameSeparator}${toolName}` (see mcpService), so the MCP
+ * tool-name charset — `A-Za-z0-9._-`, 1-128 chars, no spaces or other special
+ * characters — applies to server names indirectly. The MCPB upload path
+ * already enforced this pattern locally; this module lifts it into a shared
+ * helper used by every create/rename path.
+ *
+ * Names loaded from disk (e.g. `mcp_settings.json`) are NOT rejected here —
+ * callers only warn about them at startup, so existing configurations keep
+ * working after upgrade.
+ */
+
+export const SERVER_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export const SERVER_NAME_MAX_LENGTH = 128;
+
+export interface ServerNameValidationResult {
+  valid: boolean;
+  /** Human-readable error message when invalid; the caller decides exposure. */
+  message?: string;
+  /** Trimmed name when valid. */
+  normalized?: string;
+}
+
+export const validateServerName = (name: unknown): ServerNameValidationResult => {
+  if (typeof name !== 'string' || name.trim() === '') {
+    return { valid: false, message: 'Server name is required' };
+  }
+
+  const normalized = name.trim();
+
+  if (normalized.length > SERVER_NAME_MAX_LENGTH) {
+    return {
+      valid: false,
+      message: `Server name must be at most ${SERVER_NAME_MAX_LENGTH} characters`,
+    };
+  }
+
+  if (!SERVER_NAME_PATTERN.test(normalized)) {
+    return {
+      valid: false,
+      message:
+        'Server name can only contain letters, numbers, dots, underscores, and hyphens (no spaces or other special characters)',
+    };
+  }
+
+  // `..` is allowed by the charset but rejected because names are used in
+  // filesystem paths (e.g. the MCPB upload directory).
+  if (normalized.includes('..')) {
+    return { valid: false, message: 'Server name cannot contain consecutive dots' };
+  }
+
+  return { valid: true, normalized };
+};
+
+/**
+ * Turn an arbitrary string (e.g. an official Registry reverse-DNS name like
+ * `io.github.user/weather`) into a charset-safe server name. Characters
+ * outside `[A-Za-z0-9._-]` become `-`; consecutive dots collapse; leading /
+ * trailing hyphens are trimmed and the result is length-capped. Falls back to
+ * `'server'` for an empty result.
+ */
+export const slugifyServerName = (name: string): string => {
+  const slugged = name
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, SERVER_NAME_MAX_LENGTH);
+  return slugged || 'server';
+};

--- a/tests/controllers/serverController.test.ts
+++ b/tests/controllers/serverController.test.ts
@@ -343,6 +343,154 @@ describe('serverController - stdio servers without arguments', () => {
   });
 });
 
+describe('serverController - server name charset validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAddServer.mockResolvedValue({ success: true });
+  });
+
+  const createResponse = () => {
+    const json = jest.fn();
+    const status = jest.fn().mockReturnThis();
+    return { json, status, response: { json, status } as unknown as Response };
+  };
+
+  const adminUser = {
+    username: 'admin',
+    isAdmin: true,
+  };
+
+  const validConfig = {
+    type: 'sse',
+    url: 'http://localhost:3001/mcp',
+  };
+
+  it('rejects a server name containing spaces on create', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      body: { name: 'my server', config: validConfig },
+      user: adminUser,
+    } as unknown as Request;
+
+    await createServer(request, response);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('only contain letters'),
+      }),
+    );
+    expect(mockAddServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a server name with non-ASCII (CJK) characters on create', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      body: { name: '我的伺服器', config: validConfig },
+      user: adminUser,
+    } as unknown as Request;
+
+    await createServer(request, response);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(mockAddServer).not.toHaveBeenCalled();
+  });
+
+  it('rejects a registry-style reverse-DNS name on create (path separator)', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      body: { name: 'io.github.user/weather', config: validConfig },
+      user: adminUser,
+    } as unknown as Request;
+
+    await createServer(request, response);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(mockAddServer).not.toHaveBeenCalled();
+  });
+
+  it('accepts a trimmed valid name on create', async () => {
+    const { status, response } = createResponse();
+    const request = {
+      body: { name: '  weather-server  ', config: validConfig },
+      user: adminUser,
+    } as unknown as Request;
+
+    await createServer(request, response);
+
+    expect(status).not.toHaveBeenCalledWith(400);
+    expect(mockAddServer).toHaveBeenCalledWith(
+      'weather-server',
+      expect.objectContaining({ type: 'sse' }),
+    );
+  });
+
+  it('reports an invalid name as a failed item in batch import', async () => {
+    const { json, status, response } = createResponse();
+    const request = {
+      body: {
+        servers: [
+          { name: 'ok-server', config: validConfig },
+          { name: 'bad server', config: validConfig },
+        ],
+      },
+      user: adminUser,
+    } as unknown as Request;
+
+    await batchCreateServers(request, response);
+
+    expect(status).toHaveBeenCalledWith(207);
+    expect(mockAddServer).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          successCount: 1,
+          failureCount: 1,
+          results: expect.arrayContaining([
+            expect.objectContaining({
+              name: 'bad server',
+              success: false,
+              message: expect.stringContaining('only contain letters'),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it('rejects an invalid newName when renaming', async () => {
+    mockServerDao.findById.mockResolvedValue({
+      name: 'old-server',
+      type: 'sse',
+      url: 'http://localhost:3001/mcp',
+      owner: 'admin',
+      visibility: 'private',
+    });
+
+    const { json, status, response } = createResponse();
+    const request = {
+      params: { name: 'old-server' },
+      body: {
+        config: { type: 'sse', url: 'http://localhost:3001/mcp' },
+        newName: 'new server',
+      },
+      user: adminUser,
+    } as unknown as Request;
+
+    await updateServer(request, response);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(mockServerDao.rename).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: expect.stringContaining('only contain letters'),
+      }),
+    );
+  });
+});
+
 describe('serverController - getAllSettings', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/tests/services/templateService-import-privilege.test.ts
+++ b/tests/services/templateService-import-privilege.test.ts
@@ -127,3 +127,27 @@ describe('template import privileged-config policy (#1094)', () => {
     expect(addServer).toHaveBeenCalledWith('local', expect.objectContaining({ command: 'npx' }));
   });
 });
+
+describe('template import server-name charset validation', () => {
+  it('rejects servers whose names do not match the MCP tool-name charset', async () => {
+    const result = await importTemplate(
+      templateWith({
+        'bad server': { type: 'sse', url: 'http://example.com/sse' },
+        'io.github.user/weather': { type: 'sse', url: 'http://example.com/sse' },
+        good: { type: 'sse', url: 'http://example.com/sse' },
+      }),
+      'admin',
+      admin,
+    );
+
+    expect(result.serversCreated).toBe(1);
+    expect(result.details.find((d) => d.name === 'bad server')?.action).toBe('failed');
+    expect(result.details.find((d) => d.name === 'io.github.user/weather')?.action).toBe('failed');
+    expect(result.details.find((d) => d.name === 'good')?.action).toBe('created');
+    expect(addServer).toHaveBeenCalledTimes(1);
+    expect(addServer).toHaveBeenCalledWith(
+      'good',
+      expect.objectContaining({ type: 'sse', url: 'http://example.com/sse' }),
+    );
+  });
+});

--- a/tests/utils/serverNameValidation.test.ts
+++ b/tests/utils/serverNameValidation.test.ts
@@ -1,0 +1,106 @@
+import {
+  validateServerName,
+  slugifyServerName,
+  SERVER_NAME_PATTERN,
+  SERVER_NAME_MAX_LENGTH,
+} from '../../src/utils/serverNameValidation.js';
+
+describe('validateServerName', () => {
+  it('accepts charset-safe names', () => {
+    expect(validateServerName('weather-server')).toEqual({
+      valid: true,
+      normalized: 'weather-server',
+    });
+    expect(validateServerName('io.github.user-weather')).toEqual({
+      valid: true,
+      normalized: 'io.github.user-weather',
+    });
+    expect(validateServerName('foo_1.BAR')).toEqual({
+      valid: true,
+      normalized: 'foo_1.BAR',
+    });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(validateServerName('  weather-server  ')).toEqual({
+      valid: true,
+      normalized: 'weather-server',
+    });
+  });
+
+  it('rejects empty / non-string / whitespace-only names', () => {
+    expect(validateServerName(undefined).valid).toBe(false);
+    expect(validateServerName(null).valid).toBe(false);
+    expect(validateServerName('').valid).toBe(false);
+    expect(validateServerName('   ').valid).toBe(false);
+    expect(validateServerName(12345).valid).toBe(false);
+  });
+
+  it('rejects names with spaces', () => {
+    const result = validateServerName('my server');
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('only contain letters');
+  });
+
+  it('rejects CJK / non-ASCII names', () => {
+    expect(validateServerName('我的伺服器').valid).toBe(false);
+    expect(validateServerName('héllo').valid).toBe(false);
+  });
+
+  it('rejects names containing the path separator', () => {
+    expect(validateServerName('io.github.user/weather').valid).toBe(false);
+    expect(validateServerName('a\\b').valid).toBe(false);
+  });
+
+  it('rejects consecutive dots', () => {
+    const result = validateServerName('a..b');
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain('consecutive dots');
+  });
+
+  it('rejects names longer than the max length', () => {
+    const longName = 'a'.repeat(SERVER_NAME_MAX_LENGTH + 1);
+    const result = validateServerName(longName);
+    expect(result.valid).toBe(false);
+    expect(result.message).toContain(`${SERVER_NAME_MAX_LENGTH} characters`);
+  });
+
+  it('accepts a name at exactly the max length', () => {
+    expect(validateServerName('a'.repeat(SERVER_NAME_MAX_LENGTH)).valid).toBe(true);
+  });
+});
+
+describe('SERVER_NAME_PATTERN', () => {
+  it('matches the documented charset', () => {
+    for (const c of 'abcXYZ0123._-') {
+      expect(SERVER_NAME_PATTERN.test(c)).toBe(true);
+    }
+    for (const c of ' /\\,é中文!@#') {
+      expect(SERVER_NAME_PATTERN.test(c)).toBe(false);
+    }
+  });
+});
+
+describe('slugifyServerName', () => {
+  it('turns a reverse-DNS registry name into a charset-safe name', () => {
+    expect(slugifyServerName('io.github.user/weather')).toBe('io.github.user-weather');
+  });
+
+  it('replaces other unsafe characters with hyphens', () => {
+    expect(slugifyServerName('My Server 中文')).toBe('My-Server');
+    expect(slugifyServerName('a b/c')).toBe('a-b-c');
+  });
+
+  it('collapses consecutive dots and trims leading/trailing hyphens', () => {
+    expect(slugifyServerName('--foo..bar--')).toBe('foo.bar');
+  });
+
+  it('caps the result length', () => {
+    const result = slugifyServerName('x'.repeat(SERVER_NAME_MAX_LENGTH + 50));
+    expect(result.length).toBe(SERVER_NAME_MAX_LENGTH);
+  });
+
+  it('falls back to "server" for an empty result', () => {
+    expect(slugifyServerName('///')).toBe('server');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the actionable part of #1076 (the separator-ambiguity point stays as a follow-up discussion).

Server names are embedded into downstream tool identifiers as `${serverName}${nameSeparator}${toolName}` (`mcpService.ts:632/698/1733/4125`), so the MCP tool-name charset — `A-Za-z0-9._-`, no spaces or special characters — applies to server names indirectly. A name like `我的伺服器` or `my server` produces a downstream tool name a strict client may reject, dropping the whole `tools/list`. This PR lifts the rule the MCPB upload path already had into a shared validator and enforces it on every create/rename path, while **not** rejecting names loaded from disk.

## Behavior change

- **Backend** — new `src/utils/serverNameValidation.ts`:
  - `validateServerName()` — charset `^[A-Za-z0-9._-]+$`, max 128 chars, no `..`, trims whitespace.
  - `slugifyServerName()` — for registry names.
- `createServer`, `batchCreateServers`, `updateServer` (rename) now reject invalid names with a 400.
- `templateService.importTemplate` reports invalid server names as per-server failed details.
- `mcpbController` reuses the shared validator (same "Invalid manifest" wording — no behavior change).
- `mcpService` warns **once at startup** for invalid names loaded from disk (`isInit`), so existing working configs are not broken on upgrade.
- **Frontend** — `ServerForm` name field gets `pattern`/`maxLength`/inline message; enforced on create and rename only, so a no-op edit of a legacy invalid name still works (mirrors backend create/rename-only rule). Registry installs slugify `io.github.user/weather` → `io.github.user-weather` (field stays editable).
- `locales/{en,zh,fr,tr}.json` — new `server.nameInvalid`.

## Tests

- New `tests/utils/serverNameValidation.test.ts` (validator + slugifier + charset).
- `serverController.test.ts` — create rejects space/CJK/`/` names, batch partial-failure reporting, rename rejects invalid `newName`, trimmed valid name accepted.
- `templateService-import-privilege.test.ts` — invalid template server names skipped as failed details.
- `mcpbController.test.ts` unchanged and passing (shared-validator refactor preserves behavior).

## Verification

- `pnpm lint` ✅
- `pnpm backend:build` + `pnpm frontend:build` ✅
- `pnpm test:ci` — 1338 passed; the only failures are 4 pre-existing environmental timeouts in `tests/integration/sse-service-real-client.test.ts` (real TCP/OAuth server creation hangs in sandboxed environments; reproduces on clean `main`).

## Follow-ups (not in this PR)

- Separator ambiguity: with the default `-`, `a`+`b-c` and `a-b`+`c` both yield `a-b-c` and can silently route to the wrong server — independent of charset validation (see issue point 4).
- Registry install modal pre-fills a slugified name, but an edited name is still ignored by the install handler (`onInstall` passes the registry `server.name`) — pre-existing quirk, out of scope.
