### PR TITLE
fix(mcp): isolate transport creation failures to the affected server

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1815,7 +1815,35 @@ export const initializeClientsFromSettings = async (
           continue;
         }
       } else {
-        transport = await createTransportFromConfig(name, expandedConf);
+        try {
+          transport = await createTransportFromConfig(name, expandedConf);
+        } catch (error) {
+          // Fail this server only. Letting the error escape the loop hits the
+          // outer catch, which restores `serverInfos` to its previous value -
+          // empty at startup - so a single malformed config (an unparseable URL
+          // rejected by assertSafeUrl, say) would drop every server from
+          // getServersInfo and leave the whole fleet reporting 'connecting'.
+          // The OpenAPI branch above already isolates its failures this way.
+          logger.error('Failed to create transport for server', {
+            serverName: name,
+            error: summarizeErrorForLogging(error),
+          });
+          nextServerInfos.push({
+            name,
+            owner: expandedConf.owner,
+            visibility: expandedConf.visibility,
+            sharedWithUsers: expandedConf.sharedWithUsers,
+            status: 'disconnected',
+            error: `Failed to create transport: ${formatErrorForLogging(error)}`,
+            tools: [],
+            prompts: [],
+            resources: [],
+            createTime: Date.now(),
+            enabled: true,
+            config: expandedConf,
+          });
+          continue;
+        }
       }
 
       const serverInfoRef: { current?: ServerInfo } = {};

