### PR TITLE
fix: use group names in copied MCP configuration

### DIFF
--- a/frontend/src/components/GroupCard.tsx
+++ b/frontend/src/components/GroupCard.tsx
@@ -201,7 +201,7 @@ const GroupCard = ({ group, servers, onEdit, onDelete, cost }: GroupCardProps) =
                       JSON.stringify(
                         {
                           mcpServers: {
-                            mcphub: {
+                            [group.name]: {
                               url: groupEndpoint,
                               headers: { Authorization: 'Bearer <your-access-token>' },
                             },


### PR DESCRIPTION
Copying MCP JSON for different groups currently produces the same `mcphub` key, so combining snippets overwrites entries. Use the group name as the key: `u8` and `dbx` now produce distinct entries while preserving the endpoint and authorization placeholder.

Preserve names verbatim through JSON serialization to avoid collisions introduced by sanitization. Client-specific format presets from the follow-up comment are outside this fix.

Fixes #1139

Validation:
- `pnpm lint`
- `pnpm test:ci`: 190 suites, 1426 tests passed (rerun with local port access after sandbox restrictions prevented test servers from starting).
- `pnpm build`
- `node scripts/verify-dist.js`
- Executed the actual GroupCard JSON expression for seven names, including CJK, spaces, quotes, and `__proto__`; verified distinct keys, URLs, and authorization headers.
- `git diff --check`

Browser validation: the Vite frontend opened, but the authenticated group copy flow was not exercised because a usable login environment was unavailable.
