### PR TITLE
feat: add exponential backoff for remote MCP server connection retries

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1441,8 +1441,13 @@ const callToolWithReconnect = async (
       const isSSE = transport instanceof SSEClientTransport;
       if (attempt < maxRetries && transport && ((isStreamableHttp && isHttp40xError) || isSSE)) {
         logger.warn(
-          `${isHttp40xError ? 'HTTP 40x error' : 'error'} detected for ${isStreamableHttp ? 'StreamableHTTP' : 'SSE'} server ${serverInfo.name}${isolated ? ` (isolated session ${isolated.sessionId})` : ''}, attempting reconnection (attempt ${attempt + 1}/${maxRetries + 1})`,
+          `${isHttp40xError ? 'HTTP 40x error' : 'error'} detected for ${isStreamableHttp ? 'StreamableHTTP' : 'SSE'} server ${serverInfo.name}${isolated ? ` (isolated session ${isolated.sessionId})` : ''}, attempting reconnection (attempt ${attempt + 1}/${maxRetries})`,
         );
+
+        // Exponential backoff delay: 1s, 2s, 4s... max 10s
+        const backoffMs = Math.min(1000 * Math.pow(2, attempt), 10000);
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+
 
         try {
           const server = await getServerDao().findById(serverInfo.name);

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1441,12 +1441,14 @@ const callToolWithReconnect = async (
       const isSSE = transport instanceof SSEClientTransport;
       if (attempt < maxRetries && transport && ((isStreamableHttp && isHttp40xError) || isSSE)) {
         logger.warn(
-          `${isHttp40xError ? 'HTTP 40x error' : 'error'} detected for ${isStreamableHttp ? 'StreamableHTTP' : 'SSE'} server ${serverInfo.name}${isolated ? ` (isolated session ${isolated.sessionId})` : ''}, attempting reconnection (attempt ${attempt + 1}/${maxRetries})`,
+          `${isHttp40xError ? 'HTTP 40x error' : 'error'} detected for ${isStreamableHttp ? 'StreamableHTTP' : 'SSE'} server ${serverInfo.name}${isolated ? ` (isolated session ${isolated.sessionId})` : ''}, attempting reconnection (attempt ${attempt + 1}/${maxRetries + 1})`,
         );
 
-        // Exponential backoff delay: 1s, 2s, 4s... max 10s
-        const backoffMs = Math.min(1000 * Math.pow(2, attempt), 10000);
-        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        if (attempt > 0) {
+          // Exponential backoff delay: 1s, 2s, 4s... max 10s on subsequent retry attempts
+          const backoffMs = Math.min(1000 * Math.pow(2, attempt - 1), 10000);
+          await new Promise((resolve) => setTimeout(resolve, backoffMs));
+        }
 
 
         try {

--- a/tests/services/mcpService-reconnect.test.ts
+++ b/tests/services/mcpService-reconnect.test.ts
@@ -148,14 +148,6 @@ import * as mcpService from '../../src/services/mcpService.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 describe('mcpService streamable-http reconnect', () => {
-  beforeAll(() => {
-    jest.useFakeTimers();
-    jest.spyOn(global, 'setTimeout');
-  });
-
-  afterAll(() => {
-    jest.useRealTimers();
-  });
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/tests/services/mcpService-reconnect.test.ts
+++ b/tests/services/mcpService-reconnect.test.ts
@@ -148,6 +148,14 @@ import * as mcpService from '../../src/services/mcpService.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 describe('mcpService streamable-http reconnect', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.spyOn(global, 'setTimeout');
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
   beforeEach(() => {
     jest.clearAllMocks();
   });


### PR DESCRIPTION
This PR introduces an exponential backoff strategy when attempting to reconnect to remote MCP servers, preventing aggressive immediate retries and improving system stability when the upstream is temporarily unavailable.