### PR TITLE
fix(logs): reset the log-stream reconnect backoff on open, not on every attempt

### DIFF
--- a/frontend/src/services/logService.ts
+++ b/frontend/src/services/logService.ts
@@ -97,6 +97,16 @@ class LogStreamManager {
         this.subscribers.forEach((cb) => cb(event));
       };
 
+      // Reset attempts only once the connection is actually established.
+      // `new EventSource()` returns immediately and connects asynchronously, so
+      // resetting here (rather than in onopen) cleared the counter on every
+      // attempt and pinned the backoff below to its first step - a fixed 1s
+      // retry loop whenever the stream kept dropping.
+      this.eventSource.onopen = () => {
+        this.openAttempts = 0;
+        console.log('[LogStreamManager] EventSource opened successfully');
+      };
+
       this.eventSource.onerror = () => {
         console.warn('[LogStreamManager] EventSource error, attempting reconnect...');
         this.closeEventSource();
@@ -104,10 +114,6 @@ class LogStreamManager {
           this.scheduleReconnect();
         }
       };
-
-      // Reset attempts on successful connection
-      this.openAttempts = 0;
-      console.log('[LogStreamManager] EventSource opened successfully');
     } catch (error) {
       console.error('[LogStreamManager] Failed to open EventSource:', error);
       this.closeEventSource();

--- a/tests/frontend/logStreamBackoff.test.ts
+++ b/tests/frontend/logStreamBackoff.test.ts
@@ -1,0 +1,84 @@
+jest.mock('../../frontend/src/utils/fetchInterceptor', () => ({
+  apiGet: jest.fn(),
+  apiDelete: jest.fn(),
+}));
+
+jest.mock('../../frontend/src/utils/runtime', () => ({
+  getApiUrl: (path: string) => `http://localhost:3000/api${path}`,
+}));
+
+jest.mock('../../frontend/src/utils/interceptors', () => ({
+  getToken: () => 'test-token',
+}));
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+describe('LogStreamManager reconnect backoff', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    FakeEventSource.instances = [];
+    (global as unknown as { EventSource: unknown }).EventSource = FakeEventSource;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    delete (global as unknown as { EventSource?: unknown }).EventSource;
+  });
+
+  it('backs off exponentially when the stream never opens', async () => {
+    const { logStreamManager } = await import('../../frontend/src/services/logService');
+    const unsubscribe = logStreamManager.subscribe(() => {});
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+
+    // First failure: reconnect after 1s.
+    FakeEventSource.instances[0].onerror?.();
+    jest.advanceTimersByTime(999);
+    expect(FakeEventSource.instances).toHaveLength(1);
+    jest.advanceTimersByTime(1);
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // Second failure: the delay must grow to 2s rather than staying at 1s.
+    FakeEventSource.instances[1].onerror?.();
+    jest.advanceTimersByTime(1000);
+    expect(FakeEventSource.instances).toHaveLength(2);
+    jest.advanceTimersByTime(1000);
+    expect(FakeEventSource.instances).toHaveLength(3);
+
+    unsubscribe();
+  });
+
+  it('resets the backoff only after the connection actually opens', async () => {
+    const { logStreamManager } = await import('../../frontend/src/services/logService');
+    const unsubscribe = logStreamManager.subscribe(() => {});
+
+    // Burn one step of backoff.
+    FakeEventSource.instances[0].onerror?.();
+    jest.advanceTimersByTime(1000);
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    // This attempt genuinely opens, so the next failure starts from 1s again.
+    FakeEventSource.instances[1].onopen?.();
+    FakeEventSource.instances[1].onerror?.();
+    jest.advanceTimersByTime(1000);
+    expect(FakeEventSource.instances).toHaveLength(3);
+
+    unsubscribe();
+  });
+});


### PR DESCRIPTION
Fixes the second root cause in #1151.

## Problem

`frontend/src/services/logService.ts` resets the reconnect counter immediately after
constructing the `EventSource`:

```ts
this.eventSource = new EventSource(url);

this.eventSource.onmessage = ...;
this.eventSource.onerror = () => { this.closeEventSource(); this.scheduleReconnect(); };

// Reset attempts on successful connection
this.openAttempts = 0;
console.log('[LogStreamManager] EventSource opened successfully');
```

`new EventSource(url)` returns synchronously and connects asynchronously, so this line
runs on every *attempt*, not on a successful connection — and the counter is always back
to zero before `onerror` can fire.

`scheduleReconnect` then computes:

```ts
const delayMs = Math.min(1000 * Math.pow(2, this.openAttempts), 8000);
this.openAttempts++;
```

so the documented `1s, 2s, 4s, 8s max` backoff never advances past its first step. A
stream that keeps dropping reconnects **once per second, indefinitely**.

Two things make that costly rather than merely wasteful:

1. `/api/logs/stream` is under `/api`, so every reconnect is counted against the shared
   `authenticatedRouteRateLimiter` budget (600 / 15 min = 40 requests/minute per IP).
   A 1-second loop is ~60 requests/minute — one dashboard tab can exhaust the budget by
   itself, before the dashboard's own polling is counted.

2. The stream is subscribed **globally**, not just on the Logs page —
   `EmbeddingSyncAlertListener` in `App.tsx` and `EmbeddingSyncProvider` in
   `MainLayout.tsx` both subscribe — so any open dashboard tab is affected, and there is
   no way for an operator to opt out short of closing the tab.

The loop tends to engage exactly when the backend is under load and the SSE connection is
flapping, which is when the extra request volume is least affordable.

## Change

Move the reset into an `onopen` handler, so it only fires on a connection that was
actually established:

```ts
this.eventSource.onopen = () => {
  this.openAttempts = 0;
  console.log('[LogStreamManager] EventSource opened successfully');
};
```

The backoff then behaves as its comment already describes.

## Tests

`tests/frontend/logStreamBackoff.test.ts` drives the manager with a fake `EventSource`
and fake timers, covering both directions:

- when the stream never opens, the delay grows (1s, then 2s) instead of staying at 1s;
- after a connection genuinely opens, the next failure starts from 1s again.

Verified the first test fails without the source change — the third connection is created
after 1000 ms instead of 2000 ms:

```
● LogStreamManager reconnect backoff › backs off exponentially when the stream never opens
  Expected length: 2
  Received length: 3
```

Full suite: 1448 passed. The three failing suites on my machine
(`src/utils/processTree.test.ts`, `tests/controllers/mcpbController.test.ts`,
`tests/services/credentialBindingService.test.ts`) fail identically on a clean checkout —
pre-existing and platform-related (Windows), not caused by this change.

## Note

This is independent of #1152, which fixes the routing side of #1151. Either can land on
its own; together they remove both the lockout and its main trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarhjXLQBBxNc6EgrMXf3M
