### PR TITLE
fix(security): count only failed auth attempts and allow rate limit tuning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,19 @@ NODE_ENV=development
 # INIT_TIMEOUT=300000
 
 # Rate limiting (all optional; the defaults below are applied when unset).
-# Windows are in milliseconds. The auth limiter counts failed login attempts
-# only, so API clients and service accounts that re-authenticate on token
-# expiry are never locked out.
+# Windows are in milliseconds. The login limiter counts failed attempts only, so
+# API clients and service accounts that re-authenticate on token expiry are never
+# locked out; the registration limiter counts every request, because a successful
+# registration is what its cap exists to limit.
+#
+# Set any *_MAX to 0 (or "off") to remove that limit entirely. Note this is not
+# passed through to express-rate-limit, where a limit of 0 rejects every request.
+# Disabling a limiter logs a warning at startup; only do it where the deployment
+# is protected by other means.
 # AUTH_RATE_LIMIT_MAX=20
 # AUTH_RATE_LIMIT_WINDOW_MS=900000
+# REGISTER_RATE_LIMIT_MAX=20
+# REGISTER_RATE_LIMIT_WINDOW_MS=900000
 # API_RATE_LIMIT_MAX=600
 # API_RATE_LIMIT_WINDOW_MS=900000
 # MCP_RATE_LIMIT_MAX=480

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,23 @@ NODE_ENV=development
 # DEFAULT_REQUEST_TIMEOUT=60000
 # INIT_TIMEOUT=300000
 
+# Rate limiting (all optional; the defaults below are applied when unset).
+# Windows are in milliseconds. The auth limiter counts failed login attempts
+# only, so API clients and service accounts that re-authenticate on token
+# expiry are never locked out.
+# AUTH_RATE_LIMIT_MAX=20
+# AUTH_RATE_LIMIT_WINDOW_MS=900000
+# API_RATE_LIMIT_MAX=600
+# API_RATE_LIMIT_WINDOW_MS=900000
+# MCP_RATE_LIMIT_MAX=480
+# MCP_RATE_LIMIT_WINDOW_MS=60000
+# TEMPLATE_RATE_LIMIT_MAX=200
+# TEMPLATE_RATE_LIMIT_WINDOW_MS=900000
+# SPA_RATE_LIMIT_MAX=600
+# SPA_RATE_LIMIT_WINDOW_MS=60000
+# HOSTED_EVENT_RATE_LIMIT_MAX=600
+# HOSTED_EVENT_RATE_LIMIT_WINDOW_MS=60000
+
 # Database Configuration (Optional - for database-backed configuration)
 # Simply set DB_URL to enable database mode (auto-detected)
 # DB_URL=postgresql://mcphub:password@localhost:5432/mcphub

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -172,6 +172,7 @@ import { auth } from '../middlewares/auth.js';
 import { getBetterAuthRuntimeConfig } from '../services/betterAuthConfig.js';
 import {
   authAttemptRateLimiter,
+  authRegistrationRateLimiter,
   authenticatedRouteRateLimiter,
   hostedInternalEventRateLimiter,
   mcpConnectionRateLimiter,
@@ -435,7 +436,7 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
       check('username', 'Username is required').not().isEmpty(),
       check('password', 'Password must be at least 6 characters').isLength({ min: 6 }),
     ],
-    authAttemptRateLimiter,
+    authRegistrationRateLimiter,
     register,
   );
 

--- a/src/utils/rateLimit.test.ts
+++ b/src/utils/rateLimit.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 const rateLimitMock = jest.fn((options: unknown) => options);
 
@@ -8,11 +8,35 @@ jest.mock('express-rate-limit', () => ({
 }));
 
 import {
+  authAttemptRateLimiter,
   authenticatedRouteRateLimiter,
   createStandardRateLimiter,
   mcpConnectionRateLimiter,
   templateRateLimiter,
 } from './rateLimit.js';
