### PR TITLE
fix: serialize OpenAPI query arrays correctly

### DIFF
--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -868,13 +868,35 @@ export class OpenAPIClient {
 
       // Build query parameters
       const queryParams: Record<string, unknown> = {};
+      const serializedArrayQueryParams = new URLSearchParams();
       const queryParamDefs = tool.parameters?.filter((p) => p.in === 'query') || [];
 
       for (const param of queryParamDefs) {
         const value = args[param.name];
         if (value !== undefined) {
-          queryParams[param.name] = value;
+          // OpenAPI query parameters default to style=form and explode=true.
+          // Axios serializes arrays as `name[]=value`, which differs from the
+          // OpenAPI default of repeated `name=value` pairs. Keep non-form
+          // styles with Axios so this focused fix does not alter their current
+          // behavior.
+          if (
+            Array.isArray(value) &&
+            (param.style === undefined || param.style === 'form') &&
+            param.explode !== false
+          ) {
+            for (const item of value) {
+              if (item !== null && item !== undefined) {
+                serializedArrayQueryParams.append(param.name, String(item));
+              }
+            }
+          } else {
+            queryParams[param.name] = value;
+          }
         }
+      }
+
+      if (serializedArrayQueryParams.size > 0) {
+        url += `${url.includes('?') ? '&' : '?'}${serializedArrayQueryParams.toString()}`;
       }
 
       // Prepare request configuration

--- a/src/clients/openapi.ts
+++ b/src/clients/openapi.ts
@@ -885,7 +885,7 @@ export class OpenAPIClient {
             param.explode !== false
           ) {
             for (const item of value) {
-              if (item !== null && item !== undefined) {
+              if (item !== undefined) {
                 serializedArrayQueryParams.append(param.name, String(item));
               }
             }
@@ -895,8 +895,9 @@ export class OpenAPIClient {
         }
       }
 
-      if (serializedArrayQueryParams.size > 0) {
-        url += `${url.includes('?') ? '&' : '?'}${serializedArrayQueryParams.toString()}`;
+      const serializedArrayQuery = serializedArrayQueryParams.toString();
+      if (serializedArrayQuery) {
+        url += `${url.includes('?') ? '&' : '?'}${serializedArrayQuery}`;
       }
 
       // Prepare request configuration

--- a/tests/clients/openapiBaseUrl.test.ts
+++ b/tests/clients/openapiBaseUrl.test.ts
@@ -56,6 +56,7 @@ const specWithServers = (serverUrl: string | undefined) => ({
         operationId: 'ping',
         parameters: [
           { name: 'q', in: 'query', schema: { type: 'string' } },
+          { name: 'tag', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
         ],
         responses: { '200': { description: 'ok' } },
       },
@@ -135,6 +136,18 @@ describe('OpenAPIClient tool call base path resolution (#1098)', () => {
     expect(requestConfig).toMatchObject({
       baseURL: HOST,
       url: '/api/v1/ping',
+      params: { q: 'hello' },
+    });
+  });
+
+  test('serializes default-form query arrays as repeated parameter names', async () => {
+    const client = await makeInitializedClient(`${HOST}/api/v1`);
+    await client.callTool('ping', { q: 'hello', tag: ['alpha', 'beta'] });
+
+    const requestConfig = instances[0].request.mock.calls[0][0];
+    expect(requestConfig).toMatchObject({
+      baseURL: HOST,
+      url: '/api/v1/ping?tag=alpha&tag=beta',
       params: { q: 'hello' },
     });
   });

--- a/tests/clients/openapiBaseUrl.test.ts
+++ b/tests/clients/openapiBaseUrl.test.ts
@@ -151,4 +151,16 @@ describe('OpenAPIClient tool call base path resolution (#1098)', () => {
       params: { q: 'hello' },
     });
   });
+
+  test('preserves nullable items in default-form query arrays', async () => {
+    const client = await makeInitializedClient(`${HOST}/api/v1`);
+    await client.callTool('ping', { tag: [null, undefined, 'alpha'] });
+
+    const requestConfig = instances[0].request.mock.calls[0][0];
+    expect(requestConfig).toMatchObject({
+      baseURL: HOST,
+      url: '/api/v1/ping?tag=null&tag=alpha',
+      params: {},
+    });
+  });
 });


### PR DESCRIPTION
## Summary

OpenAPI query parameters default to `style: form` and `explode: true`, so an array such as `tag: ["alpha", "beta"]` must be sent as `?tag=alpha&tag=beta`. MCPHub previously passed arrays to Axios, which serializes them as `?tag[]=alpha&tag[]=beta`; APIs that follow the OpenAPI default do not receive the declared parameter name.

This change serializes default-form exploded arrays into the request URL before Axios processes the remaining query parameters. Explicit non-form styles and `explode: false` retain their existing behavior.

## Validation

- Added a regression test covering an OpenAPI operation behind a server base path with scalar and array query parameters.
- `pnpm exec jest tests/clients/openapiBaseUrl.test.ts --runInBand` — 6 passed.
- `pnpm test --runInBand` — 189 suites, 1,410 tests passed.
- `pnpm exec eslint src/clients/openapi.ts tests/clients/openapiBaseUrl.test.ts` — passed.
- `pnpm backend:build` — passed.
- `git diff --check` — passed.

AI assistance: OpenAI Codex (GPT-6) was used for investigation, implementation, and testing.
