### PR TITLE
fix: reject multipart content type line breaks

### DIFF
--- a/src/utils/openApiRequestBody.test.ts
+++ b/src/utils/openApiRequestBody.test.ts
@@ -139,6 +139,37 @@ describe('openApiRequestBody utils (#1078)', () => {
       expect(body).toContain('\r\n\r\nhello\r\n');
       expect(body.trimEnd().endsWith('--BOUNDARY--')).toBe(true);
     });
+
+    test('rejects content types containing header line breaks', () => {
+      const parts: MultipartPart[] = [
+        {
+          name: 'file',
+          value: Buffer.from('x'),
+          filename: 'upload.txt',
+          contentType: 'text/plain\r\nX-MCPHub-Probe: injected',
+        },
+      ];
+
+      expect(() => serializeMultipartBody(parts, 'BOUNDARY')).toThrow(
+        /content type.*CR or LF/i,
+      );
+    });
+
+    test('preserves quoted MIME parameters in content types', () => {
+      const body = serializeMultipartBody(
+        [
+          {
+            name: 'file',
+            value: Buffer.from('x'),
+            filename: 'upload.txt',
+            contentType: 'text/plain; charset="utf-8"',
+          },
+        ],
+        'BOUNDARY',
+      ).toString('utf8');
+
+      expect(body).toContain('Content-Type: text/plain; charset="utf-8"');
+    });
   });
 
   describe('encodeFormUrlEncoded', () => {

--- a/src/utils/openApiRequestBody.ts
+++ b/src/utils/openApiRequestBody.ts
@@ -242,6 +242,12 @@ function sanitizeHeaderToken(token: string): string {
   return token.replace(/[\r\n"]/g, '_');
 }
 
+function assertValidMultipartContentType(contentType: string): void {
+  if (/\r|\n/.test(contentType)) {
+    throw new Error('Multipart part content type must not contain CR or LF');
+  }
+}
+
 export function serializeMultipartBody(parts: MultipartPart[], boundary: string): Buffer {
   const chunks: Buffer[] = [];
   for (const part of parts) {
@@ -253,8 +259,10 @@ export function serializeMultipartBody(parts: MultipartPart[], boundary: string)
           'utf8',
         ),
       );
+      const contentType = part.contentType ?? DEFAULT_UPLOAD_CONTENT_TYPE;
+      assertValidMultipartContentType(contentType);
       chunks.push(
-        Buffer.from(`Content-Type: ${part.contentType ?? DEFAULT_UPLOAD_CONTENT_TYPE}\r\n\r\n`, 'utf8'),
+        Buffer.from(`Content-Type: ${contentType}\r\n\r\n`, 'utf8'),
       );
       chunks.push(part.value as Buffer);
     } else {


### PR DESCRIPTION
## Summary

Reject CR or LF in the `contentType` of file multipart parts before serializing their `Content-Type` header.

Before this change, a descriptor such as `contentType: "text/plain\\r\\nX-MCPHub-Probe: injected"` emitted a second header line in the multipart body. The serializer now raises before producing the body. Names and filenames retain their existing sanitization behavior.

Quoted MIME parameters remain valid; `text/plain; charset="utf-8"` is preserved unchanged.

## Validation

- `pnpm exec jest src/utils/openApiRequestBody.test.ts --runInBand` — 13 passed
- `pnpm lint`
- `pnpm test:ci` — 188 suites, 1,405 tests passed
- `pnpm build`
- `node scripts/verify-dist.js`
- `git diff --check`

The new rejection test fails on the current `main` implementation because serialization did not throw.