+
+const ENV_KEYS = [
+  'AUTH_RATE_LIMIT_MAX',
+  'AUTH_RATE_LIMIT_WINDOW_MS',
+  'API_RATE_LIMIT_MAX',
+  'API_RATE_LIMIT_WINDOW_MS',
+];
+
+/** Re-evaluates the module so module-level limiters pick up the patched env. */
+const reloadWithEnv = async (env: Record<string, string>) => {
+  for (const [key, value] of Object.entries(env)) {
+    process.env[key] = value;
+  }
+  jest.resetModules();
+  return import('./rateLimit.js');
+};
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  jest.resetModules();
+});
 
 describe('rateLimit configuration', () => {
   it('uses relaxed default limits across authenticated, template, and MCP routes', () => {
@@ -43,5 +67,55 @@ describe('rateLimit configuration', () => {
     }) as { skip: () => boolean };
 
     expect(limiter.skip()).toBe(true);
+  });
+
+  it('answers with a JSON body so clients can parse the 429', () => {
+    expect(authenticatedRouteRateLimiter).toMatchObject({
+      message: { success: false, message: 'Too many requests, please try again later.' },
+    });
+  });
+
+  describe('auth attempt limiter', () => {
+    it('counts only failed attempts so successful logins never exhaust the window', () => {
+      expect(authAttemptRateLimiter).toMatchObject({
+        windowMs: 15 * 60 * 1000,
+        max: 20,
+        skipSuccessfulRequests: true,
+      });
+    });
+
+    it('keeps counting every request on the other limiters', () => {
+      expect(authenticatedRouteRateLimiter).not.toMatchObject({ skipSuccessfulRequests: true });
+      expect(mcpConnectionRateLimiter).not.toMatchObject({ skipSuccessfulRequests: true });
+    });
+  });
+
+  describe('environment overrides', () => {
+    it('applies positive integer overrides', async () => {
+      const mod = await reloadWithEnv({
+        AUTH_RATE_LIMIT_MAX: '100',
+        AUTH_RATE_LIMIT_WINDOW_MS: '60000',
+        API_RATE_LIMIT_MAX: '5000',
+      });
+
+      expect(mod.authAttemptRateLimiter).toMatchObject({ windowMs: 60000, max: 100 });
+      expect(mod.authenticatedRouteRateLimiter).toMatchObject({ max: 5000 });
+    });
+
+    it('falls back to the default when the value is not a positive integer', async () => {
+      const mod = await reloadWithEnv({
+        AUTH_RATE_LIMIT_MAX: 'not-a-number',
+        API_RATE_LIMIT_MAX: '-5',
+      });
+
+      expect(mod.authAttemptRateLimiter).toMatchObject({ max: 20 });
+      expect(mod.authenticatedRouteRateLimiter).toMatchObject({ max: 600 });
+    });
+
+    it('falls back to the default when the value is empty', async () => {
+      const mod = await reloadWithEnv({ AUTH_RATE_LIMIT_MAX: '   ' });
+
+      expect(mod.authAttemptRateLimiter).toMatchObject({ max: 20 });
+    });
   });
 });

--- a/src/utils/rateLimit.test.ts
+++ b/src/utils/rateLimit.test.ts
@@ -17,9 +17,18 @@ jest.mock('dotenv', () => ({
   default: { config: jest.fn() },
 }));
 
