### PR TITLE
fix: re-read mcp_settings.json on external edits to match server definitions

### DIFF
--- a/docs/configuration/mcp-settings.mdx
+++ b/docs/configuration/mcp-settings.mdx
@@ -494,6 +494,16 @@ Complement `mcp_settings.json` with server metadata:
 }
 ```
 
+## Editing mcp_settings.json while running
+
+In file mode, MCPHub re-reads `mcp_settings.json` when it changes, without a restart:
+
+- **Server definitions and credentials** are picked up on the next server reload — `POST /api/servers/:name/reload`, the `reload` button in the dashboard, or `mcphub servers reload <name>`.
+- **System settings** (`systemConfig`, e.g. `nameSeparator`) are picked up on the next read once the file has changed.
+- Settings that are read once at process startup still require a restart to take effect: the Better Auth bootstrap, `skipAuth`, the listening port, and anything driven by environment variables.
+
+In database mode (`USE_DB=true`), `mcp_settings.json` is only a one-time seed; edit configuration through the dashboard, API, or CLI instead.
+
 {/* ### Access Control
 
 | Access Level    | Description                |

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -43,15 +43,27 @@ const ensureOAuthServerDefaults = (settings: McpSettings): boolean => {
 
 // Settings cache
 let settingsCache: McpSettings | null = null;
+// mtime of the settings file our cache snapshot was read from. The file is
+// re-read when it is newer, mirroring JsonFileBaseDao so system settings do
+// not behave differently from server definitions on external edits (#1081).
+let lastModified = 0;
 
 export const getSettingsPath = (): string => {
   return getConfigFilePath('mcp_settings.json', 'Settings');
 };
 
 export const loadOriginalSettings = (): McpSettings => {
-  // If cache exists, return cached data directly
+  // If cache exists and the file hasn't changed, return cached data directly.
   if (settingsCache) {
-    return settingsCache;
+    try {
+      const stats = fs.statSync(getSettingsPath());
+      if (lastModified >= stats.mtime.getTime()) {
+        return settingsCache;
+      }
+    } catch {
+      // Missing/unreadable file — keep serving the cached snapshot.
+      return settingsCache;
+    }
   }
 
   const settingsPath = getSettingsPath();
@@ -62,6 +74,7 @@ export const loadOriginalSettings = (): McpSettings => {
     ensureOAuthServerDefaults(defaultSettings);
     // Cache default settings
     settingsCache = defaultSettings;
+    lastModified = Date.now();
     return defaultSettings;
   }
 
@@ -83,6 +96,11 @@ export const loadOriginalSettings = (): McpSettings => {
 
     // Update cache
     settingsCache = settings;
+    try {
+      lastModified = fs.statSync(settingsPath).mtime.getTime();
+    } catch {
+      lastModified = Date.now();
+    }
 
     logger.log(`Loaded settings from ${settingsPath}`);
     return settings;
@@ -103,6 +121,7 @@ export const saveSettings = (settings: McpSettings, user?: IUser): boolean => {
 
     // Update cache after successful save
     settingsCache = mergedSettings;
+    lastModified = Date.now();
 
     return true;
   } catch (error) {
@@ -116,6 +135,7 @@ export const saveSettings = (settings: McpSettings, user?: IUser): boolean => {
  */
 export const clearSettingsCache = (): void => {
   settingsCache = null;
+  lastModified = 0;
 };
 
 /**

--- a/src/utils/systemConfigCache.ts
+++ b/src/utils/systemConfigCache.ts
@@ -1,19 +1,55 @@
-import { SystemConfig } from '../types/index.js';
+import fs from 'fs';
+import { SystemConfig, McpSettings } from '../types/index.js';
+import { getConfigFilePath } from './path.js';
 
 let cachedSystemConfig: SystemConfig | null = null;
+// mtime of the settings file the cache was last read from. In file mode,
+// `getCachedSystemConfig()` lazily re-reads `mcp_settings.json` when the file
+// is newer, mirroring `JsonFileBaseDao`'s staleness check so system settings
+// (e.g. `nameSeparator`) don't stay pinned to the startup value after an
+// external edit (#1081).
+let lastSeenSettingsFileMtime: number | null = null;
 
 export const isDatabaseModeEnabled = (): boolean =>
   process.env.USE_DB !== undefined ? process.env.USE_DB === 'true' : Boolean(process.env.DB_URL);
 
-export const getCachedSystemConfig = (): SystemConfig | null => cachedSystemConfig;
+export const getCachedSystemConfig = (): SystemConfig | null => {
+  // In database mode the file is not authoritative; the cache is populated
+  // from the database and must not be refreshed from the settings file.
+  if (!isDatabaseModeEnabled()) {
+    const settingsPath = getConfigFilePath('mcp_settings.json', 'Settings');
+    try {
+      const mtime = fs.statSync(settingsPath).mtime.getTime();
+      if (lastSeenSettingsFileMtime === null || mtime > lastSeenSettingsFileMtime) {
+        const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as McpSettings;
+        cachedSystemConfig = settings.systemConfig ?? null;
+        lastSeenSettingsFileMtime = mtime;
+      }
+    } catch {
+      // Missing or unreadable file — keep serving the last known value.
+    }
+  }
+  return cachedSystemConfig;
+};
 
 export const setCachedSystemConfig = (systemConfig: SystemConfig | null | undefined): void => {
   cachedSystemConfig = systemConfig ?? null;
+  if (!isDatabaseModeEnabled()) {
+    // A programmatic set (e.g. a dashboard system-config update that has
+    // already been persisted to the file) is authoritative until the file is
+    // externally edited, so record the current file mtime as the baseline.
+    try {
+      const settingsPath = getConfigFilePath('mcp_settings.json', 'Settings');
+      lastSeenSettingsFileMtime = fs.statSync(settingsPath).mtime.getTime();
+    } catch {
+      lastSeenSettingsFileMtime = null;
+    }
+  }
 };
 
 export const hydrateSystemConfigCache = async (): Promise<SystemConfig> => {
   const { getSystemConfigDao } = await import('../dao/DaoFactory.js');
   const systemConfig = (await getSystemConfigDao().get()) || {};
-  cachedSystemConfig = systemConfig;
+  setCachedSystemConfig(systemConfig);
   return systemConfig;
 };

--- a/tests/config/loadOriginalSettings.test.ts
+++ b/tests/config/loadOriginalSettings.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Regression tests for #1081: `loadOriginalSettings()` (and the cached system
+ * config it feeds) must re-read `mcp_settings.json` when the file is edited
+ * externally, mirroring the mtime check `JsonFileBaseDao` already applies to
+ * server definitions. System settings should not behave differently from
+ * server definitions.
+ */
+
+const writeSettings = (settingsPath: string, settings: unknown): void => {
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+};
+
+// Push the file mtime into the future so the test never depends on
+// filesystem mtime granularity.
+const bumpMtime = (filePath: string): void => {
+  const future = new Date(Date.now() + 60_000);
+  fs.utimesSync(filePath, future, future);
+};
+
+type ConfigModule = typeof import('../../src/config/index.js');
+
+describe('settings file cache staleness (#1081)', () => {
+  let tmpDir: string;
+  let settingsPath: string;
+  let originalSettingsEnv: string | undefined;
+  let originalUseDb: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcphub-config-'));
+    settingsPath = path.join(tmpDir, 'mcp_settings.json');
+
+    originalSettingsEnv = process.env.MCPHUB_SETTING_PATH;
+    originalUseDb = process.env.USE_DB;
+    process.env.MCPHUB_SETTING_PATH = settingsPath;
+    // Force file mode regardless of DB_URL (tests/setup.ts sets it).
+    process.env.USE_DB = 'false';
+  });
+
+  afterEach(() => {
+    if (originalSettingsEnv === undefined) {
+      delete process.env.MCPHUB_SETTING_PATH;
+    } else {
+      process.env.MCPHUB_SETTING_PATH = originalSettingsEnv;
+    }
+    if (originalUseDb === undefined) {
+      delete process.env.USE_DB;
+    } else {
+      process.env.USE_DB = originalUseDb;
+    }
+
+    jest.resetModules();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  const loadConfigModule = async (): Promise<ConfigModule> => {
+    jest.resetModules();
+    return import('../../src/config/index.js');
+  };
+
+  it('re-reads mcp_settings.json when the file is externally modified', async () => {
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'a' },
+    });
+    const config = await loadConfigModule();
+
+    expect(config.loadOriginalSettings().systemConfig?.nameSeparator).toBe('a');
+
+    // Simulate a hand edit to the settings file.
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'b' },
+    });
+    bumpMtime(settingsPath);
+
+    expect(config.loadOriginalSettings().systemConfig?.nameSeparator).toBe('b');
+  });
+
+  it('serves the cached snapshot while the file is unchanged', async () => {
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'a' },
+    });
+    const config = await loadConfigModule();
+
+    const readSpy = jest.spyOn(fs, 'readFileSync');
+    expect(config.loadOriginalSettings().systemConfig?.nameSeparator).toBe('a');
+    expect(config.loadOriginalSettings().systemConfig?.nameSeparator).toBe('a');
+    // The file is read exactly once; the second call hits the cache and must
+    // not trigger a re-read (the mtime check must preserve the cache).
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    readSpy.mockRestore();
+  });
+
+  it('getNameSeparator() reflects an external edit after the cache is populated', async () => {
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'a' },
+    });
+    const config = await loadConfigModule();
+    // Populate the cached system config the way startup hydration does.
+    const systemConfigCache = await import('../../src/utils/systemConfigCache.js');
+    await systemConfigCache.hydrateSystemConfigCache();
+
+    expect(config.getNameSeparator()).toBe('a');
+
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'b' },
+    });
+    bumpMtime(settingsPath);
+
+    // getNameSeparator() must pick up the edited separator without a restart.
+    expect(config.getNameSeparator()).toBe('b');
+  });
+
+  it('honors a programmatic system config set until the file is externally edited', async () => {
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'a' },
+    });
+    const config = await loadConfigModule();
+    const systemConfigCache = await import('../../src/utils/systemConfigCache.js');
+
+    // Simulate a dashboard system-config update: set programmatically.
+    systemConfigCache.setCachedSystemConfig({ nameSeparator: 'c' });
+
+    expect(config.getNameSeparator()).toBe('c');
+
+    // An external edit still wins once the file changes.
+    writeSettings(settingsPath, {
+      mcpServers: {},
+      users: [],
+      systemConfig: { nameSeparator: 'b' },
+    });
+    bumpMtime(settingsPath);
+
+    expect(config.getNameSeparator()).toBe('b');
+  });
+});


### PR DESCRIPTION
## What

Fixes #1081. Two caches over `mcp_settings.json` used different staleness rules: `JsonFileBaseDao` re-reads on mtime change (so server definitions pick up hand edits on reload), while `loadOriginalSettings()` cached unconditionally — system settings (`systemConfig`) stayed pinned to the startup snapshot until a restart or an app write.

## Behavior change

- **`src/config/index.ts`**: `loadOriginalSettings()` now re-reads the file when it is newer than the cached snapshot, mirroring `JsonFileBaseDao`. Missing-file behavior is unchanged (keeps serving the cached snapshot, no repeated warnings).
- **`src/utils/systemConfigCache.ts`**: `getCachedSystemConfig()` lazily re-reads `systemConfig` in **file mode** when the file mtime advances, so `nameSeparator`, `activityLog`, and tool-result-compression settings no longer lag server definitions after an external edit. `setCachedSystemConfig()` (dashboard system-config update path) records the file baseline so a programmatic set stays authoritative until the file is externally edited. **Database mode is untouched** — the file is not authoritative there and is never consulted.
- **`docs/configuration/mcp-settings.mdx`**: new live section documenting the reload vs restart sequence when editing `mcp_settings.json` while running.

Not in scope (per issue, out of the reported bug): a file watcher, and startup-baked settings (`skipAuth`, Better Auth bootstrap) that still require a restart.

## Automated tests

- New `tests/config/loadOriginalSettings.test.ts` (4 cases): external edit → re-read; unchanged file → cache hit; `getNameSeparator()` reflects an external edit after cache population; programmatic `setCachedSystemConfig` stays authoritative until external edit. Two cases drove the fix (Red → Green).
- `pnpm lint` ✅
- `pnpm test:ci` ✅ — 182 suites / 1336 tests passed (coverage on)
- `pnpm build` ✅

Note: `tests/integration/sse-service-real-client.test.ts` fails/times out in this environment (real server binding in `beforeAll`); verified pre-existing on a clean tree via `git stash` — unrelated to this change.

## Manual checks

- Not applicable beyond the integration suite above (backend-only change; no UI surface touched).

## Test plan notes

- File-mode external edit → `POST /api/servers/:name/reload` (or `mcphub servers reload <name>`) picks up new server definitions **and** now system settings on the next read; `skipAuth`/Better Auth still need a restart.