### PR TITLE
chore: remove deprecated baseUrl from frontend tsconfig

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,7 +21,6 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Paths */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

Remove the deprecated `baseUrl` compiler option from `frontend/tsconfig.json`.

TypeScript 5.5+ reports `baseUrl` as deprecated (scheduled for removal in TS 7.0), which surfaces as an editor diagnostic. `paths` has worked without `baseUrl` since TS 4.1 and resolves relative to the tsconfig directory, so the `@/* → ./src/*` alias behavior is unchanged. The Vite config already maps `@` to `./src`, so bundling is unaffected.

## Validation

- `tsc --noEmit -p frontend/tsconfig.json` (TypeScript 5.9.3): **0 errors, no deprecation warnings**.
- Frontend has no imports relying on bare `baseUrl` resolution — all `@/` imports go through `paths`.

No UI change, so no before/after screenshots.