### PR TITLE
fix: propagate SSRF DNS lookup to redirect validation

### DIFF
--- a/src/services/cimdClientService.ts
+++ b/src/services/cimdClientService.ts
@@ -158,7 +158,11 @@ const fetchCimdDocument = async (clientIdUrl: string): Promise<IOAuthClient | un
     ...(ssrfLookupOverride ? { lookup: ssrfLookupOverride } : {}),
   });
 
-  const validatingFetch = createRedirectValidatingFetch((url, init) => fetchImpl(url, init), false);
+  const validatingFetch = createRedirectValidatingFetch(
+    (url, init) => fetchImpl(url, init),
+    false,
+    ssrfLookupOverride,
+  );
   const response = await validatingFetch(clientIdUrl, {
     method: 'GET',
     headers: { Accept: 'application/json' },

--- a/src/utils/__tests__/ssrf.test.ts
+++ b/src/utils/__tests__/ssrf.test.ts
@@ -170,6 +170,19 @@ describe('createRedirectValidatingFetch', () => {
     expect(baseFetch).not.toHaveBeenCalled();
   });
 
+  it('uses the supplied DNS lookup for the initial URL and redirects', async () => {
+    const lookup = jest.fn(async () => ['93.184.216.34']);
+    const baseFetch = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(makeResponse(302, 'https://redirect.example/next') as Response)
+      .mockResolvedValueOnce(makeResponse(200) as Response);
+    const safeFetch = createRedirectValidatingFetch(baseFetch, false, lookup);
+
+    await expect(safeFetch('https://client.example/start')).resolves.toMatchObject({ status: 200 });
+    expect(lookup).toHaveBeenCalledWith('client.example');
+    expect(lookup).toHaveBeenCalledWith('redirect.example');
+  });
+
   it('returns the response directly for a non-redirect (2xx)', async () => {
     const baseFetch = jest.fn(async () => makeResponse(200));
     const safeFetch = createRedirectValidatingFetch(baseFetch as unknown as typeof fetch, false);

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -160,12 +160,13 @@ export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Respo
 export function createRedirectValidatingFetch(
   baseFetch: FetchLike,
   allowInternal: boolean,
+  lookup: SsrfLookup = defaultLookup,
 ): FetchLike {
   const maxHops = 5;
   return async (url, init) => {
     let currentUrl = typeof url === 'string' ? url : url.toString();
     let hops = 0;
-    currentUrl = await assertSafeUrl(currentUrl, { allowInternal });
+    currentUrl = await assertSafeUrl(currentUrl, { allowInternal, lookup });
     let response = await baseFetch(currentUrl, { ...init, redirect: 'manual' });
     while (
       response.status >= 300 &&
@@ -178,7 +179,7 @@ export function createRedirectValidatingFetch(
         return response;
       }
       const resolvedUrl = new URL(location, currentUrl).toString();
-      currentUrl = await assertSafeUrl(resolvedUrl, { allowInternal });
+      currentUrl = await assertSafeUrl(resolvedUrl, { allowInternal, lookup });
       hops++;
       response = await baseFetch(currentUrl, { ...init, redirect: 'manual' });
     }


### PR DESCRIPTION
## Summary

- Preserve the caller-provided DNS lookup when validating the initial URL and redirect hops.
- Pass the CIMD test DNS seam through the redirect-validating fetch wrapper.
- Prevent CIMD metadata resolution tests from failing before the mocked fetch is reached.

## Context

The post-merge CI run failed only in the existing CIMD suite because the shared SSRF wrapper performed a second lookup with the real resolver for client.example.com. The mocked fetch was therefore never called.

Fixes the failed run: https://github.com/samanhappy/mcphub/actions/runs/33501448992

## Validation

- Focused security/CIMD/SSRF tests: 81 passed
- Full test suite: 186 suites, 1378 tests passed
- pnpm lint
- pnpm backend:build
- pnpm build
- node scripts/verify-dist.js
- git diff --check