### PR TITLE
docs: prefer gh api for security advisories

### DIFF
--- a/docs/agents/git-and-contribution.md
+++ b/docs/agents/git-and-contribution.md
@@ -10,13 +10,29 @@ GitHub Issues for `samanhappy/mcphub` are operated with `gh`. See [issue-tracker
 
 ## Security advisories and code scanning
 
-For private GitHub security work, first inspect the actual advisory or alert with:
+For private GitHub security work, use `gh api` as the primary interface for
+reading and updating security advisories. Do not treat the GitHub security
+advisories web page as the source of truth when the API can expose the details.
+First inspect the actual advisory or alert with:
 
 ```bash
 gh auth status
+gh api --paginate 'repos/samanhappy/mcphub/security-advisories?state=draft&per_page=100'
 gh api repos/samanhappy/mcphub/security-advisories/<ghsa_id>
 gh api repos/samanhappy/mcphub/code-scanning/alerts/<alert_number>
 gh api repos/samanhappy/mcphub/code-scanning/alerts/<alert_number>/instances
 ```
 
 Compare advisory details against the current `main` and the tagged fix commit before deciding whether an issue is still live. Prefer these APIs over the GitHub code-scanning web page, which may hide details without the required session.
+
+When a fix is released, update the advisory through the API with its patched
+version and the appropriate state, preserving the existing advisory fields:
+
+```bash
+gh api --method PATCH \
+  repos/samanhappy/mcphub/security-advisories/<ghsa_id> \
+  --input advisory-update.json
+```
+
+The JSON payload should include `vulnerabilities[].patched_versions` and, when
+the advisory is ready for disclosure, `state: "published"`.


### PR DESCRIPTION
## Summary

- Document gh api as the primary interface for private security advisory work.
- Add standard commands for listing, inspecting, and updating advisories.
- Record the patched-version and publication workflow.

## Validation

- git diff --check
- Verified via gh api that GHSA-xvpg-v6pr-xc32, GHSA-94jf-cmwm-q3p5, and GHSA-cvw6-m995-5vvv are published with patched version 1.0.34.

This PR contains documentation only; the advisory updates were made separately through the GitHub REST API.