### PR TITLE
fix: reconnect upstream OAuth servers after reauthorization

### DIFF
--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -373,77 +373,83 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         );
         serverInfo.transport = refreshedTransport;
 
-        // Update server status to indicate OAuth is complete
-        serverInfo.status = 'connected';
+        // OAuth tokens are available, but the new transport is not connected yet.
+        serverInfo.status = 'connecting';
         if (serverInfo.oauth) {
           serverInfo.oauth.authorizationUrl = undefined;
           serverInfo.oauth.state = undefined;
         }
 
-        // Check if client needs to be connected
-        const isClientConnected = serverInfo.client && serverInfo.client.getServerCapabilities();
+        if (!serverInfo.client || !serverInfo.transport) {
+          const missingRuntimeError = new Error(
+            `Cannot reconnect ${serverInfo.name} after OAuth callback because client or transport is missing`,
+          );
+          serverInfo.status = 'disconnected';
+          serverInfo.error = missingRuntimeError.message;
+          throw missingRuntimeError;
+        }
 
-        if (!isClientConnected) {
-          // Client is not connected yet, connect it
-          if (serverInfo.client && serverInfo.transport) {
-            logger.log('Connecting client with refreshed transport', {
+        logger.log('Connecting client with refreshed transport', {
+          serverName: serverInfo.name,
+        });
+        try {
+          await connectClientWithDiagnostics(
+            serverInfo.client,
+            serverInfo.transport,
+            serverInfo.options,
+          );
+        } catch (connectError) {
+          serverInfo.status = 'disconnected';
+          serverInfo.error = `Failed to connect after OAuth callback: ${
+            connectError instanceof Error ? connectError.message : String(connectError)
+          }`;
+          logger.error('Error connecting client after OAuth callback', {
+            serverName: serverInfo.name,
+            error: connectError,
+          });
+          if (connectError instanceof Error) {
+            logger.error('Connect error details after OAuth callback', {
               serverName: serverInfo.name,
+              message: connectError.message,
+              stack: connectError.stack,
             });
-            try {
-              await connectClientWithDiagnostics(
-                serverInfo.client,
-                serverInfo.transport,
-                serverInfo.options,
-              );
-              logger.log('Client connected successfully after OAuth callback', {
-                serverName: serverInfo.name,
-              });
+          }
+          throw connectError;
+        }
 
-              // List tools after successful connection
-              const capabilities = serverInfo.client.getServerCapabilities();
-              logger.log('Server capabilities after OAuth callback', {
-                serverName: serverInfo.name,
-                capabilities,
-              });
+        serverInfo.status = 'connected';
+        serverInfo.error = null;
+        logger.log('Client connected successfully after OAuth callback', {
+          serverName: serverInfo.name,
+        });
 
-              if (capabilities?.tools) {
-                logger.log('Listing tools after OAuth callback', {
-                  serverName: serverInfo.name,
-                });
-                const toolsResult = await serverInfo.client.listTools({}, serverInfo.options);
-                updateServerToolsCache(serverInfo, toolsResult.tools);
-                logger.log('Listed tools after OAuth callback', {
-                  serverName: serverInfo.name,
-                  toolCount: serverInfo.tools.length,
-                });
-              } else {
-                logger.log('Server does not support tools capability after OAuth callback', {
-                  serverName: serverInfo.name,
-                });
-              }
-            } catch (connectError) {
-              logger.error('Error connecting client after OAuth callback', {
-                serverName: serverInfo.name,
-                error: connectError,
-              });
-              if (connectError instanceof Error) {
-                logger.error('Connect error details after OAuth callback', {
-                  serverName: serverInfo.name,
-                  message: connectError.message,
-                  stack: connectError.stack,
-                });
-              }
-              // Even if connection fails, mark OAuth as complete
-              // The user can try reconnecting from the dashboard
-            }
-          } else {
-            logger.log(
-              'Cannot connect client after OAuth callback because client or transport is missing',
-              { serverName: serverInfo.name },
-            );
+        // List tools after successful connection. A cache refresh failure does not
+        // invalidate the connection established by the MCP handshake.
+        const capabilities = serverInfo.client.getServerCapabilities();
+        logger.log('Server capabilities after OAuth callback', {
+          serverName: serverInfo.name,
+          capabilities,
+        });
+
+        if (capabilities?.tools) {
+          logger.log('Listing tools after OAuth callback', {
+            serverName: serverInfo.name,
+          });
+          try {
+            const toolsResult = await serverInfo.client.listTools({}, serverInfo.options);
+            updateServerToolsCache(serverInfo, toolsResult.tools);
+            logger.log('Listed tools after OAuth callback', {
+              serverName: serverInfo.name,
+              toolCount: serverInfo.tools.length,
+            });
+          } catch (listToolsError) {
+            logger.error('Failed to list tools after OAuth callback', {
+              serverName: serverInfo.name,
+              error: listToolsError,
+            });
           }
         } else {
-          logger.log('Client already connected after OAuth callback', {
+          logger.log('Server does not support tools capability after OAuth callback', {
             serverName: serverInfo.name,
           });
         }

--- a/src/controllers/oauthCallbackController.ts
+++ b/src/controllers/oauthCallbackController.ts
@@ -392,10 +392,12 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
         logger.log('Connecting client with refreshed transport', {
           serverName: serverInfo.name,
         });
+        const reconnectClient = serverInfo.client;
+        const reconnectTransport = serverInfo.transport;
         try {
           await connectClientWithDiagnostics(
-            serverInfo.client,
-            serverInfo.transport,
+            reconnectClient,
+            reconnectTransport,
             serverInfo.options,
           );
         } catch (connectError) {
@@ -414,6 +416,32 @@ export const handleOAuthCallback = async (req: Request, res: Response) => {
               stack: connectError.stack,
             });
           }
+
+          try {
+            await reconnectClient.close();
+          } catch (clientCloseError) {
+            logger.warn('Failed to close client after OAuth reconnect failure', {
+              serverName: serverInfo.name,
+              error: clientCloseError,
+            });
+          }
+
+          try {
+            await reconnectTransport.close();
+          } catch (transportCloseError) {
+            logger.warn('Failed to close transport after OAuth reconnect failure', {
+              serverName: serverInfo.name,
+              error: transportCloseError,
+            });
+          }
+
+          if (serverInfo.client === reconnectClient) {
+            serverInfo.client = undefined;
+          }
+          if (serverInfo.transport === reconnectTransport) {
+            serverInfo.transport = undefined;
+          }
+
           throw connectError;
         }
 

--- a/tests/controllers/oauthCallbackController.test.ts
+++ b/tests/controllers/oauthCallbackController.test.ts
@@ -32,11 +32,13 @@ import { loadServerConfig } from '../../src/services/oauthSettingsStore.js';
 const AUTHORIZATION_URL = 'https://as.example.com/authorize?client_id=mcphub';
 
 type MockClient = {
+  close: jest.Mock;
   getServerCapabilities: jest.Mock;
   listTools: jest.Mock;
 };
 
 const createMockClient = (): MockClient => ({
+  close: jest.fn().mockResolvedValue(undefined),
   getServerCapabilities: jest.fn().mockReturnValue(undefined),
   listTools: jest.fn(),
 });
@@ -143,6 +145,7 @@ describe('oauthCallbackController iss validation', () => {
 
   it('reconnects a previously initialized client with the refreshed transport', async () => {
     const client: MockClient = {
+      close: jest.fn().mockResolvedValue(undefined),
       getServerCapabilities: jest.fn().mockReturnValue({ tools: {} }),
       listTools: jest.fn().mockResolvedValue({
         tools: [{ name: 'refreshed-tool', inputSchema: { type: 'object' } }],
@@ -176,12 +179,15 @@ describe('oauthCallbackController iss validation', () => {
 
   it('reports a disconnected server when the refreshed transport cannot connect', async () => {
     const client: MockClient = {
+      close: jest.fn().mockResolvedValue(undefined),
       getServerCapabilities: jest.fn().mockReturnValue({ tools: {} }),
       listTools: jest.fn(),
     };
     serverInfo = createServerInfo(client);
     (getServerByOAuthState as jest.Mock).mockReturnValue(serverInfo);
 
+    const refreshedTransport = { close: jest.fn().mockResolvedValue(undefined) };
+    (createTransportFromConfig as jest.Mock).mockResolvedValue(refreshedTransport);
     const connectionError = new Error('upstream unavailable');
     (connectClientWithDiagnostics as jest.Mock).mockRejectedValue(connectionError);
 
@@ -193,8 +199,46 @@ describe('oauthCallbackController iss validation', () => {
     );
 
     expect(connectClientWithDiagnostics).toHaveBeenCalledTimes(1);
+    expect(client.close).toHaveBeenCalledTimes(1);
+    expect(refreshedTransport.close).toHaveBeenCalledTimes(1);
+    expect(serverInfo.client).toBeUndefined();
+    expect(serverInfo.transport).toBeUndefined();
     expect(serverInfo.status).toBe('disconnected');
     expect(serverInfo.error).toContain('upstream unavailable');
+    expect(res.statusCode).toBe(500);
+    expect(String(res.body)).toContain('upstream unavailable');
+  });
+
+  it('preserves the reconnect error when cleanup also fails', async () => {
+    const client: MockClient = {
+      close: jest.fn().mockRejectedValue(new Error('client cleanup failed')),
+      getServerCapabilities: jest.fn().mockReturnValue({ tools: {} }),
+      listTools: jest.fn(),
+    };
+    serverInfo = createServerInfo(client);
+    (getServerByOAuthState as jest.Mock).mockReturnValue(serverInfo);
+
+    const refreshedTransport = {
+      close: jest.fn().mockRejectedValue(new Error('transport cleanup failed')),
+    };
+    (createTransportFromConfig as jest.Mock).mockResolvedValue(refreshedTransport);
+    (connectClientWithDiagnostics as jest.Mock).mockRejectedValue(
+      new Error('upstream unavailable'),
+    );
+
+    const res = createResponse();
+
+    await handleOAuthCallback(
+      createRequest({ code: 'auth-code', state: 'state-123' }),
+      res as never,
+    );
+
+    expect(client.close).toHaveBeenCalledTimes(1);
+    expect(refreshedTransport.close).toHaveBeenCalledTimes(1);
+    expect(serverInfo.client).toBeUndefined();
+    expect(serverInfo.transport).toBeUndefined();
+    expect(serverInfo.error).toContain('upstream unavailable');
+    expect(serverInfo.error).not.toContain('cleanup failed');
     expect(res.statusCode).toBe(500);
     expect(String(res.body)).toContain('upstream unavailable');
   });

--- a/tests/controllers/oauthCallbackController.test.ts
+++ b/tests/controllers/oauthCallbackController.test.ts
@@ -23,13 +23,25 @@ jest.mock('../../src/config/index.js', () => ({
 import { handleOAuthCallback } from '../../src/controllers/oauthCallbackController.js';
 import {
   getServerByOAuthState,
+  connectClientWithDiagnostics,
   createTransportFromConfig,
+  updateServerToolsCache,
 } from '../../src/services/mcpService.js';
 import { loadServerConfig } from '../../src/services/oauthSettingsStore.js';
 
 const AUTHORIZATION_URL = 'https://as.example.com/authorize?client_id=mcphub';
 
-const createServerInfo = () => {
+type MockClient = {
+  getServerCapabilities: jest.Mock;
+  listTools: jest.Mock;
+};
+
+const createMockClient = (): MockClient => ({
+  getServerCapabilities: jest.fn().mockReturnValue(undefined),
+  listTools: jest.fn(),
+});
+
+const createServerInfo = (client: MockClient = createMockClient()) => {
   const finishAuth = jest.fn().mockResolvedValue(undefined);
   return {
     name: 'upstream-server',
@@ -40,7 +52,7 @@ const createServerInfo = () => {
     },
     options: undefined,
     transport: { finishAuth, close: jest.fn().mockResolvedValue(undefined) },
-    client: undefined,
+    client,
     tools: [],
     oauth: {
       authorizationUrl: AUTHORIZATION_URL,
@@ -127,5 +139,63 @@ describe('oauthCallbackController iss validation', () => {
 
     expect(res.statusCode).toBe(200);
     expect(originalFinishAuth).toHaveBeenCalledWith('auth-code');
+  });
+
+  it('reconnects a previously initialized client with the refreshed transport', async () => {
+    const client: MockClient = {
+      getServerCapabilities: jest.fn().mockReturnValue({ tools: {} }),
+      listTools: jest.fn().mockResolvedValue({
+        tools: [{ name: 'refreshed-tool', inputSchema: { type: 'object' } }],
+      }),
+    };
+    serverInfo = createServerInfo(client);
+    (getServerByOAuthState as jest.Mock).mockReturnValue(serverInfo);
+
+    const refreshedTransport = { close: jest.fn().mockResolvedValue(undefined) };
+    (createTransportFromConfig as jest.Mock).mockResolvedValue(refreshedTransport);
+    (connectClientWithDiagnostics as jest.Mock).mockResolvedValue(undefined);
+
+    const res = createResponse();
+
+    await handleOAuthCallback(
+      createRequest({ code: 'auth-code', state: 'state-123' }),
+      res as never,
+    );
+
+    expect(connectClientWithDiagnostics).toHaveBeenCalledWith(
+      client,
+      refreshedTransport,
+      expect.objectContaining({ timeout: 60000 }),
+    );
+    expect(updateServerToolsCache).toHaveBeenCalledWith(serverInfo, [
+      { name: 'refreshed-tool', inputSchema: { type: 'object' } },
+    ]);
+    expect(serverInfo.status).toBe('connected');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('reports a disconnected server when the refreshed transport cannot connect', async () => {
+    const client: MockClient = {
+      getServerCapabilities: jest.fn().mockReturnValue({ tools: {} }),
+      listTools: jest.fn(),
+    };
+    serverInfo = createServerInfo(client);
+    (getServerByOAuthState as jest.Mock).mockReturnValue(serverInfo);
+
+    const connectionError = new Error('upstream unavailable');
+    (connectClientWithDiagnostics as jest.Mock).mockRejectedValue(connectionError);
+
+    const res = createResponse();
+
+    await handleOAuthCallback(
+      createRequest({ code: 'auth-code', state: 'state-123' }),
+      res as never,
+    );
+
+    expect(connectClientWithDiagnostics).toHaveBeenCalledTimes(1);
+    expect(serverInfo.status).toBe('disconnected');
+    expect(serverInfo.error).toContain('upstream unavailable');
+    expect(res.statusCode).toBe(500);
+    expect(String(res.body)).toContain('upstream unavailable');
   });
 });

--- a/tests/integration/oauth-callback-reconnect.test.ts
+++ b/tests/integration/oauth-callback-reconnect.test.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import rateLimit from 'express-rate-limit';
 import request from 'supertest';
 
 jest.mock('../../src/services/mcpService.js', () => ({
@@ -53,6 +54,11 @@ describe('OAuth callback reconnect integration', () => {
     };
     const refreshedTransport = { close: jest.fn().mockResolvedValue(undefined) };
     const app = express();
+    const limiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 100,
+    });
+    app.use(limiter);
     app.get('/oauth/callback', (req, res) => {
       void handleOAuthCallback(req, res);
     });

--- a/tests/integration/oauth-callback-reconnect.test.ts
+++ b/tests/integration/oauth-callback-reconnect.test.ts
@@ -1,0 +1,77 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../src/services/mcpService.js', () => ({
+  getServerByName: jest.fn(),
+  getServerByOAuthState: jest.fn(),
+  connectClientWithDiagnostics: jest.fn(),
+  createTransportFromConfig: jest.fn(),
+  updateServerToolsCache: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthSettingsStore.js', () => ({
+  loadServerConfig: jest.fn(),
+}));
+
+jest.mock('../../src/config/index.js', () => ({
+  replaceEnvVars: jest.fn((value: unknown) => value),
+}));
+
+import { handleOAuthCallback } from '../../src/controllers/oauthCallbackController.js';
+import {
+  connectClientWithDiagnostics,
+  createTransportFromConfig,
+  getServerByOAuthState,
+} from '../../src/services/mcpService.js';
+import { loadServerConfig } from '../../src/services/oauthSettingsStore.js';
+
+describe('OAuth callback reconnect integration', () => {
+  it('reconnects an existing client after replacing its transport', async () => {
+    const serverInfo = {
+      name: 'oauth-server',
+      status: 'oauth_required' as const,
+      config: {
+        url: 'https://upstream.example.com/mcp',
+        oauth: { dynamicRegistration: { enabled: true } },
+      },
+      options: undefined,
+      transport: {
+        finishAuth: jest.fn().mockResolvedValue(undefined),
+        close: jest.fn().mockResolvedValue(undefined),
+      },
+      client: {
+        getServerCapabilities: jest.fn().mockReturnValue({ tools: {} }),
+        listTools: jest.fn().mockResolvedValue({ tools: [] }),
+      },
+      tools: [],
+      prompts: [],
+      resources: [],
+      oauth: {
+        authorizationUrl: 'https://as.example.com/authorize',
+        state: 'state-123',
+      },
+    };
+    const refreshedTransport = { close: jest.fn().mockResolvedValue(undefined) };
+    const app = express();
+    app.get('/oauth/callback', (req, res) => {
+      void handleOAuthCallback(req, res);
+    });
+
+    (getServerByOAuthState as jest.Mock).mockReturnValue(serverInfo);
+    (loadServerConfig as jest.Mock).mockResolvedValue(serverInfo.config);
+    (createTransportFromConfig as jest.Mock).mockResolvedValue(refreshedTransport);
+    (connectClientWithDiagnostics as jest.Mock).mockResolvedValue(undefined);
+
+    const response = await request(app)
+      .get('/oauth/callback')
+      .query({ code: 'auth-code', state: 'state-123' });
+
+    expect(response.status).toBe(200);
+    expect(connectClientWithDiagnostics).toHaveBeenCalledWith(
+      serverInfo.client,
+      refreshedTransport,
+      expect.objectContaining({ timeout: 60000 }),
+    );
+    expect(serverInfo.status).toBe('connected');
+  });
+});


### PR DESCRIPTION
## Summary

- Always reconnect the existing MCP client after OAuth replaces its transport.
- Keep server status disconnected when reconnect fails instead of reporting a false connected state.
- Add controller and route-level regression coverage for OAuth reauthorization.

## Validation

- `pnpm lint`
- `pnpm test:ci`
- `pnpm backend:build`
- `pnpm build`
- `git diff --check`
- Manual OAuth-provider validation was not run because no upstream provider credentials were available locally.

Fixes #1127
