### PR TITLE
fix(mcp): stop overlapping inits from stranding servers on 'connecting'

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -729,6 +729,13 @@ const normalizeResourceForCache = (resource: McpResource): Resource => {
 
 // Store all server information
 let serverInfos: ServerInfo[] = [];
+
+// Bumped by every initializeClientsFromSettings pass. Connections are started
+// fire-and-forget and settle long after the pass that started them returned, so
+// a callback needs to know whether a later pass has run before it writes its
+// result anywhere. See the `liveServerInfo` helper in that function.
+let initGeneration = 0;
+
 const principalServerScope = new AsyncLocalStorage<ServerInfo[]>();
 
 const getVisibleServerInfos = (): ServerInfo[] => {
@@ -1586,6 +1593,7 @@ export const initializeClientsFromSettings = async (
   const allServers: ServerConfigWithName[] = await getServerDao().findAll();
   const existingServerInfos = serverInfos;
   const nextServerInfos: ServerInfo[] = [];
+  const generation = ++initGeneration;
 
   try {
     for (const conf of allServers) {
@@ -1866,12 +1874,39 @@ export const initializeClientsFromSettings = async (
       }
       nextServerInfos.push(serverInfo);
 
+      // The connect below settles long after this loop returns. If another
+      // initialization pass has run by then, `serverInfo` may no longer be the
+      // object `serverInfos` holds for this server - even when the reuse guard
+      // "preserved" it, because preservation spreads the entry into a fresh
+      // object. Writing the result into a replaced object leaves the server
+      // stuck on 'connecting' for good while the log reports a successful
+      // connect and a full tool list.
+      //
+      // While this pass is still the newest one, `serverInfo` is the entry that
+      // will be published, so it is the right target even before the swap. Once
+      // a later pass has run, resolve the live entry by name and only apply the
+      // result if it still owns this client - which is exactly the case where
+      // the later pass preserved this server rather than reconnecting it.
+      const liveServerInfo = (): ServerInfo | undefined => {
+        if (generation === initGeneration) return serverInfo;
+        const current = serverInfos.find((si) => si.name === name);
+        return current && current.client === client ? current : undefined;
+      };
+
       connectClientWithDiagnostics(client, transport, initRequestOptions || requestOptions)
         .then(() => {
+          const info = liveServerInfo();
+          if (!info) {
+            // Nothing will ever read this connection again, so shut it down
+            // rather than leaving its stdio child process running.
+            logger.log(`Discarding superseded connection result for server: ${name}`);
+            closeServerRuntime(serverInfo);
+            return;
+          }
           logger.log(`Successfully connected client for server: ${name}`);
           const serverVersion = client.getServerVersion?.();
-          serverInfo.version = serverVersion?.version;
-          serverInfo.instructions = client.getInstructions?.();
+          info.version = serverVersion?.version;
+          info.instructions = client.getInstructions?.();
           const capabilities: ServerCapabilities | undefined = client.getServerCapabilities();
           logger.log('Server capabilities', JSON.stringify(capabilities));
 
@@ -1880,8 +1915,10 @@ export const initializeClientsFromSettings = async (
             client
               .listTools({}, initRequestOptions || requestOptions)
               .then((tools) => {
+                const target = liveServerInfo();
+                if (!target) return;
                 logger.log(`Successfully listed ${tools.tools.length} tools for server: ${name}`);
-                updateServerToolsCache(serverInfo, tools.tools, {
+                updateServerToolsCache(target, tools.tools, {
                   reportEmbeddingProgress:
                     options?.reportEmbeddingProgress === true && serverName === name,
                 });
@@ -1904,10 +1941,12 @@ export const initializeClientsFromSettings = async (
             client
               .listPrompts({}, initRequestOptions || requestOptions)
               .then((prompts) => {
+                const target = liveServerInfo();
+                if (!target) return;
                 logger.log(
                   `Successfully listed ${prompts.prompts.length} prompts for server: ${name}`,
                 );
-                updateServerPromptsCache(serverInfo, prompts.prompts);
+                updateServerPromptsCache(target, prompts.prompts);
                 broadcastPromptListChanged();
               })
               .catch((error) => {
@@ -1923,10 +1962,12 @@ export const initializeClientsFromSettings = async (
             client
               .listResources({}, initRequestOptions || requestOptions)
               .then((resources) => {
+                const target = liveServerInfo();
+                if (!target) return;
                 logger.log(
                   `Successfully listed ${resources.resources.length} resources for server: ${name}`,
                 );
-                updateServerResourcesCache(serverInfo, resources.resources);
+                updateServerResourcesCache(target, resources.resources);
                 broadcastResourceListChanged();
               })
               .catch((error) => {
@@ -1939,17 +1980,24 @@ export const initializeClientsFromSettings = async (
           }
 
           if (!dataError) {
-            serverInfo.status = 'connected';
-            serverInfo.error = null;
+            info.status = 'connected';
+            info.error = null;
             // Set up keep-alive ping for SSE connections via shared service
-            setupServerKeepAlive(serverInfo, expandedConf);
+            setupServerKeepAlive(info, expandedConf);
           } else {
-            serverInfo.status = 'disconnected';
-            serverInfo.error = `Failed to list data: ${formatErrorForLogging(dataError)}`;
-            setupServerKeepAlive(serverInfo, expandedConf);
+            info.status = 'disconnected';
+            info.error = `Failed to list data: ${formatErrorForLogging(dataError)}`;
+            setupServerKeepAlive(info, expandedConf);
           }
         })
         .catch(async (error) => {
+          const info = liveServerInfo();
+          if (!info) {
+            logger.log(`Discarding superseded connection failure for server: ${name}`);
+            closeServerRuntime(serverInfo);
+            return;
+          }
+
           // Check if this is an OAuth authorization error
           const isOAuthError =
             error?.message?.includes('OAuth authorization required') ||
@@ -1962,19 +2010,19 @@ export const initializeClientsFromSettings = async (
               `OAuth authorization required for server ${name}. Status should be set to 'oauth_required'.`,
             );
             // Make sure status is set correctly
-            if (serverInfo.status !== 'oauth_required') {
-              serverInfo.status = 'oauth_required';
+            if (info.status !== 'oauth_required') {
+              info.status = 'oauth_required';
             }
-            serverInfo.error = null;
+            info.error = null;
           } else {
             logger.error('Failed to connect client for server', {
               serverName: name,
               error: summarizeErrorForLogging(error),
             });
             // Other connection errors
-            serverInfo.status = 'disconnected';
-            serverInfo.error = `Failed to connect: ${formatErrorForLogging(error)}`;
-            setupServerKeepAlive(serverInfo, expandedConf);
+            info.status = 'disconnected';
+            info.error = `Failed to connect: ${formatErrorForLogging(error)}`;
+            setupServerKeepAlive(info, expandedConf);
           }
         });
       logger.log(`Initialized client for server: ${name}`);

--- a/tests/services/mcpService-reinit-race.test.ts
+++ b/tests/services/mcpService-reinit-race.test.ts
@@ -1,0 +1,208 @@
+// Mock dependencies before importing mcpService
+const mockRemoveServerToolEmbeddings = jest.fn().mockResolvedValue(undefined);
+const mockSaveToolsAsVectorEmbeddings = jest.fn().mockResolvedValue(undefined);
+const mockClientConnect = jest.fn().mockResolvedValue(undefined);
+const mockClientClose = jest.fn();
+const mockListTools = jest.fn().mockResolvedValue({ tools: [] });
+const mockStderrListeners = new Map<string, (data?: Buffer) => void>();
+
+jest.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: jest.fn().mockImplementation(() => ({
+    connect: mockClientConnect,
+    close: mockClientClose,
+    getServerCapabilities: jest.fn(() => ({ tools: {} })),
+    listTools: mockListTools,
+  })),
+}));
+
+jest.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: jest.fn().mockImplementation(() => ({
+    close: jest.fn(),
+    stderr: {
+      on: jest.fn((event: string, listener: (data?: Buffer) => void) => {
+        mockStderrListeners.set(event, listener);
+      }),
+    },
+  })),
+}));
+
+jest.mock('../../src/services/oauthService.js', () => ({
+  initializeAllOAuthClients: jest.fn(),
+}));
+
+jest.mock('../../src/services/oauthClientRegistration.js', () => ({
+  registerOAuthClient: jest.fn(),
+}));
+
+jest.mock('../../src/services/mcpOAuthProvider.js', () => ({
+  createOAuthProvider: jest.fn(),
+}));
+
+jest.mock('../../src/services/groupService.js', () => ({
+  getServersInGroup: jest.fn(),
+  getServerConfigInGroup: jest.fn(),
+}));
+
+jest.mock('../../src/services/sseService.js', () => ({
+  getGroup: jest.fn(),
+}));
+
+const mockServerDao = {
+  findById: jest.fn(),
+  findAll: jest.fn(() => Promise.resolve([] as any[])),
+  setEnabled: jest.fn().mockResolvedValue(true),
+};
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: jest.fn(() => mockServerDao),
+  getSystemConfigDao: jest.fn(() => ({
+    get: jest.fn(),
+  })),
+}));
+
+jest.mock('../../src/services/services.js', () => ({
+  getDataService: jest.fn(() => ({
+    filterData: (data: any) => data,
+  })),
+}));
+
+jest.mock('../../src/services/smartRoutingService.js', () => ({
+  initSmartRoutingService: jest.fn(),
+  handleSearchToolsRequest: jest.fn(),
+  handleDescribeToolRequest: jest.fn(),
+  isSmartRoutingGroup: jest.fn(),
+  getSmartRoutingTools: jest.fn(),
+}));
+
+jest.mock('../../src/services/vectorSearchService.js', () => ({
+  searchToolsByVector: jest.fn(),
+  saveToolsAsVectorEmbeddings: mockSaveToolsAsVectorEmbeddings,
+  removeServerToolEmbeddings: mockRemoveServerToolEmbeddings,
+}));
+
+jest.mock('../../src/config/index.js', () => ({
+  loadSettings: jest.fn(),
+  expandEnvVars: jest.fn((val: string) => val),
+  replaceEnvVars: jest.fn((val: any) => val),
+  getNameSeparator: jest.fn(() => '::'),
+  default: {
+    mcpHubName: 'test-hub',
+    mcpHubVersion: '1.0.0',
+  },
+}));
+
+jest.mock('../../src/services/keepAliveService.js', () => ({
+  setupClientKeepAlive: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../src/services/activityLoggingService.js', () => ({
+  getActivityLoggingService: jest.fn(() => ({
+    logActivity: jest.fn(),
+  })),
+}));
+
+
+import {
+  getServerByName,
+  initializeClientsFromSettings,
+  setServerInfosForTest,
+} from '../../src/services/mcpService.js';
+
+const flush = async () => {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
+  }
+};
+
+describe('initializeClientsFromSettings re-entrancy', () => {
+  const serverConfig = { name: 'alpha', enabled: true, command: 'node', args: ['server.js'] };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setServerInfosForTest([]);
+    mockServerDao.findAll.mockResolvedValue([serverConfig]);
+    mockListTools.mockResolvedValue({ tools: [{ name: 'tool-a' }] });
+  });
+
+  it('discards a superseded connect and lets the newer one own the state', async () => {
+    // Every connect() stays pending until we release it explicitly.
+    const releases: Array<() => void> = [];
+    mockClientConnect.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releases.push(() => resolve());
+        }),
+    );
+
+    // Run 1: returns as soon as the loop finishes; the connect is still in flight.
+    await initializeClientsFromSettings(true);
+    expect(getServerByName('alpha')?.status).toBe('connecting');
+    expect(releases).toHaveLength(1);
+
+    // Run 2: a second full init (no serverName) while run 1's connect is pending.
+    // The reuse guard only preserves servers already in 'connected', so 'alpha'
+    // is rebuilt with a new client and a second connect is started.
+    await initializeClientsFromSettings(false);
+    expect(releases).toHaveLength(2);
+
+    // Run 1's connect now succeeds, after it has been superseded.
+    releases[0]();
+    await flush();
+
+    // Its result must not be applied to the live entry, and its client must be
+    // shut down rather than leaking a stdio child process.
+    expect(mockClientClose).toHaveBeenCalled();
+    expect(getServerByName('alpha')?.status).toBe('connecting');
+
+    // The newer connection owns the state.
+    releases[1]();
+    await flush();
+
+    const live = getServerByName('alpha');
+    expect(live?.status).toBe('connected');
+    expect(live?.tools).toHaveLength(1);
+  });
+});
+
+describe('initializeClientsFromSettings scoped reload', () => {
+  const servers = [
+    { name: 'alpha', enabled: true, command: 'node', args: ['server.js'] },
+    { name: 'beta', enabled: true, command: 'node', args: ['server.js'] },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setServerInfosForTest([]);
+    mockServerDao.findAll.mockResolvedValue(servers);
+    mockListTools.mockResolvedValue({ tools: [{ name: 'tool-a' }] });
+  });
+
+  it('does not orphan an unrelated server that is still connecting', async () => {
+    const releases: Array<() => void> = [];
+    mockClientConnect.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releases.push(() => resolve());
+        }),
+    );
+
+    // Startup: both servers begin connecting.
+    await initializeClientsFromSettings(true);
+    expect(releases).toHaveLength(2);
+    expect(getServerByName('alpha')?.status).toBe('connecting');
+
+    // A scoped reload of 'beta' only - e.g. enabling it from the dashboard.
+    // 'alpha' is "preserved" by the reuse guard, but preservation shallow-copies
+    // it into a new object, so the in-flight connect's closure now holds a
+    // reference that is no longer in serverInfos.
+    await initializeClientsFromSettings(false, 'beta');
+
+    // alpha's original connect completes successfully.
+    releases[0]();
+    await flush();
+
+    const alpha = getServerByName('alpha');
+    expect(alpha?.status).toBe('connected');
+    expect(alpha?.tools).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #1150.

## Problem

`initializeClientsFromSettings` starts each connection fire-and-forget
(`src/services/mcpService.ts:1869`) and the callbacks mutate the `ServerInfo` object
captured in the closure. That is only correct while the captured object is still the one
`serverInfos` holds — and often it is not, because a later pass replaces every entry,
including the ones it means to keep:

```ts
nextServerInfos.push({
  ...existingServer,     // a new object, not the preserved one
  ...
});
```

Two situations follow from that:

- **A full re-init** rebuilds every server that is not already `connected`, so a server
  still mid-connect gets a fresh client while the earlier connect keeps running.
- **A scoped reload** of a single server shallow-copies all the others, so *every*
  in-flight connection in the fleet loses its target. This is what makes the natural
  recovery procedure — reloading failed servers one at a time — strand each server that
  has not finished connecting yet.

In both cases the connection completes normally, logs `Successfully connected client` and
a full tool list, and writes all of it into an object nothing can reach. The dashboard
reports `connecting` indefinitely, and the superseded client is never closed, so its stdio
child process leaks.

From the issue, on a production instance:

```
$ docker logs <container> | grep "tools for server: <server>"
[...] Successfully listed 70 tools for server: <server>

$ curl ... /api/servers | ... grep -o '"status":"[a-z_]*"'
"status":"connecting"
```

## Change

Resolve the live entry when the promise settles rather than trusting the captured
reference.

A module-level generation counter is bumped by each pass. In the callbacks:

- if no later pass has run, the captured `serverInfo` is still the entry that will be
  published, so it is the correct target — this keeps normal startup working, where
  connections routinely settle before the array is swapped in;
- if a later pass has run, look the server up by name and apply the result only when the
  live entry still owns this client. That is precisely the case where the later pass
  preserved this server rather than reconnecting it, so the shallow copy carries the same
  client through.

A superseded connection is discarded and its runtime closed via the existing
`closeServerRuntime`, so it no longer leaves a stdio child behind.

The same resolution runs before each of the `listTools` / `listPrompts` / `listResources`
callbacks and in the connect `catch`, since those settle later still.

## Tests

`tests/services/mcpService-reinit-race.test.ts`, on the existing mock harness from
`tests/services/mcpService-toggle.test.ts`, covers both situations with connects held
pending until released explicitly:

1. **Overlapping full init** — the superseded connect is discarded, its client closed, the
   live entry stays `connecting`, and the newer connection then owns the state.
2. **Scoped reload** — a reload of `beta` must not strand `alpha`, whose connect was still
   in flight; `alpha` reaches `connected` with its tools.

Both fail on `main`:

```
● discards a superseded connect and lets the newer one own the state
  Expected number of calls: >= 1        (mockClientClose)
  Received number of calls:    0

● does not orphan an unrelated server that is still connecting
  Expected: "connected"
  Received: "connecting"
```

Full suite: 1448 passed. Three suites fail identically on a clean checkout
(`src/utils/processTree.test.ts`, `tests/controllers/mcpbController.test.ts`,
`tests/services/credentialBindingService.test.ts`) — pre-existing and platform-related on
Windows.

## Note on approach

The issue listed three possible directions. This is the first one (resolve by identity on
settle) because it is contained: no lifecycle redesign, no change to when or how often
re-inits happen, and no new interface. Serialising re-inits or making preservation reuse
the object would both work too, and would be larger changes — happy to go either way if
you'd prefer one of those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GarhjXLQBBxNc6EgrMXf3M
