### PR TITLE
docs: prefer gh CLI for GitHub operations in agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ MCPHub (`@samanhappy/mcphub`) is a TypeScript/Node.js ESM hub that aggregates MC
 - Treat the current implementation as the source of truth. If this guide disagrees with the code, follow the code and update the guide; tests document expected behavior and should change only when behavior intentionally changes.
 - Do not hand-edit generated output: `dist/`, `frontend/dist/`, or `coverage/`.
 - Read the scoped guide relevant to the files you will change. The full index is in [docs/agents/README.md](docs/agents/README.md).
+- Prefer the `gh` CLI for GitHub operations — reviewing PRs, reading issues, fetching diffs, creating PRs — over scraping the GitHub web UI or hand-calling the REST API. Command details live in [docs/agents/git-and-contribution.md](docs/agents/git-and-contribution.md).
 
 ## Project-specific build checks
 

--- a/docs/agents/git-and-contribution.md
+++ b/docs/agents/git-and-contribution.md
@@ -8,6 +8,23 @@
 
 GitHub Issues for `samanhappy/mcphub` are operated with `gh`. See [issue-tracker.md](issue-tracker.md) for commands and [triage-labels.md](triage-labels.md) for the canonical labels.
 
+## Pull request review
+
+Prefer the `gh` CLI over scraping the GitHub web UI or hand-calling the REST API. For a review, read the structured metadata, per-file patches, and the linked issue with:
+
+```bash
+gh pr view <number> --json title,body,files,commits,mergeable,headRefName,baseRefName
+gh pr diff <number>
+gh issue view <number>
+```
+
+`gh pr diff` prints the same unified diff as the web view. When the PR branch exists locally, cross-check it against the remote before judging the change:
+
+```bash
+git fetch origin pull/<number>/head:<local-branch>
+git diff main...<local-branch> --stat
+```
+
 ## Security advisories and code scanning
 
 For private GitHub security work, use `gh api` as the primary interface for


### PR DESCRIPTION
## Summary

Adds a durable agent-guide convention to reach for the `gh` CLI for GitHub operations instead of scraping the GitHub web UI or hand-calling the REST API.

- `AGENTS.md` (Always apply): one-line rule that agents should use `gh` for reviewing PRs, reading issues, fetching diffs, and creating PRs, with a link to the owning scoped guide for command details.
- `docs/agents/git-and-contribution.md`: new "Pull request review" section with the concrete `gh pr view --json`, `gh pr diff`, and `gh issue view` commands, plus a note to cross-check the remote PR branch against the local branch via `git fetch origin pull/<n>/head:<branch>`.

Placed per [docs/agents/guide-maintenance.md](docs/agents/guide-maintenance.md): the root `AGENTS.md` stays small and carries only the global convention; the actionable commands live in the smallest owning guide (`git-and-contribution.md`, which already documents `gh` for issues and security advisories — precedent #1125).

## Validation

- Markdown-only change; no build/tests affected.
- Existing `gh` workflow verified locally: `gh auth status`, `gh pr view`, `gh pr diff`, `gh issue view` all functional against this repository.
- This PR itself was created with `gh pr create` per the new convention.
