### PR TITLE
fix(routes): stop the shared /api rate limiter from counting public auth routes

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -243,7 +243,13 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
   app.delete('/oauth/register/:clientId', mcpConnectionRateLimiter, deleteClientRegistration); // Delete client registration
 
   authenticatedRouter.use(authenticatedRouteRateLimiter);
-  router.use(authenticatedRouter);
+  // `authenticatedRouter` is mounted at the end of this function, after the public
+  // routes below have been registered on `router`. The order matters: the limiter
+  // above is a path-less `use`, so it runs for every request that reaches the
+  // sub-router - including ones that match no authenticated route and only fall
+  // through to a public route such as POST /api/auth/login. Mounting last lets
+  // those public routes match first, so they are governed by their own limiters
+  // instead of consuming the shared authenticated-route budget.
 
   // API routes protected by auth middleware in middlewares/index.ts and rate limited here
   authenticatedRouter.get('/credentials', listMyCredentials);
@@ -488,6 +494,11 @@ export const initRoutes = async (app: express.Application): Promise<void> => {
   app.post(`${config.basePath}/api/tools/:serverName/:toolName`, executeToolViaOpenAPI);
   app.get(`${config.basePath}/api/:name/tools/:serverName/:toolName`, executeToolViaOpenAPI);
   app.post(`${config.basePath}/api/:name/tools/:serverName/:toolName`, executeToolViaOpenAPI);
+
+  // Mounted last so the public routes registered on `router` above are matched
+  // before the shared authenticated-route rate limiter runs. See the comment on
+  // `authenticatedRouter.use(authenticatedRouteRateLimiter)`.
+  router.use(authenticatedRouter);
 
   app.use(`${config.basePath}/api`, router);
 };

--- a/tests/routes/index.test.ts
+++ b/tests/routes/index.test.ts
@@ -302,6 +302,36 @@ describe('initRoutes authenticated API rate limiting', () => {
     expect(routerContainsRoute(protectedRouter!, 'delete', '/oauth/clients/:clientId')).toBe(true);
   });
 
+  it('matches public auth routes before the shared authenticated rate limiter', async () => {
+    const app = express();
+
+    await initRoutes(app);
+
+    const apiRouter = findMountedRouter(app);
+    const stack = apiRouter.stack ?? [];
+
+    // The authenticated sub-router carries a path-less rate limiter, so anything
+    // mounted after it on the API router would be counted against the shared
+    // authenticated-route budget - including public routes that carry their own
+    // limiter, such as POST /api/auth/login.
+    const authenticatedRouterIndex = stack.findIndex(
+      (layer) => layer.name === 'router' && layer.handle?.stack,
+    );
+    expect(authenticatedRouterIndex).toBeGreaterThanOrEqual(0);
+
+    for (const [method, path] of [
+      ['post', '/auth/login'],
+      ['post', '/auth/register'],
+    ] as const) {
+      const routeIndex = stack.findIndex(
+        (layer) => layer.route?.path === path && Boolean(layer.route.methods[method]),
+      );
+
+      expect(routeIndex).toBeGreaterThanOrEqual(0);
+      expect(routeIndex).toBeLessThan(authenticatedRouterIndex);
+    }
+  });
+
   it('mounts the hosted internal webhook ingress behind its dedicated rate limiter', async () => {
     const app = express();
 


### PR DESCRIPTION
Fixes the first root cause in #1151.

## Problem

`authenticatedRouter.use(authenticatedRouteRateLimiter)` is a path-less `use`, and
`authenticatedRouter` was mounted on the API router *before* the public routes were
registered:

```ts
authenticatedRouter.use(authenticatedRouteRateLimiter);
router.use(authenticatedRouter);          // mounted here, at the router root
// ...
router.post('/auth/login', [ ...validators ], authAttemptRateLimiter, login);
// ...
app.use(`${config.basePath}/api`, router);
```

Every request entering `/api/*` therefore runs the shared authenticated-route limiter
(600 / 15 min per IP), including requests that match no authenticated route and only fall
through to a public one — `POST /api/auth/login` in particular.

The operational consequence is that ordinary dashboard traffic can exhaust the shared
budget and then return 429 on login, on an endpoint that has no limiter of its own on
that path. Being already authenticated does not help: the limiter runs before auth and
`createStandardRateLimiter` only skips in test environments.

Minimal reproduction of the mount semantics (`max: 3` for brevity):

```
GET  /api/servers    -> 200
GET  /api/servers    -> 200
GET  /api/servers    -> 200
POST /api/auth/login -> 429 Too many requests, please try again later.
```

## Change

Mount `authenticatedRouter` at the end of `initRoutes`, after the public routes have been
registered on `router`. Express matches router layers in order, so `/api/auth/login` now
matches its own route first and is governed by `authAttemptRateLimiter`, as intended,
instead of consuming the shared budget.

Nothing is removed: routes that *should* count against the shared budget already attach
`authenticatedRouteRateLimiter` explicitly (`/auth/user`, `/auth/change-password`), so
they keep exactly the protection they had. They were previously counted twice — once by
the path-less `use` and once by their own reference.

There are no path collisions between the two routers under `/auth`: `router` owns
`/auth/login`, `/auth/register`, `/auth/user`, `/auth/change-password`, while
`authenticatedRouter` owns `/auth/keys*`.

## Tests

Adds a regression test to `tests/routes/index.test.ts` asserting that the public auth
routes appear on the API router stack *before* the authenticated sub-router mount. The
real limiters cannot be exercised behaviourally in tests (`createStandardRateLimiter`
sets `skip: () => isTestEnv`), so this follows the structural style already used by the
neighbouring rate-limiter tests in that file.

Verified the test fails without the source change:

```
● initRoutes authenticated API rate limiting › matches public auth routes before the
  shared authenticated rate limiter
  Expected: < 0
  Received:   1
```

Full suite: 1447 passed. The four failing suites on my machine
(`src/utils/processTree.test.ts`, `tests/controllers/mcpbController.test.ts`,
`tests/services/credentialBindingService.test.ts`) fail identically on a clean checkout —
they are pre-existing and platform-related (Windows), not caused by this change.

## A question on direction

Would you like the rate limits to be configurable from the environment as well —
something like an on/off switch plus a max and window per limiter?

This PR deliberately only fixes the scoping bug, because that part is a defect regardless
of what the limits are. But the two are related: operators behind a single egress IP (a
container, a reverse proxy, NAT) share one budget across all of their users, and at
larger deployments the defaults are easy to reach with legitimate traffic. #1135 already
proposes environment-configurable thresholds for exactly that reason.

I am happy to either:

- extend this PR with `AUTHENTICATED_RATE_LIMIT_MAX` / `_WINDOW_MS` / an enable flag,
- fold it into #1135 so all the limits are configured in one place, or
- leave it as is if you would rather keep the limits fixed.

Whichever you prefer — just say the word and I will adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarhjXLQBBxNc6EgrMXf3M
