### PR TITLE
fix: preserve single-route tool calls after session rebuild

### DIFF
--- a/docs/api-reference/config.mdx
+++ b/docs/api-reference/config.mdx
@@ -131,3 +131,15 @@ Retrieves public configuration, primarily to check if authentication is skipped.
     }
   }
   ```
+
+## Session rebuild
+
+Set `enableSessionRebuild` to `true` to recreate a missing Streamable HTTP session
+using its existing ID. This does not restore the client's negotiated capabilities.
+Single-upstream routes accept both raw and prefixed tool names, allowing cached
+ordinary tool calls to continue. MCP Apps metadata and app-only tools still require
+a fresh initialization that advertises Apps support.
+
+When rebuild is disabled, requests with an unknown session ID return HTTP 404 so
+the client can initialize a new session. Requests missing a required session ID
+continue to return HTTP 400.

--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -3023,7 +3023,6 @@ const assertToolAvailableForRoute = (tool: Tool, appsRouteContext: McpAppsRouteC
 const resolveToolInGroup = async (
   group: string | undefined,
   toolName: string,
-  allowRawName: boolean,
 ): Promise<{ serverInfo: ServerInfo; toolName: string; tool: Tool } | undefined> => {
   const lookupGroup = getGroupLookupName(group);
   if (!lookupGroup) {
@@ -3032,6 +3031,14 @@ const resolveToolInGroup = async (
 
   const { filteredServerInfos, serverConfigsByName } =
     await getFilteredServerInfosForGroup(lookupGroup);
+
+  // Accept raw names only on single-upstream routes, even without client
+  // capabilities after session rebuild. Count configured servers as well so
+  // a disabled or disconnected peer cannot make a group appear unambiguous.
+  const allowRawName =
+    !isSmartRoutingGroup(group) &&
+    serverConfigsByName.size <= 1 &&
+    filteredServerInfos.length === 1;
 
   for (const serverInfo of filteredServerInfos) {
     // A disconnected on-demand server may still have a cached tool list from a
@@ -3300,7 +3307,7 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
       } else if (extra && extra.server) {
         targetServerInfo = getVisibleServerByName(extra.server);
       } else if (getGroupLookupName(group)) {
-        const groupTool = await resolveToolInGroup(group, toolName, false);
+        const groupTool = await resolveToolInGroup(group, toolName);
         if (groupTool) {
           targetServerInfo = groupTool.serverInfo;
           targetToolName = groupTool.toolName;
@@ -3530,7 +3537,7 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
     const singleServerAppsRoute = !!appsRouteContext.serverInfo;
     const groupTool =
       !singleServerAppsRoute && lookupGroup
-        ? await resolveToolInGroup(lookupGroup, request.params.name, false)
+        ? await resolveToolInGroup(group, request.params.name)
         : undefined;
     const serverInfo = singleServerAppsRoute
       ? appsRouteContext.serverInfo

--- a/src/services/sseService.test.ts
+++ b/src/services/sseService.test.ts
@@ -846,12 +846,12 @@ describe('sseService', () => {
       await handleMcpPostRequest(req, res);
 
       // When session rebuild is disabled, invalid sessions should return an error
-      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.status).toHaveBeenCalledWith(404);
       expect(res.json).toHaveBeenCalledWith({
         jsonrpc: '2.0',
         error: {
-          code: -32000,
-          message: 'Bad Request: No valid session ID provided',
+          code: -32001,
+          message: 'Session not found. Please reinitialize the session.',
         },
         id: null,
       });
@@ -1197,9 +1197,9 @@ describe('sseService', () => {
 
       await handleMcpOtherRequest(req, res);
 
-      // Should return 400 error when session rebuild is disabled
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.send).toHaveBeenCalledWith('Invalid or missing session ID');
+      // Should return 404 error when session rebuild is disabled
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.send).toHaveBeenCalledWith('Session not found. Please reinitialize the session.');
     });
 
     it('should transparently rebuild invalid session in handleMcpOtherRequest when enabled', async () => {

--- a/src/services/sseService.ts
+++ b/src/services/sseService.ts
@@ -898,14 +898,7 @@ export const handleMcpPostRequest = async (req: Request, res: Response): Promise
       logger.warn(
         `[SESSION ERROR] Session ${sessionId} not found and session rebuild is disabled${username ? ` for user: ${username}` : ''}`,
       );
-      res.status(400).json({
-        jsonrpc: '2.0',
-        error: {
-          code: -32000,
-          message: 'Bad Request: No valid session ID provided',
-        },
-        id: null,
-      });
+      sendSessionNotFoundJsonRpc(res);
       return;
     }
   } else if (isInitializeRequest(req.body)) {
@@ -1045,7 +1038,7 @@ export const handleMcpOtherRequest = async (req: Request, res: Response) => {
       logger.warn(
         `[SESSION ERROR] Session ${sessionId} not found and session rebuild is disabled in handleMcpOtherRequest`,
       );
-      res.status(400).send('Invalid or missing session ID');
+      sendSessionNotFoundText(res);
       return;
     }
   }

--- a/tests/integration/sse-service-real-client.test.ts
+++ b/tests/integration/sse-service-real-client.test.ts
@@ -415,96 +415,108 @@ describe('Real Client Transport Integration Tests', () => {
       expect(isConnected).toBe(true);
     }, 60000);
 
-    it('should continue serving requests when a client reuses a cached session ID after session state is cleared', async () => {
-      const testGroup = 'integration-test-group';
-      const mcpUrl = new URL(`${baseURL}/mcp/${testGroup}`);
-      const options: any = {
-        requestInit: {
-          headers: {
-            Authorization: 'Bearer test-auth-token-123',
+    it.each([false, true])(
+      'serves cached tool names after session rebuild (Apps: %s)',
+      async (appsCapable) => {
+        const testGroup = 'integration-test-group';
+        const mcpUrl = new URL(`${baseURL}/mcp/${testGroup}`);
+        const options: any = {
+          requestInit: {
+            headers: {
+              Authorization: 'Bearer test-auth-token-123',
+            },
           },
-        },
-      };
+        };
 
-      const transport = new StreamableHTTPClientTransport(mcpUrl, options);
-      const client = new Client(
-        {
-          name: 'real-http-rebuild-test-client',
-          version: '1.0.0',
-        },
-        {
-          capabilities: {
-            tools: {},
-            resources: {},
-            prompts: {},
+        const transport = new StreamableHTTPClientTransport(mcpUrl, options);
+        const client = new Client(
+          {
+            name: 'real-http-rebuild-test-client',
+            version: '1.0.0',
           },
-        },
-      );
+          {
+            capabilities: {
+              ...(appsCapable
+                ? {
+                    extensions: {
+                      'io.modelcontextprotocol/ui': { mimeTypes: ['text/html;profile=mcp-app'] },
+                    },
+                  }
+                : {}),
+              tools: {},
+              resources: {},
+              prompts: {},
+            },
+          },
+        );
 
-      const createTimeout = (ms: number) =>
-        new Promise<never>((_, reject) => {
-          setTimeout(() => {
-            reject(new Error(`Timed out after ${ms}ms waiting for rebuilt session response`));
-          }, ms);
-        });
+        const createTimeout = (ms: number) =>
+          new Promise<never>((_, reject) => {
+            setTimeout(() => {
+              reject(new Error(`Timed out after ${ms}ms waiting for rebuilt session response`));
+            }, ms);
+          });
 
-      const waitForTools = async () => {
-        const maxAttempts = 30;
+        const waitForTools = async () => {
+          const maxAttempts = 30;
 
-        for (let attempt = 0; attempt < maxAttempts; attempt++) {
-          const listedTools = await client.listTools({});
+          for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            const listedTools = await client.listTools({});
 
-          if (listedTools.tools.length > 0) {
-            return listedTools;
+            if (listedTools.tools.length > 0) {
+              return listedTools;
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, 500));
           }
 
-          await new Promise((resolve) => setTimeout(resolve, 500));
+          throw new Error('Timed out waiting for upstream tools to become available');
+        };
+
+        let sessionId: string | undefined;
+
+        try {
+          await client.connect(transport, {});
+
+          const tools = await waitForTools();
+          sessionId = transport.sessionId;
+
+          expect(sessionId).toBeDefined();
+          expect(tools.tools.length).toBeGreaterThan(0);
+
+          const toolName = tools.tools[0]?.name;
+
+          expect(toolName).toBeDefined();
+
+          delete transports[sessionId as string];
+          deleteMcpServer(sessionId as string);
+
+          const result = await Promise.race([
+            client.callTool({ name: toolName as string, arguments: {} }),
+            createTimeout(5000),
+          ]);
+
+          expect(result.isError).not.toBe(true);
+          expect(result).toEqual(
+            expect.objectContaining({
+              content: expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'text',
+                }),
+              ]),
+            }),
+          );
+        } finally {
+          if (sessionId) {
+            delete transports[sessionId];
+            deleteMcpServer(sessionId);
+          }
+
+          await client.close();
         }
-
-        throw new Error('Timed out waiting for upstream tools to become available');
-      };
-
-      let sessionId: string | undefined;
-
-      try {
-        await client.connect(transport, {});
-
-        const tools = await waitForTools();
-        sessionId = transport.sessionId;
-
-        expect(sessionId).toBeDefined();
-        expect(tools.tools.length).toBeGreaterThan(0);
-
-        const toolName = tools.tools[0]?.name;
-
-        expect(toolName).toBeDefined();
-
-        delete transports[sessionId as string];
-        deleteMcpServer(sessionId as string);
-
-        const result = await Promise.race([
-          client.callTool({ name: toolName as string, arguments: {} }),
-          createTimeout(5000),
-        ]);
-
-        expect(result).toEqual(
-          expect.objectContaining({
-            content: expect.arrayContaining([
-              expect.objectContaining({
-                type: 'text',
-              }),
-            ]),
-          }),
-        );
-      } finally {
-        if (sessionId) {
-          delete transports[sessionId];
-          deleteMcpServer(sessionId);
-        }
-
-        await client.close();
-      }
-    }, 60000);
+      },
+      60000,
+    );
   });
 
   describe('Real Client Authentication Tests', () => {
@@ -527,6 +539,28 @@ describe('Real Client Transport Integration Tests', () => {
         _authHttpServer.close();
       }
     });
+
+    it.each(['POST', 'GET', 'DELETE'])(
+      'returns 404 for expired sessions with rebuild disabled (%s)',
+      async (method) => {
+        const response = await fetch(authBaseURL + '/mcp', {
+          method,
+          headers: {
+            Authorization: 'Bearer test-auth-token-123',
+            Accept: 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'mcp-session-id': 'expired-session-1144',
+          },
+          ...(method === 'POST'
+            ? {
+                body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+              }
+            : {}),
+        });
+        expect(response.status).toBe(404);
+        expect(await response.text()).toContain('Please reinitialize the session');
+      },
+    );
 
     it('should fail to connect with SSEClientTransport without auth', async () => {
       const sseUrl = new URL(`${authBaseURL}/sse`);

--- a/tests/services/mcpService-apps.test.ts
+++ b/tests/services/mcpService-apps.test.ts
@@ -292,6 +292,57 @@ describe('mcpService MCP Apps transparent proxy', () => {
     expect(result.tools[0]._meta).toEqual(appsTools[0]._meta);
   });
 
+  it.each(['direct', 'wrapped'])(
+    'accepts cached raw and qualified names without capabilities (%s)',
+    async (mode) => {
+      await initUpstreamServers();
+      await flushPromises();
+      await getMcpServer('ordinary-session', 'apps-server');
+
+      for (const name of ['open-dashboard', 'apps-server::open-dashboard']) {
+        const params =
+          mode === 'direct'
+            ? { name, arguments: {} }
+            : { name: 'call_tool', arguments: { toolName: name, arguments: {} } };
+        const result = await handleCallToolRequest({ params }, { sessionId: 'ordinary-session' });
+        expect(result.isError).toBe(false);
+        expect(mockClient.callTool).toHaveBeenLastCalledWith(
+          { name: 'open-dashboard', arguments: {} },
+          undefined,
+          expect.anything(),
+        );
+      }
+
+      mockClient.callTool.mockClear();
+      for (const name of ['missing-tool', 'poll-dashboard']) {
+        const params =
+          mode === 'direct'
+            ? { name, arguments: {} }
+            : { name: 'call_tool', arguments: { toolName: name, arguments: {} } };
+        const result = await handleCallToolRequest({ params }, { sessionId: 'ordinary-session' });
+        expect(result.isError).toBe(true);
+      }
+      expect(mockClient.callTool).not.toHaveBeenCalled();
+    },
+  );
+
+  it('keeps group tool filtering when accepting raw names', async () => {
+    mockGroupFindByName.mockImplementation(async (name: string) =>
+      name === 'apps-server' ? { servers: [{ name: 'apps-server', tools: [] }] } : null,
+    );
+    await initUpstreamServers();
+    await flushPromises();
+    await getMcpServer('ordinary-session', 'apps-server');
+    for (const params of [
+      { name: 'open-dashboard', arguments: {} },
+      { name: 'call_tool', arguments: { toolName: 'open-dashboard', arguments: {} } },
+    ]) {
+      const result = await handleCallToolRequest({ params }, { sessionId: 'ordinary-session' });
+      expect(result.isError).toBe(true);
+    }
+    expect(mockClient.callTool).not.toHaveBeenCalled();
+  });
+
   it('allows raw app-only calls only on an eligible Apps route', async () => {
     await initUpstreamServers();
     await flushPromises();
@@ -387,6 +438,40 @@ describe('mcpService MCP Apps transparent proxy', () => {
         name === 'pair' ? { servers: ['apps-server', 'other-server'] } : null,
       );
     };
+
+    it.each(['direct', 'wrapped'])(
+      'rejects ambiguous raw names without capabilities (%s)',
+      async (mode) => {
+        setUpPairGroup();
+        await initUpstreamServers();
+        await flushPromises();
+        await getMcpServer('aggregate-session', 'pair');
+        const params =
+          mode === 'direct'
+            ? { name: 'open-dashboard', arguments: {} }
+            : { name: 'call_tool', arguments: { toolName: 'open-dashboard', arguments: {} } };
+        const result = await handleCallToolRequest({ params }, { sessionId: 'aggregate-session' });
+        expect(result.isError).toBe(true);
+        expect(mockClient.callTool).not.toHaveBeenCalled();
+      },
+    );
+
+    it('does not allow raw names when a configured peer is disabled', async () => {
+      setUpPairGroup();
+      mockFindAll.mockResolvedValue([
+        makeServerConfig('apps-server'),
+        { ...makeServerConfig('other-server'), enabled: false },
+      ]);
+      await initUpstreamServers();
+      await flushPromises();
+      await getMcpServer('aggregate-session', 'pair');
+      const result = await handleCallToolRequest(
+        { params: { name: 'open-dashboard', arguments: {} } },
+        { sessionId: 'aggregate-session' },
+      );
+      expect(result.isError).toBe(true);
+      expect(mockClient.callTool).not.toHaveBeenCalled();
+    });
 
     it('keeps qualified tool names and full Apps metadata on a multi-server Apps route', async () => {
       setUpPairGroup();


### PR DESCRIPTION
## Summary

After a session rebuild, MCP Apps clients could keep calling cached raw tool names (for example, `get_orders`) while MCPHub required prefixed names. Accept both forms on single-upstream routes in the shared resolver used by direct calls and `call_tool`. Multi-upstream groups, including those with disabled peers, still require qualified names; tool filtering and Apps-only capability checks remain enforced.

Return HTTP 404 for unknown Streamable HTTP sessions when rebuild is disabled, so clients can initialize again. Missing session IDs still return HTTP 400.

No session persistence or capability restoration is added. Apps metadata and app-only tools still require fresh initialization; this limitation is documented.

Fixes #1144

## Validation

- `pnpm lint`
- `USE_DB=false pnpm test:ci --runInBand`: 194 suites, 1459 tests passed.
- Subsequent boundary additions: Apps suite passed all 21 tests.
- Real-client integration: cached calls after session loss with and without Apps capabilities, and POST/GET/DELETE returning 404 for expired sessions.
- `pnpm build`
- `node scripts/verify-dist.js`
- `git diff --check`

Tests were rerun with local networking allowed after sandbox port/DNS restrictions caused environment failures. Docker/PostgreSQL and Claude.ai were not exercised.
