### PR TITLE
fix: align smart routing env docs with code

### DIFF
--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -114,13 +114,13 @@ Smart Routing performs vector search over upstream tools to surface only the few
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `SMART_ROUTING_ENABLED` | `false` | Master switch for smart routing. |
+| `SMART_ROUTING_ENABLED` | `false` | Canonical master switch for Smart Routing. `ENABLE_SMART_ROUTING` is accepted as a legacy alias; when both are set, this variable takes precedence. |
 | `SMART_ROUTING_EMBEDDING_PROVIDER` | `openai` | Embedding provider. Currently `openai` or `azure_openai`. |
 | `SMART_ROUTING_EMBEDDING_ENCODING_FORMAT` | provider default | Override the `encoding_format` passed to the embedding API. |
 | `SMART_ROUTING_BASE_PACING_DELAY_MS` | `0` | Base delay (ms) applied between embedding requests to avoid rate limits. |
 | `SMART_ROUTING_PROGRESSIVE_DISCLOSURE` | unset | When set, expose progressively-disclosed tool metadata (see Smart Routing docs). |
 | `SMART_ROUTING_SERVER_DESCRIPTION_MODE` | `names` | Control how `search_tools` lists available servers: `names` for server names only, `full` to include server descriptions/instructions when available. |
-| `EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model name. |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` | Embedding model name. `OPENAI_API_EMBEDDING_MODEL` is accepted as a legacy alias; when both are set, this variable takes precedence. |
 | `EMBEDDING_MAX_TOKENS` | per-model | Override token truncation limit before embedding. Useful to match a local inference server's batch size. |
 
 ### OpenAI

--- a/docs/features/smart-routing.mdx
+++ b/docs/features/smart-routing.mdx
@@ -208,9 +208,6 @@ OPENAI_API_KEY=your_openai_api_key
 # Optional
 SMART_ROUTING_ENABLED=true
 EMBEDDING_MODEL=text-embedding-3-small
-SIMILARITY_THRESHOLD=0.7
-MAX_TOOLS_RETURNED=10
-EMBEDDING_BATCH_SIZE=100
 ```
 
 ### Configuration Options
@@ -240,7 +237,7 @@ EMBEDDING_BATCH_SIZE=100
     # Azure OpenAI
     AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
     AZURE_OPENAI_API_KEY=your-api-key
-    AZURE_OPENAI_DEPLOYMENT=your-embedding-deployment
+    AZURE_OPENAI_EMBEDDING_DEPLOYMENT=your-embedding-deployment
     # The actual OpenAI model name behind the deployment (for accurate token counting)
     AZURE_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
 

--- a/docs/zh/configuration/environment-variables.mdx
+++ b/docs/zh/configuration/environment-variables.mdx
@@ -97,6 +97,39 @@ OIDC_CLIENT_ID=your-oidc-client-id
 OIDC_CLIENT_SECRET=your-oidc-client-secret
 ```
 