+const warnMock = jest.fn();
+
+jest.mock('./logger.js', () => ({
+  __esModule: true,
+  logger: { warn: warnMock, info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
 const ENV_KEYS = [
   'AUTH_RATE_LIMIT_MAX',
   'AUTH_RATE_LIMIT_WINDOW_MS',
+  'REGISTER_RATE_LIMIT_MAX',
+  'REGISTER_RATE_LIMIT_WINDOW_MS',
   'API_RATE_LIMIT_MAX',
   'API_RATE_LIMIT_WINDOW_MS',
   'MCP_RATE_LIMIT_MAX',
@@ -43,17 +52,46 @@ const clearEnv = () => {
  * cleared first, so a test asserting a default never depends on what happens to
  * be set in the ambient environment.
  */
-const loadRateLimit = async (env: Record<string, string> = {}) => {
+const loadRateLimit = async (
+  env: Record<string, string> = {},
+  options: { productionLike?: boolean } = {},
+) => {
   clearEnv();
   for (const [key, value] of Object.entries(env)) {
     process.env[key] = value;
   }
+
+  // `skip()` is always true under a test runner, so asserting that a limiter is
+  // disabled by configuration requires evaluating the module as production would.
+  const restore: Array<() => void> = [];
+  if (options.productionLike) {
+    for (const key of ['NODE_ENV', 'JEST_WORKER_ID', 'VITEST_WORKER_ID']) {
+      const previous = process.env[key];
+      restore.push(() => {
+        if (previous === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = previous;
+        }
+      });
+      delete process.env[key];
+    }
+    process.env.NODE_ENV = 'production';
+  }
+
   jest.resetModules();
-  return import('./rateLimit.js');
+  try {
+    return await import('./rateLimit.js');
+  } finally {
+    for (const undo of restore) {
+      undo();
+    }
+  }
 };
 
 beforeEach(() => {
   clearEnv();
+  warnMock.mockClear();
 });
 
 afterEach(() => {
@@ -118,10 +156,84 @@ describe('rateLimit configuration', () => {
     it('keeps counting every request on the other limiters', async () => {
       const mod = await loadRateLimit();
 
-      expect(mod.authenticatedRouteRateLimiter).not.toMatchObject({
+      for (const limiter of [
+        mod.authenticatedRouteRateLimiter,
+        mod.mcpConnectionRateLimiter,
+        mod.templateRateLimiter,
+        mod.spaPageRateLimiter,
+        mod.hostedInternalEventRateLimiter,
+        mod.authRegistrationRateLimiter,
+      ]) {
+        expect(limiter).not.toMatchObject({ skipSuccessfulRequests: true });
+      }
+    });
+  });
+
+  describe('registration limiter', () => {
+    it('counts successful registrations so the per-IP account cap survives', async () => {
+      const mod = await loadRateLimit();
+
+      // /auth/register is ungated: a successful request creates an account, which is
+      // exactly what the cap exists to limit. It must not inherit skipSuccessfulRequests
+      // from the login limiter.
+      expect(mod.authRegistrationRateLimiter).toMatchObject({
+        windowMs: 15 * 60 * 1000,
+        max: 20,
+      });
+      expect(mod.authRegistrationRateLimiter).not.toMatchObject({
         skipSuccessfulRequests: true,
       });
-      expect(mod.mcpConnectionRateLimiter).not.toMatchObject({ skipSuccessfulRequests: true });
+    });
+
+    it('has its own budget so login traffic cannot exhaust it', async () => {
+      const mod = await loadRateLimit({
+        AUTH_RATE_LIMIT_MAX: '500',
+        REGISTER_RATE_LIMIT_MAX: '5',
+        REGISTER_RATE_LIMIT_WINDOW_MS: '60000',
+      });
+
+      expect(mod.authAttemptRateLimiter).toMatchObject({ max: 500 });
+      expect(mod.authRegistrationRateLimiter).toMatchObject({ max: 5, windowMs: 60000 });
+    });
+  });
+
+  describe('disabling a limiter', () => {
+    it('treats 0 as unlimited rather than blocking every request', async () => {
+      // express-rate-limit >= 7 rejects every request when limit is 0, so an operator
+      // reaching for "no limit" must not have that value passed through verbatim.
+      const mod = await loadRateLimit({ AUTH_RATE_LIMIT_MAX: '0' }, { productionLike: true });
+
+      const auth = mod.authAttemptRateLimiter as unknown as { skip: () => boolean; max: number };
+      expect(auth.skip()).toBe(true);
+      expect(auth.max).toBeGreaterThan(0);
+    });
+
+    it('accepts off as a spelling of unlimited', async () => {
+      const mod = await loadRateLimit({ API_RATE_LIMIT_MAX: 'off' }, { productionLike: true });
+
+      expect((mod.authenticatedRouteRateLimiter as unknown as { skip: () => boolean }).skip()).toBe(
+        true,
+      );
+    });
+
+    it('leaves every other limiter enabled', async () => {
+      const mod = await loadRateLimit({ AUTH_RATE_LIMIT_MAX: '0' }, { productionLike: true });
+
+      for (const limiter of [
+        mod.authenticatedRouteRateLimiter,
+        mod.mcpConnectionRateLimiter,
+        mod.authRegistrationRateLimiter,
+      ]) {
+        expect((limiter as unknown as { skip: () => boolean }).skip()).toBe(false);
+      }
+    });
+
+    it('warns so a disabled limiter is visible in the logs', async () => {
+      await loadRateLimit({ AUTH_RATE_LIMIT_MAX: '0' });
+
+      expect(warnMock).toHaveBeenCalledWith(
+        expect.stringContaining('Rate limiting disabled by AUTH_RATE_LIMIT_MAX'),
+      );
     });
   });
 

--- a/src/utils/rateLimit.test.ts
+++ b/src/utils/rateLimit.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const rateLimitMock = jest.fn((options: unknown) => options);
 
@@ -7,23 +7,44 @@ jest.mock('express-rate-limit', () => ({
   default: rateLimitMock,
 }));
 
-import {
-  authAttemptRateLimiter,
-  authenticatedRouteRateLimiter,
-  createStandardRateLimiter,
-  mcpConnectionRateLimiter,
-  templateRateLimiter,
-} from './rateLimit.js';
+// rateLimit.ts calls dotenv.config() at module scope so its limits do not depend
+// on evaluation order. Stub it here: without this the module would read the
+// developer's real .env, and the default-value assertions below would fail on
+// exactly the machines this feature is aimed at - the ones that set these
+// variables.
+jest.mock('dotenv', () => ({
+  __esModule: true,
+  default: { config: jest.fn() },
+}));
 
 const ENV_KEYS = [
   'AUTH_RATE_LIMIT_MAX',
   'AUTH_RATE_LIMIT_WINDOW_MS',
   'API_RATE_LIMIT_MAX',
   'API_RATE_LIMIT_WINDOW_MS',
+  'MCP_RATE_LIMIT_MAX',
+  'MCP_RATE_LIMIT_WINDOW_MS',
+  'TEMPLATE_RATE_LIMIT_MAX',
+  'TEMPLATE_RATE_LIMIT_WINDOW_MS',
+  'SPA_RATE_LIMIT_MAX',
+  'SPA_RATE_LIMIT_WINDOW_MS',
+  'HOSTED_EVENT_RATE_LIMIT_MAX',
+  'HOSTED_EVENT_RATE_LIMIT_WINDOW_MS',
 ];
 
-/** Re-evaluates the module so module-level limiters pick up the patched env. */
-const reloadWithEnv = async (env: Record<string, string>) => {
+const clearEnv = () => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+};
+
+/**
+ * Evaluates the module against a known environment. Every rate-limit variable is
+ * cleared first, so a test asserting a default never depends on what happens to
+ * be set in the ambient environment.
+ */
+const loadRateLimit = async (env: Record<string, string> = {}) => {
+  clearEnv();
   for (const [key, value] of Object.entries(env)) {
     process.env[key] = value;
   }
@@ -31,28 +52,32 @@ const reloadWithEnv = async (env: Record<string, string>) => {
   return import('./rateLimit.js');
 };
 
+beforeEach(() => {
+  clearEnv();
+});
+
 afterEach(() => {
-  for (const key of ENV_KEYS) {
-    delete process.env[key];
-  }
+  clearEnv();
   jest.resetModules();
 });
 
 describe('rateLimit configuration', () => {
-  it('uses relaxed default limits across authenticated, template, and MCP routes', () => {
-    expect(templateRateLimiter).toMatchObject({
+  it('uses relaxed default limits across authenticated, template, and MCP routes', async () => {
+    const mod = await loadRateLimit();
+
+    expect(mod.templateRateLimiter).toMatchObject({
       windowMs: 15 * 60 * 1000,
       max: 200,
       standardHeaders: true,
       legacyHeaders: false,
     });
-    expect(authenticatedRouteRateLimiter).toMatchObject({
+    expect(mod.authenticatedRouteRateLimiter).toMatchObject({
       windowMs: 15 * 60 * 1000,
       max: 600,
       standardHeaders: true,
       legacyHeaders: false,
     });
-    expect(mcpConnectionRateLimiter).toMatchObject({
+    expect(mod.mcpConnectionRateLimiter).toMatchObject({
       windowMs: 60 * 1000,
       max: 480,
       standardHeaders: true,
@@ -60,39 +85,49 @@ describe('rateLimit configuration', () => {
     });
   });
 
-  it('skips rate limiting automatically in test environments', () => {
-    const limiter = createStandardRateLimiter({
+  it('skips rate limiting automatically in test environments', async () => {
+    const mod = await loadRateLimit();
+
+    const limiter = mod.createStandardRateLimiter({
       windowMs: 1000,
       max: 1,
-    }) as { skip: () => boolean };
+    }) as unknown as { skip: () => boolean };
 
     expect(limiter.skip()).toBe(true);
   });
 
-  it('answers with a JSON body so clients can parse the 429', () => {
-    expect(authenticatedRouteRateLimiter).toMatchObject({
+  it('answers with a JSON body so clients can parse the 429', async () => {
+    const mod = await loadRateLimit();
+
+    expect(mod.authenticatedRouteRateLimiter).toMatchObject({
       message: { success: false, message: 'Too many requests, please try again later.' },
     });
   });
 
   describe('auth attempt limiter', () => {
-    it('counts only failed attempts so successful logins never exhaust the window', () => {
-      expect(authAttemptRateLimiter).toMatchObject({
+    it('counts only failed attempts so successful logins never exhaust the window', async () => {
+      const mod = await loadRateLimit();
+
+      expect(mod.authAttemptRateLimiter).toMatchObject({
         windowMs: 15 * 60 * 1000,
         max: 20,
         skipSuccessfulRequests: true,
       });
     });
 
-    it('keeps counting every request on the other limiters', () => {
-      expect(authenticatedRouteRateLimiter).not.toMatchObject({ skipSuccessfulRequests: true });
-      expect(mcpConnectionRateLimiter).not.toMatchObject({ skipSuccessfulRequests: true });
+    it('keeps counting every request on the other limiters', async () => {
+      const mod = await loadRateLimit();
+
+      expect(mod.authenticatedRouteRateLimiter).not.toMatchObject({
+        skipSuccessfulRequests: true,
+      });
+      expect(mod.mcpConnectionRateLimiter).not.toMatchObject({ skipSuccessfulRequests: true });
     });
   });
 
   describe('environment overrides', () => {
     it('applies positive integer overrides', async () => {
-      const mod = await reloadWithEnv({
+      const mod = await loadRateLimit({
         AUTH_RATE_LIMIT_MAX: '100',
         AUTH_RATE_LIMIT_WINDOW_MS: '60000',
         API_RATE_LIMIT_MAX: '5000',
@@ -102,8 +137,26 @@ describe('rateLimit configuration', () => {
       expect(mod.authenticatedRouteRateLimiter).toMatchObject({ max: 5000 });
     });
 
+    it('covers every limiter family', async () => {
+      const mod = await loadRateLimit({
+        TEMPLATE_RATE_LIMIT_MAX: '11',
+        API_RATE_LIMIT_MAX: '12',
+        HOSTED_EVENT_RATE_LIMIT_MAX: '13',
+        MCP_RATE_LIMIT_MAX: '14',
+        AUTH_RATE_LIMIT_MAX: '15',
+        SPA_RATE_LIMIT_MAX: '16',
+      });
+
+      expect(mod.templateRateLimiter).toMatchObject({ max: 11 });
+      expect(mod.authenticatedRouteRateLimiter).toMatchObject({ max: 12 });
+      expect(mod.hostedInternalEventRateLimiter).toMatchObject({ max: 13 });
+      expect(mod.mcpConnectionRateLimiter).toMatchObject({ max: 14 });
+      expect(mod.authAttemptRateLimiter).toMatchObject({ max: 15 });
+      expect(mod.spaPageRateLimiter).toMatchObject({ max: 16 });
+    });
+
     it('falls back to the default when the value is not a positive integer', async () => {
-      const mod = await reloadWithEnv({
+      const mod = await loadRateLimit({
         AUTH_RATE_LIMIT_MAX: 'not-a-number',
         API_RATE_LIMIT_MAX: '-5',
       });
@@ -113,7 +166,7 @@ describe('rateLimit configuration', () => {
     });
 
     it('falls back to the default when the value is empty', async () => {
-      const mod = await reloadWithEnv({ AUTH_RATE_LIMIT_MAX: '   ' });
+      const mod = await loadRateLimit({ AUTH_RATE_LIMIT_MAX: '   ' });
 
       expect(mod.authAttemptRateLimiter).toMatchObject({ max: 20 });
     });

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -1,44 +1,88 @@
 import rateLimit from 'express-rate-limit';
+import dotenv from 'dotenv';
+import { logger } from './logger.js';
+
+// Self-contained so the limits below do not depend on this module being
+// evaluated after src/config, which also loads the environment.
+dotenv.config({ quiet: true });
 
 const isTestEnv =
   process.env.NODE_ENV === 'test' ||
   process.env.JEST_WORKER_ID !== undefined ||
   process.env.VITEST_WORKER_ID !== undefined;
 
-export const createStandardRateLimiter = (options: { windowMs: number; max: number }) =>
+/**
+ * Reads a positive integer from the environment, falling back to the built-in
+ * default when the variable is unset, empty, or not a positive integer. Every
+ * limit below keeps its previous value when the variable is absent, so this is
+ * opt-in for operators who need different thresholds.
+ */
+const envInt = (name: string, fallback: number): number => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    logger.warn(
+      `Ignoring invalid ${name}="${raw}"; expected a positive integer. Using ${fallback}.`,
+    );
+    return fallback;
+  }
+
+  return parsed;
+};
+
+const MINUTES_15 = 15 * 60 * 1000;
+const MINUTE_1 = 60 * 1000;
+
+export const createStandardRateLimiter = (options: {
+  windowMs: number;
+  max: number;
+  skipSuccessfulRequests?: boolean;
+}) =>
   rateLimit({
     ...options,
     standardHeaders: true,
     legacyHeaders: false,
     skip: () => isTestEnv,
+    // The rest of the API answers with JSON; without this the 429 body is bare
+    // text, so clients that parse the response as JSON lose the error entirely.
+    message: { success: false, message: 'Too many requests, please try again later.' },
   });
 
 export const templateRateLimiter = createStandardRateLimiter({
-  windowMs: 15 * 60 * 1000,
-  max: 200,
+  windowMs: envInt('TEMPLATE_RATE_LIMIT_WINDOW_MS', MINUTES_15),
+  max: envInt('TEMPLATE_RATE_LIMIT_MAX', 200),
 });
 
 export const authenticatedRouteRateLimiter = createStandardRateLimiter({
-  windowMs: 15 * 60 * 1000,
-  max: 600,
+  windowMs: envInt('API_RATE_LIMIT_WINDOW_MS', MINUTES_15),
+  max: envInt('API_RATE_LIMIT_MAX', 600),
 });
 
 export const hostedInternalEventRateLimiter = createStandardRateLimiter({
-  windowMs: 60 * 1000,
-  max: 600,
+  windowMs: envInt('HOSTED_EVENT_RATE_LIMIT_WINDOW_MS', MINUTE_1),
+  max: envInt('HOSTED_EVENT_RATE_LIMIT_MAX', 600),
 });
 
 export const mcpConnectionRateLimiter = createStandardRateLimiter({
-  windowMs: 60 * 1000,
-  max: 480,
+  windowMs: envInt('MCP_RATE_LIMIT_WINDOW_MS', MINUTE_1),
+  max: envInt('MCP_RATE_LIMIT_MAX', 480),
 });
 
 export const authAttemptRateLimiter = createStandardRateLimiter({
-  windowMs: 15 * 60 * 1000,
-  max: 20,
+  windowMs: envInt('AUTH_RATE_LIMIT_WINDOW_MS', MINUTES_15),
+  max: envInt('AUTH_RATE_LIMIT_MAX', 20),
+  // Brute-force protection is about failed credentials. Counting successful
+  // logins adds no protection but locks out legitimate clients that hold no
+  // session -- API consumers and service accounts re-authenticate on every
+  // token expiry, and a burst of concurrent renewals exhausts the window.
+  skipSuccessfulRequests: true,
 });
 
 export const spaPageRateLimiter = createStandardRateLimiter({
-  windowMs: 60 * 1000,
-  max: 600,
+  windowMs: envInt('SPA_RATE_LIMIT_WINDOW_MS', MINUTE_1),
+  max: envInt('SPA_RATE_LIMIT_MAX', 600),
 });

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -34,47 +34,79 @@ const envInt = (name: string, fallback: number): number => {
   return parsed;
 };
 
+/**
+ * Reads a request cap, additionally accepting `0` or `off` to mean "no limit".
+ *
+ * The value cannot simply be forwarded to express-rate-limit: since v7 a `limit`
+ * of 0 rejects every request instead of disabling the limiter, so an operator
+ * reaching for "unlimited" would lock themselves out completely. Disabling is
+ * expressed through `skip` instead.
+ */
+const envLimit = (name: string, fallback: number): number | typeof UNLIMITED => {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === '0' || normalized === 'off' || normalized === 'unlimited') {
+    logger.warn(
+      `Rate limiting disabled by ${name}="${raw}". Requests to these routes are no longer capped; only do this where the deployment is protected by other means.`,
+    );
+    return UNLIMITED;
+  }
+
+  return envInt(name, fallback);
+};
+
+const UNLIMITED = Symbol('unlimited');
+
 const MINUTES_15 = 15 * 60 * 1000;
 const MINUTE_1 = 60 * 1000;
 
 export const createStandardRateLimiter = (options: {
   windowMs: number;
-  max: number;
+  max: number | typeof UNLIMITED;
   skipSuccessfulRequests?: boolean;
-}) =>
-  rateLimit({
-    ...options,
+}) => {
+  const { max, ...rest } = options;
+
+  return rateLimit({
+    ...rest,
+    // Kept positive so the middleware never blocks; `skip` is what disables it.
+    max: max === UNLIMITED ? Number.MAX_SAFE_INTEGER : max,
     standardHeaders: true,
     legacyHeaders: false,
-    skip: () => isTestEnv,
+    skip: () => isTestEnv || max === UNLIMITED,
     // The rest of the API answers with JSON; without this the 429 body is bare
     // text, so clients that parse the response as JSON lose the error entirely.
     message: { success: false, message: 'Too many requests, please try again later.' },
   });
+};
 
 export const templateRateLimiter = createStandardRateLimiter({
   windowMs: envInt('TEMPLATE_RATE_LIMIT_WINDOW_MS', MINUTES_15),
-  max: envInt('TEMPLATE_RATE_LIMIT_MAX', 200),
+  max: envLimit('TEMPLATE_RATE_LIMIT_MAX', 200),
 });
 
 export const authenticatedRouteRateLimiter = createStandardRateLimiter({
   windowMs: envInt('API_RATE_LIMIT_WINDOW_MS', MINUTES_15),
-  max: envInt('API_RATE_LIMIT_MAX', 600),
+  max: envLimit('API_RATE_LIMIT_MAX', 600),
 });
 
 export const hostedInternalEventRateLimiter = createStandardRateLimiter({
   windowMs: envInt('HOSTED_EVENT_RATE_LIMIT_WINDOW_MS', MINUTE_1),
-  max: envInt('HOSTED_EVENT_RATE_LIMIT_MAX', 600),
+  max: envLimit('HOSTED_EVENT_RATE_LIMIT_MAX', 600),
 });
 
 export const mcpConnectionRateLimiter = createStandardRateLimiter({
   windowMs: envInt('MCP_RATE_LIMIT_WINDOW_MS', MINUTE_1),
-  max: envInt('MCP_RATE_LIMIT_MAX', 480),
+  max: envLimit('MCP_RATE_LIMIT_MAX', 480),
 });
 
 export const authAttemptRateLimiter = createStandardRateLimiter({
   windowMs: envInt('AUTH_RATE_LIMIT_WINDOW_MS', MINUTES_15),
-  max: envInt('AUTH_RATE_LIMIT_MAX', 20),
+  max: envLimit('AUTH_RATE_LIMIT_MAX', 20),
   // Brute-force protection is about failed credentials. Counting successful
   // logins adds no protection but locks out legitimate clients that hold no
   // session -- API consumers and service accounts re-authenticate on every
@@ -82,7 +114,16 @@ export const authAttemptRateLimiter = createStandardRateLimiter({
   skipSuccessfulRequests: true,
 });
 
+// /auth/register is ungated and a successful request creates an account, so this
+// limiter deliberately counts every request -- successes are the thing being
+// capped. It is separate from the login limiter so the two cannot exhaust each
+// other's budget.
+export const authRegistrationRateLimiter = createStandardRateLimiter({
+  windowMs: envInt('REGISTER_RATE_LIMIT_WINDOW_MS', MINUTES_15),
+  max: envLimit('REGISTER_RATE_LIMIT_MAX', 20),
+});
+
 export const spaPageRateLimiter = createStandardRateLimiter({
   windowMs: envInt('SPA_RATE_LIMIT_WINDOW_MS', MINUTE_1),
-  max: envInt('SPA_RATE_LIMIT_MAX', 600),
+  max: envLimit('SPA_RATE_LIMIT_MAX', 600),
 });

--- a/tests/integration/auth-rate-limit.test.ts
+++ b/tests/integration/auth-rate-limit.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import express from 'express';
+import type { RequestHandler } from 'express';
+import request from 'supertest';
+
+const ENV_KEYS = [
+  'AUTH_RATE_LIMIT_MAX',
+  'AUTH_RATE_LIMIT_WINDOW_MS',
+  'REGISTER_RATE_LIMIT_MAX',
+  'REGISTER_RATE_LIMIT_WINDOW_MS',
+];
+
+const originalEnv = process.env;
+
+/**
+ * Loads the real limiters against an explicit environment.
+ *
+ * Two things are deliberate. Every limit this suite asserts is set explicitly
+ * rather than relying on defaults, because `rateLimit.ts` calls `dotenv.config()`
+ * at module scope and would otherwise read a developer's `.env`. And the test
+ * runner markers are removed, because the shared limiters disable themselves
+ * under a test runner (`skip: () => isTestEnv`) — without this the middleware
+ * would be a no-op and prove nothing.
+ */
+const loadLimiters = async (env: Record<string, string>) => {
+  jest.resetModules();
+  process.env = { ...originalEnv, NODE_ENV: 'production' };
+  delete process.env.JEST_WORKER_ID;
+  delete process.env.VITEST_WORKER_ID;
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+  Object.assign(process.env, env);
+
+  const mod = await import('../../src/utils/rateLimit.js');
+  return {
+    login: mod.authAttemptRateLimiter as unknown as RequestHandler,
+    register: mod.authRegistrationRateLimiter as unknown as RequestHandler,
+  };
+};
+
+const buildApp = (limiters: { login: RequestHandler; register: RequestHandler }) => {
+  const app = express();
+  app.post('/api/auth/login', limiters.login, (req, res) => {
+    if (req.headers['x-valid-credentials'] === 'true') {
+      res.status(200).json({ success: true, token: 'token' });
+      return;
+    }
+    res.status(401).json({ success: false, message: 'Invalid credentials' });
+  });
+  app.post('/api/auth/register', limiters.register, (_req, res) => {
+    res.status(200).json({ success: true });
+  });
+  return app;
+};
+
+const post = (app: express.Express, path: string, valid = false) => {
+  const pending = request(app).post(path);
+  return valid ? pending.set('x-valid-credentials', 'true') : pending;
+};
+
+describe('auth rate limiting', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  it('does not spend the login budget on successful logins', async () => {
+    const app = buildApp(
+      await loadLimiters({ AUTH_RATE_LIMIT_MAX: '20', AUTH_RATE_LIMIT_WINDOW_MS: '900000' }),
+    );
+
+    // A service account re-authenticating in a burst — for example after a restart
+    // invalidated its cached token — must not lock itself out with valid credentials.
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      expect((await post(app, '/api/auth/login', true)).status).toBe(200);
+    }
+
+    expect((await post(app, '/api/auth/login')).status).toBe(401);
+  });
+
+  it('still blocks repeated failed logins', async () => {
+    const app = buildApp(
+      await loadLimiters({ AUTH_RATE_LIMIT_MAX: '20', AUTH_RATE_LIMIT_WINDOW_MS: '900000' }),
+    );
+
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 21; attempt += 1) {
+      statuses.push((await post(app, '/api/auth/login')).status);
+    }
+
+    expect(statuses.slice(0, 20)).toEqual(Array(20).fill(401));
+    expect(statuses[20]).toBe(429);
+  });
+
+  it('answers a blocked request with a JSON body', async () => {
+    const app = buildApp(
+      await loadLimiters({ AUTH_RATE_LIMIT_MAX: '1', AUTH_RATE_LIMIT_WINDOW_MS: '900000' }),
+    );
+
+    await post(app, '/api/auth/login');
+    const blocked = await post(app, '/api/auth/login');
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toEqual({
+      success: false,
+      message: 'Too many requests, please try again later.',
+    });
+  });
+
+  it('keeps capping successful registrations', async () => {
+    const app = buildApp(
+      await loadLimiters({ REGISTER_RATE_LIMIT_MAX: '3', REGISTER_RATE_LIMIT_WINDOW_MS: '900000' }),
+    );
+
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      statuses.push((await post(app, '/api/auth/register')).status);
+    }
+
+    // Unlike login, a successful registration is exactly what the cap exists to limit.
+    expect(statuses).toEqual([200, 200, 200, 429]);
+  });
+
+  it('does not let login traffic exhaust the registration budget', async () => {
+    const app = buildApp(
+      await loadLimiters({ AUTH_RATE_LIMIT_MAX: '2', REGISTER_RATE_LIMIT_MAX: '3' }),
+    );
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await post(app, '/api/auth/login');
+    }
+    expect((await post(app, '/api/auth/login')).status).toBe(429);
+
+    expect((await post(app, '/api/auth/register')).status).toBe(200);
+  });
+
+  it('applies no limit at all when the cap is disabled', async () => {
+    const app = buildApp(await loadLimiters({ AUTH_RATE_LIMIT_MAX: '0' }));
+
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      statuses.push((await post(app, '/api/auth/login')).status);
+    }
+
+    // Every one of these is a *failed* login: with the limiter disabled not even
+    // those are capped, and none of them may turn into a 429.
+    expect(statuses).toEqual(Array(40).fill(401));
+  });
+});


### PR DESCRIPTION
Fixes #1134

## Behaviour change

`authAttemptRateLimiter` counted every request to `POST /api/auth/login`, successful ones
included. Brute-force protection only needs to count failures, so counting successes adds no
protection while locking out legitimate clients that hold no browser session: API consumers
and service accounts re-authenticate whenever their token expires, and a burst of concurrent
renewals exhausts the 20-request window. The caller is then locked out for the rest of the
window (`Retry-After` up to ~592s) despite holding valid credentials.

### How this surfaced

We integrate MCPHub through a single admin service account and cache its token, so in steady
state we log in about once a day — the budget is far more than we need. The problem is the
moment the cache misses (token expiry, restart, a 401 forcing renewal): every in-flight
request discovers the miss at once and each one logs in. Our app runs as a container behind a
single egress IP, so those renewals share one budget, twenty of them exhaust the window, and
for the next ~10 minutes every login is rejected. Our server listing then returned `null`
status for every MCP server while MCPHub itself was healthy and serving other clients.

We are fixing the stampede on our side too, by serialising token renewal. That does not close
the gap on its own: multiple processes and containers still share one IP budget, an operator
behind a shared egress cannot raise the threshold without rebuilding the image, and a 429 that
is not JSON stays undiagnosable for clients that treat the API as JSON.

## What this PR does

1. **Sets `skipSuccessfulRequests` on the auth limiter.** Failed-attempt protection is
   unchanged; only successful logins stop being counted, so the persistent lockout after a
   renewal burst is gone. (A truly concurrent burst can still see transient 429s while
   requests are in flight — the limiter checks the count at request time and only decrements
   successful ones on completion — which is why serialising renewal matters; the persistent
   lockout is what this change removes.)
2. **Gives `/auth/register` its own limiter that counts every request.** It previously shared
   `authAttemptRateLimiter`, so `skipSuccessfulRequests` would have silently removed the
   20-accounts/15-min per-IP cap from an ungated endpoint where a successful request is
   precisely what the cap exists to limit. The login and registration budgets are now
   independent, so neither can exhaust the other.
3. **Makes every limit configurable from the environment**, each keeping its current value as
   the default, so this is a no-op for existing deployments. Operators behind a shared egress
   IP can raise thresholds without patching and rebuilding. Invalid values are ignored with a
   warning rather than silently disabling a limit.
4. **Allows any `*_MAX` to be set to `0` (or `off` / `unlimited`) to remove that limit
   entirely.** The value cannot be forwarded to express-rate-limit, where a limit of `0`
   rejects every request; disabling is expressed through `skip` instead and logs a warning at
   startup.
5. **Returns the 429 body as JSON**, matching the rest of the API — this applies to every
   limiter, including the SPA-page limiter. Clients parsing responses as JSON previously
   received `null` for the bare text body and could not distinguish rate limiting from other
   failures.

New environment variables (all optional, documented in `.env.example`):

| Variable | Default |
| --- | --- |
| `AUTH_RATE_LIMIT_MAX` / `AUTH_RATE_LIMIT_WINDOW_MS` | 20 / 900000 |
| `REGISTER_RATE_LIMIT_MAX` / `REGISTER_RATE_LIMIT_WINDOW_MS` | 20 / 900000 |
| `API_RATE_LIMIT_MAX` / `API_RATE_LIMIT_WINDOW_MS` | 600 / 900000 |
| `MCP_RATE_LIMIT_MAX` / `MCP_RATE_LIMIT_WINDOW_MS` | 480 / 60000 |
| `TEMPLATE_RATE_LIMIT_MAX` / `TEMPLATE_RATE_LIMIT_WINDOW_MS` | 200 / 900000 |
| `SPA_RATE_LIMIT_MAX` / `SPA_RATE_LIMIT_WINDOW_MS` | 600 / 60000 |
| `HOSTED_EVENT_RATE_LIMIT_MAX` / `HOSTED_EVENT_RATE_LIMIT_WINDOW_MS` | 600 / 60000 |

## Security note

The limiter middleware stays applied to exactly the same routes, so the CodeQL rate-limiting
alerts closed by #1066 remain closed. Only the counting predicate on the auth route changes,
from "every request" to "failed requests"; `/auth/register` keeps counting every request on
its own limiter.

## Automated validation

- `npx jest src/utils/rateLimit.test.ts` — 15 passed, hermetic: verified with no variables
  set, with `AUTH_RATE_LIMIT_MAX=100`, with all fourteen variables set to non-default values,
  and with a real `.env` present.
- `npx jest tests/integration/auth-rate-limit.test.ts` — 6 passed, driving the real
  middleware through supertest: successful logins never spend the budget, 20 failures still
  trip the window, the 429 body parses as JSON, successful registrations are still capped,
  the login and registration budgets are independent, and a disabled limiter caps nothing
  across 40 failed attempts.
- `npx jest` — full suite: 188 suites / 1409 tests pass. The failures seen on some machines
  (`src/utils/processTree.test.ts` and `tests/controllers/mcpbController.test.ts` on Windows;
  `tests/integration/sse-service-real-client.test.ts` timing out under full-suite load) fail
  identically on an unmodified checkout of this branch's base and pass in isolation.
- `pnpm backend:build` and `tsc --noEmit` — clean.
- `npx eslint src/utils/rateLimit.ts src/utils/rateLimit.test.ts` — clean.

## Manual validation

Compiled `dist/utils/rateLimit.js` copied into `samanhappy/mcphub:latest`, compared against an
unmodified container of the same image as a control.

| Scenario | Before | After |
| --- | --- | --- |
| 25 consecutive **successful** logins | `{"200":20,"429":5}` — locked at #21 | `{"200":25}` — none rejected |
| 24 consecutive **failed** logins | — | `{"401":20,"429":4}` — locked from #21, protection intact |
| 429 response body | `Too many requests, please try again later.` | `{"success":false,"message":"Too many requests, please try again later."}` |

Environment overrides, container started with `AUTH_RATE_LIMIT_MAX=3`,
`AUTH_RATE_LIMIT_WINDOW_MS=60000`, `API_RATE_LIMIT_MAX=99999`:

```
failed login #1 -> 401
failed login #2 -> 401
failed login #3 -> 401
failed login #4 -> 429   <- locked, AUTH_RATE_LIMIT_MAX=3 applied

GET /api/servers -> RateLimit-Policy: 99999;w=900   <- API_RATE_LIMIT_MAX applied
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
