### PR TITLE
fix: decode multipart binary file arrays

### DIFF
--- a/src/clients/__tests__/openapi-multipart-file-arrays.test.ts
+++ b/src/clients/__tests__/openapi-multipart-file-arrays.test.ts
@@ -1,0 +1,104 @@
+import { OpenAPIClient } from '../openapi.js';
+
+async function createUploadClient() {
+  const client = new OpenAPIClient({
+    type: 'openapi',
+    openapi: {
+      schema: {
+        openapi: '3.0.0',
+        info: { title: 'Multi-file upload', version: '1.0.0' },
+        paths: {
+          '/files': {
+            post: {
+              operationId: 'uploadFiles',
+              requestBody: {
+                required: true,
+                content: {
+                  'multipart/form-data': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        files: { type: 'array', items: { type: 'string', format: 'binary' } },
+                        tags: { type: 'array', items: { type: 'string' } },
+                      },
+                      required: ['files'],
+                    },
+                  },
+                },
+              },
+              responses: { '200': { description: 'Uploaded' } },
+            },
+          },
+        },
+      },
+    },
+  });
+  await client.initialize();
+  const request = jest.fn().mockResolvedValue({ data: { ok: true } });
+  (client as unknown as { httpClient: { request: jest.Mock } }).httpClient = { request };
+  return { client, request, tool: client.getTools()[0] };
+}
+
+describe('OpenAPIClient multipart file arrays', () => {
+  test('uploads advertised base64 array items as repeated binary file parts', async () => {
+    const { client, request, tool } = await createUploadClient();
+    expect(tool.inputSchema).toMatchObject({
+      properties: {
+        body: {
+          properties: {
+            files: {
+              type: 'array',
+              items: { type: 'string', description: expect.stringContaining('base64') },
+            },
+          },
+        },
+      },
+    });
+    const files = [Buffer.from([0, 255, 128, 13, 10]), Buffer.from('second file')];
+    await client.callTool(tool.name, {
+      body: { files: files.map((file) => file.toString('base64')), tags: ['first', 'second'] },
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const config = request.mock.calls[0][0];
+    const boundary = config.headers['Content-Type'].split('boundary=')[1];
+    const fileHeader = `--${boundary}\r\nContent-Disposition: form-data; name="files"; filename="upload"\r\nContent-Type: application/octet-stream\r\n\r\n`;
+    expect(config.data).toEqual(
+      Buffer.concat([
+        Buffer.from(fileHeader),
+        files[0],
+        Buffer.from('\r\n'),
+        Buffer.from(fileHeader),
+        files[1],
+        Buffer.from('\r\n'),
+        Buffer.from(
+          `--${boundary}\r\nContent-Disposition: form-data; name="tags"\r\n\r\nfirst\r\n`,
+        ),
+        Buffer.from(
+          `--${boundary}\r\nContent-Disposition: form-data; name="tags"\r\n\r\nsecond\r\n`,
+        ),
+        Buffer.from(`--${boundary}--\r\n`),
+      ]),
+    );
+  });
+
+  test('rejects invalid base64 array items before sending a request', async () => {
+    const { client, request, tool } = await createUploadClient();
+    await expect(
+      client.callTool(tool.name, {
+        body: { files: [Buffer.from('valid').toString('base64'), 'not base64!!'] },
+      }),
+    ).rejects.toThrow(/'files'.*base64/i);
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  test('preserves file descriptors within binary arrays', async () => {
+    const { client, request, tool } = await createUploadClient();
+    await client.callTool(tool.name, {
+      body: { files: [{ content: 'aGk=', filename: 'hello.txt', contentType: 'text/plain' }] },
+    });
+    expect(request.mock.calls[0][0].data.toString()).toContain(
+      'name="files"; filename="hello.txt"\r\nContent-Type: text/plain\r\n\r\nhi\r\n',
+    );
+  });
+});

--- a/src/utils/openApiRequestBody.ts
+++ b/src/utils/openApiRequestBody.ts
@@ -219,7 +219,14 @@ export function buildMultipartParts(
   const properties = schema?.properties as Record<string, OpenAPIV3.SchemaObject> | undefined;
   const isBinaryField = (name: string): boolean => {
     const propertySchema = properties?.[name];
-    return !!propertySchema && propertySchema.type === 'string' && propertySchema.format === 'binary';
+    // Multipart arrays use the item schema to determine each repeated part's type.
+    const partSchema = propertySchema?.type === 'array' ? propertySchema.items : propertySchema;
+    return (
+      !!partSchema &&
+      'type' in partSchema &&
+      partSchema.type === 'string' &&
+      partSchema.format === 'binary'
+    );
   };
 
   const parts: MultipartPart[] = [];


### PR DESCRIPTION
OpenAPI multipart file arrays are advertised as base64 inputs, but were uploaded as plain base64 text without file headers. Classify each repeated part using the array's item schema so `items: {type: string, format: binary}` uses the existing binary decoding, filename/content-type defaults, and validation.

This completes file-array handling in the multipart support introduced by #1090. Ordinary text arrays, single files, and explicit file descriptors keep their existing behavior. Nested/composed schemas and empty-file validation policy are unchanged.

Regression tests exercise an initialized OpenAPI client and inspect exact serialized multipart bytes, including non-UTF-8 data, repeated fields, ordinary text arrays, and file descriptors. Invalid base64 rejects before sending. Two tests fail on unchanged source and pass with the fix.

Validation: all 1,394 tests, lint, full backend/frontend build, distribution verification, and changed-test formatting pass locally on Node 25. An independent rerun of all 23 request-body and multipart tests also passes. No live API or manual browser test was run; CI's Node 20/Linux environment was not reproduced locally.

AI assistance: OpenAI Codex (GPT-6) was used for investigation, implementation, review, and testing.