--- a/tests/services/mcpService-transport-error.test.ts
+++ b/tests/services/mcpService-transport-error.test.ts
@@ -1,0 +1,136 @@
+// Mock dependencies before importing mcpService
+const mockRemoveServerToolEmbeddings = jest.fn().mockResolvedValue(undefined);
+const mockSaveToolsAsVectorEmbeddings = jest.fn().mockResolvedValue(undefined);
+const mockClientConnect = jest.fn().mockResolvedValue(undefined);
+const mockClientClose = jest.fn();
+const mockListTools = jest.fn().mockResolvedValue({ tools: [] });
+const mockStderrListeners = new Map<string, (data?: Buffer) => void>();
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: mockClientConnect,
+    close: mockClientClose,
+    getServerCapabilities: jest.fn(() => ({})),
+    listTools: mockListTools,
+  })),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: jest.fn().mockImplementation(() => ({
+    close: jest.fn(),
+    stderr: {
+      on: jest.fn((event: string, listener: (data?: Buffer) => void) => {
+        mockStderrListeners.set(event, listener);
+      }),
+    },
+  })),
+}));
+
+jest.mock('../../src/services/oauthService.js', () => ({
+  initializeAllOAuthClients: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthClientRegistration.js', () => ({
+  registerOAuthClient: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpOAuthProvider.js', () => ({
+  createOAuthProvider: jest.fn(),
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  getServersInGroup: jest.fn(),
+  getServerConfigInGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn(),
+}));
+
+const mockServerDao = {
+  findById: jest.fn(),
+  findAll: jest.fn(() => Promise.resolve([] as any[])),
+  setEnabled: jest.fn().mockResolvedValue(true),
+};
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: jest.fn(() => mockServerDao),
+  getSystemConfigDao: jest.fn(() => ({
+    get: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({
+    filterData: (data: any) => data,
+  })),
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  initSmartRoutingService: jest.fn(),
+  handleSearchToolsRequest: jest.fn(),
+  handleDescribeToolRequest: jest.fn(),
+  isSmartRoutingGroup: jest.fn(),
+  getSmartRoutingTools: jest.fn(),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  searchToolsByVector: jest.fn(),
+  saveToolsAsVectorEmbeddings: mockSaveToolsAsVectorEmbeddings,
+  removeServerToolEmbeddings: mockRemoveServerToolEmbeddings,
+}));
+
+jest.mock('../../src/config/index.js', () => ({
+  loadSettings: jest.fn(),
+  expandEnvVars: jest.fn((val: string) => val),
+  replaceEnvVars: jest.fn((val: any) => val),
+  getNameSeparator: jest.fn(() => '::'),
+  default: {
+    mcpHubName: 'test-hub',
+    mcpHubVersion: '1.0.0',
+  },
+}));
+
+jest.mock('../../src/services/keepAliveService.js', () => ({
+  setupClientKeepAlive: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/services/activityLoggingService.js', () => ({
+  getActivityLoggingService: jest.fn(() => ({
+    logActivity: jest.fn(),
+  })),
+}));
+
+
+import {
+  getServerByName,
+  initializeClientsFromSettings,
+  setServerInfosForTest,
+} from '../../src/services/mcpService.js';
+
+describe('initializeClientsFromSettings transport failures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setServerInfosForTest([]);
+    mockClientConnect.mockResolvedValue(undefined);
+  });
+
+  it('isolates a server whose transport cannot be created', async () => {
+    // 'bad' has an unparseable URL, which assertSafeUrl rejects with
+    // UnsafeUrlError while creating the transport.
+    mockServerDao.findAll.mockResolvedValue([
+      { name: 'bad', enabled: true, type: 'streamable-http', url: 'dd' },
+      { name: 'good', enabled: true, command: 'node', args: ['server.js'] },
+    ]);
+
+    await expect(initializeClientsFromSettings(true)).resolves.toBeDefined();
+
+    // The broken server is reported as failed...
+    const bad = getServerByName('bad');
+    expect(bad?.status).toBe('disconnected');
+    expect(bad?.error).toMatch(/Failed to create transport/);
+
+    // ...and every other server is still present rather than vanishing.
+    expect(getServerByName('good')).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #1155.

## Problem

`createTransportFromConfig` is called unguarded inside the per-server loop
(`src/services/mcpService.ts:1819`), while the loop as a whole sits in a single `try`
whose `catch` restores `serverInfos` and rethrows:

```ts
  const existingServerInfos = serverInfos;
  const nextServerInfos: ServerInfo[] = [];

  try {
    for (const conf of allServers) {
      ...
      } else {
        transport = await createTransportFromConfig(name, expandedConf);
      }
      ...
    }
  } catch (error) {
    serverInfos = existingServerInfos;
    throw error;
  }

  serverInfos = nextServerInfos;
```

`assertSafeUrl` throws `UnsafeUrlError` for a URL `new URL()` cannot parse, or for a
non-http(s) scheme. That error escapes the loop, so `nextServerInfos` is discarded and
`serverInfos` is set back to its previous value — `[]` at startup.

`getServersInfo` reports any server present in the DAO but absent from `serverInfos` as
`connecting`, so the whole deployment then shows `connecting` indefinitely. Connections
already in flight keep succeeding, writing into the discarded objects, which makes the
container log look healthy while the API reports nothing as connected.

In production this presented as 68 servers all `connecting`, 43 `Successfully connected
client` lines in the log, and no error visible anywhere in the dashboard.

## Change

Wrap the call in a per-server `try`/`catch`: log the error, push the server as
`disconnected` carrying the message, and `continue`. This mirrors the OpenAPI branch a few
lines above (`:1806`-`1817`), which already isolates its own failures the same way.

The misconfigured server now appears in the dashboard with a real error message, and the
rest of the fleet initializes normally.

## Tests

`tests/services/mcpService-transport-error.test.ts`, built on the existing mock harness
from `tests/services/mcpService-toggle.test.ts`: one server with `url: 'dd'` alongside a
healthy stdio server. It asserts that init resolves, that the broken server is
`disconnected` with a `Failed to create transport` error, and that the healthy server is
still present.

Verified it fails without the source change:

```
● initializeClientsFromSettings transport failures › isolates a server whose transport
  cannot be created

  Received promise rejected instead of resolved
```

Full suite: 1447 passed. Three suites fail identically on a clean checkout
(`src/utils/processTree.test.ts`, `tests/controllers/mcpbController.test.ts`,
`tests/services/credentialBindingService.test.ts`) — pre-existing and platform-related on
Windows. `tests/integration/personal-credentials.test.ts` flaked once during a full-suite
run and passed on re-run and in isolation, with and without this change.

## Note on scope

This only stops one server's transport failure from taking down the others. It does not
change `assertSafeUrl`, and it does not address the related behaviour where servers that
are missing from `serverInfos` are reported as `connecting` rather than as an error state
— that reporting is what made the failure so hard to diagnose, but it seemed better kept
separate from this fix. Happy to look at it too if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarhjXLQBBxNc6EgrMXf3M
