### PR TITLE
fix: launch node directly in Docker to avoid runtime Corepack download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,8 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 EXPOSE 3000
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["pnpm", "start"]
+# Launch node directly instead of `pnpm start`: the pnpm shim resolves via
+# Corepack, which re-downloads pnpm into the runtime user's HOME cache when the
+# image runs as a non-root user, breaking startup in egress-restricted
+# environments (#1105).
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Fixes #1105.

The Docker image's `CMD ["pnpm", "start"]` invoked the pnpm shim, which resolves through Corepack. When the container runs as a non-root user (e.g. Kubernetes `runAsUser: 1000`), Corepack looks for the prepared pnpm in the runtime user's HOME cache, misses, and attempts to download `pnpm-10.12.4.tgz` from `registry.npmjs.org` **before the application starts**. In egress-restricted environments this fails with a network error and the container exits without ever binding its HTTP port.

## Behavior change

- `CMD ["pnpm", "start"]` -> `CMD ["node", "dist/index.js"]` - semantically identical (the `package.json` `start` script is `node dist/index.js`), but removes the package-manager/Corepack lookup from the runtime startup path.
- The entrypoint (`/usr/local/bin/entrypoint.sh`) is unchanged: npm registry/proxy config and optional Docker daemon startup still run for MCP servers launched via `npx` at runtime.
- Root-run behavior is unchanged.

## Root cause

`corepack prepare` in the build layer (root, introduced in #895) stores the pnpm entity in the **per-user HOME cache**; only the shim in `/usr/bin` is global. Any non-root runtime user gets a cache miss and triggers a registry download.

## Verification (local Docker)

| # | Scenario | Image | Result |
| - | -------- | ----- | ------ |
| 1 | Reproduce: `--user 1000:1000`, `HOME=/tmp`, `--network none` | `samanhappy/mcphub:1.0.32` | FAIL: Corepack tries to download `pnpm-10.12.4.tgz`, exits 1 before app start |
| 2 | Control: default root, `--network none` | `samanhappy/mcphub:1.0.32` | OK: starts, `/health` responds (degraded: bundled MCP servers need egress - expected) |
| 3 | Fix, issue scenario: `--user 1000:1000`, `HOME=/tmp`, `--network none`, `MCPHUB_SETTING_PATH` on writable mount | fixed image (this branch) | OK: no Corepack download, default admin created, port 3000 bound, `/health` returns `healthy` |
| 4 | Fix regression: default root, `--network none` | fixed image | OK: same behavior as v1.0.32 control |
| 5 | Fix entrypoint passthrough: custom command override | fixed image | OK: `exec "$@"` still hands off correctly |

## Automated checks

- `pnpm lint` - pass
- `pnpm build` - pass
- `pnpm test:ci` - 1342/1346 pass; the 4 failures are in `tests/integration/sse-service-real-client.test.ts` and **fail identically on unmodified `main`** (verified in an isolated worktree: same 4 tests, timeout-class failures unrelated to this one-line Dockerfile change)