+## 智能路由与嵌入
+
+智能路由使用 PostgreSQL + pgvector 和嵌入服务，对上游工具执行向量搜索。启用智能路由至少需要配置 `DB_URL`、OpenAI 兼容嵌入服务和开关变量。
+
+| 变量 | 默认值 | 描述 |
+| --- | --- | --- |
+| `SMART_ROUTING_ENABLED` | `false` | 智能路由的规范总开关。`ENABLE_SMART_ROUTING` 仍作为旧版兼容别名；两者同时设置时，以本变量为准。 |
+| `SMART_ROUTING_EMBEDDING_PROVIDER` | `openai` | 嵌入提供商，目前支持 `openai` 和 `azure_openai`。 |
+| `SMART_ROUTING_EMBEDDING_ENCODING_FORMAT` | `auto` | 覆盖发送给嵌入 API 的 `encoding_format`。 |
+| `SMART_ROUTING_BASE_PACING_DELAY_MS` | `0` | 嵌入请求之间的基础等待时间（毫秒）。 |
+| `SMART_ROUTING_PROGRESSIVE_DISCLOSURE` | `false` | 是否启用渐进式工具信息披露。 |
+| `SMART_ROUTING_SERVER_DESCRIPTION_MODE` | `names` | `search_tools` 中服务器信息的展示方式：`names` 或 `full`。 |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` | 嵌入模型名称。`OPENAI_API_EMBEDDING_MODEL` 仍作为旧版兼容别名；两者同时设置时，以本变量为准。 |
+| `EMBEDDING_MAX_TOKENS` | 按模型决定 | 生成嵌入前的最大 token 数。 |
+
+### OpenAI 或兼容服务
+
+| 变量 | 描述 |
+| --- | --- |
+| `DB_URL` | PostgreSQL 连接 URL；数据库需要启用 `pgvector` 扩展。 |
+| `OPENAI_API_KEY` | OpenAI 或兼容嵌入服务的 API 密钥。 |
+| `OPENAI_API_BASE_URL` | OpenAI 兼容 API 的 Base URL，例如 LocalAI 或其他兼容服务。 |
+
+### Azure OpenAI
+
+| 变量 | 描述 |
+| --- | --- |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI API 密钥。 |
+| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI 资源地址。 |
+| `AZURE_OPENAI_API_VERSION` | Azure OpenAI API 版本。 |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | Azure 中的嵌入 deployment 名称。 |
+| `AZURE_OPENAI_EMBEDDING_MODEL` | deployment 背后的实际 OpenAI 模型名称，用于 tokenizer 和 token 上限选择。 |
+
 ## 配置示例
 
 ### 开发环境

--- a/src/utils/smartRouting.ts
+++ b/src/utils/smartRouting.ts
@@ -58,7 +58,8 @@ export interface SmartRoutingConfig {
  * Gets the complete smart routing configuration from environment variables and settings.
  *
  * Priority order for each setting:
- * 1. Specific environment variables (ENABLE_SMART_ROUTING, SMART_ROUTING_ENABLED, etc.)
+ * 1. Specific environment variables (SMART_ROUTING_ENABLED, with
+ *    ENABLE_SMART_ROUTING retained as a legacy alias)
  * 2. Generic environment variables (OPENAI_API_KEY, DB_URL, etc.)
  * 3. Settings configuration (systemConfig.smartRouting)
  * 4. Default values
@@ -72,9 +73,9 @@ export async function getSmartRoutingConfig(): Promise<SmartRoutingConfig> {
   const smartRoutingSettings: Partial<SmartRoutingConfig> = systemConfig.smartRouting || {};
 
   return {
-    // Enabled status - check multiple environment variables
+    // Enabled status - prefer the canonical variable but keep the legacy alias
     enabled: getConfigValue(
-      [process.env.SMART_ROUTING_ENABLED],
+      [process.env.SMART_ROUTING_ENABLED, process.env.ENABLE_SMART_ROUTING],
       smartRoutingSettings.enabled,
       false,
       parseBooleanEnvVar,
@@ -139,7 +140,7 @@ export async function getSmartRoutingConfig(): Promise<SmartRoutingConfig> {
     ),
 
     openaiApiEmbeddingModel: getConfigValue(
-      [process.env.EMBEDDING_MODEL],
+      [process.env.EMBEDDING_MODEL, process.env.OPENAI_API_EMBEDDING_MODEL],
       smartRoutingSettings.openaiApiEmbeddingModel,
       'text-embedding-3-small',
       expandEnvVars,

--- a/tests/utils/smartRouting.test.ts
+++ b/tests/utils/smartRouting.test.ts
@@ -13,6 +13,7 @@ import { getSmartRoutingConfig } from '../../src/utils/smartRouting.js';
 // not leak into the 3-layer resolution being tested.
 const SMART_ROUTING_ENV_VARS = [
   'SMART_ROUTING_ENABLED',
+  'ENABLE_SMART_ROUTING',
   'DB_URL',
   'SMART_ROUTING_BASE_PACING_DELAY_MS',
   'SMART_ROUTING_EMBEDDING_PROVIDER',
@@ -20,6 +21,7 @@ const SMART_ROUTING_ENV_VARS = [
   'OPENAI_API_BASE_URL',
   'OPENAI_API_KEY',
   'EMBEDDING_MODEL',
+  'OPENAI_API_EMBEDDING_MODEL',
   'AZURE_OPENAI_ENDPOINT',
   'AZURE_OPENAI_API_KEY',
   'AZURE_OPENAI_API_VERSION',
@@ -50,7 +52,7 @@ describe('smartRouting config resolution', () => {
   });
 
   // parseBooleanEnvVar is private; exercised indirectly through `enabled`
-  // (env: SMART_ROUTING_ENABLED) and `progressiveDisclosure`
+  // (env: SMART_ROUTING_ENABLED / ENABLE_SMART_ROUTING) and `progressiveDisclosure`
   // (env: SMART_ROUTING_PROGRESSIVE_DISCLOSURE / settings passthrough).
   describe('parseBooleanEnvVar (via enabled / progressiveDisclosure)', () => {
     it.each(['true', '1', 'yes', 'on', 'TRUE', 'True', 'YES'])(
@@ -61,6 +63,19 @@ describe('smartRouting config resolution', () => {
         expect(config.enabled).toBe(true);
       },
     );
+
+    it('accepts the legacy ENABLE_SMART_ROUTING alias', async () => {
+      process.env.ENABLE_SMART_ROUTING = 'true';
+      const config = await getSmartRoutingConfig();
+      expect(config.enabled).toBe(true);
+    });
+
+    it('prefers SMART_ROUTING_ENABLED over the legacy alias', async () => {
+      process.env.SMART_ROUTING_ENABLED = 'false';
+      process.env.ENABLE_SMART_ROUTING = 'true';
+      const config = await getSmartRoutingConfig();
+      expect(config.enabled).toBe(false);
+    });
 
     it.each(['false', '0', 'no', 'off'])('treats %s as falsy', async (value) => {
       process.env.SMART_ROUTING_ENABLED = value;
@@ -131,11 +146,24 @@ describe('smartRouting config resolution', () => {
     // `continue`/fall-to-settings path cannot be exercised with real values
     // without modifying src (out of scope). We instead cover the equivalent
     // "empty env string falls through to settings" fall-through path.
-    it("empty-string env falls through to settings value", async () => {
+    it('empty-string env falls through to settings value', async () => {
       process.env.OPENAI_API_KEY = '';
       mockGet.mockResolvedValue({ smartRouting: { openaiApiKey: 'sk-from-settings' } });
       const config = await getSmartRoutingConfig();
       expect(config.openaiApiKey).toBe('sk-from-settings');
+    });
+
+    it('accepts the legacy OpenAI embedding model alias', async () => {
+      process.env.OPENAI_API_EMBEDDING_MODEL = 'legacy-embedding-model';
+      const config = await getSmartRoutingConfig();
+      expect(config.openaiApiEmbeddingModel).toBe('legacy-embedding-model');
+    });
+
+    it('prefers EMBEDDING_MODEL over the legacy model alias', async () => {
+      process.env.EMBEDDING_MODEL = 'canonical-embedding-model';
+      process.env.OPENAI_API_EMBEDDING_MODEL = 'legacy-embedding-model';
+      const config = await getSmartRoutingConfig();
+      expect(config.openaiApiEmbeddingModel).toBe('canonical-embedding-model');
     });
   });
 


### PR DESCRIPTION
## Summary

- Align Smart Routing environment-variable documentation with the implementation.
- Keep the canonical SMART_ROUTING_ENABLED and EMBEDDING_MODEL names while accepting the legacy aliases for compatibility; canonical values take precedence.
- Correct the Azure embedding deployment variable and add the missing Chinese environment-variable documentation.
- Add regression coverage for legacy aliases and precedence.

## Validation

- Focused Smart Routing tests: 49 passed.
- pnpm lint: passed.
- pnpm build: passed.
- node scripts/verify-dist.js: passed.
- pnpm test:ci: blocked in the current sandbox because integration tests cannot bind listeners and fail with listen EPERM on 0.0.0.0.

Closes #600