### PR TITLE
fix: keep on-demand servers alive while tools are running

### DIFF
--- a/src/services/mcpService.ts
+++ b/src/services/mcpService.ts
@@ -1651,23 +1651,25 @@ export const initializeClientsFromSettings = async (
       // connection) so the tool list stays visible to agents even while sleeping.
       if (expandedConf.startOnDemand === true && isStdioServer(expandedConf)) {
         const existingOnDemand = existingServerInfos.find((s) => s.name === name);
-        nextServerInfos.push({
-          // Carry over cached tools/prompts/resources if the server was previously connected
-          ...(existingOnDemand ?? {
-            name,
-            status: 'disconnected' as const,
-            error: null,
-            tools: [],
-            prompts: [],
-            resources: [],
-            createTime: Date.now(),
-          }),
+        // Active calls, spawn promises and idle callbacks must share the same
+        // runtime object across reloads, not copies of its mutable state.
+        const onDemandInfo: ServerInfo = existingOnDemand ?? {
+          name,
+          status: 'disconnected',
+          error: null,
+          tools: [],
+          prompts: [],
+          resources: [],
+          createTime: Date.now(),
+        };
+        Object.assign(onDemandInfo, {
           owner: expandedConf.owner,
           visibility: expandedConf.visibility,
           sharedWithUsers: expandedConf.sharedWithUsers,
           enabled: true,
           config: expandedConf,
         });
+        nextServerInfos.push(onDemandInfo);
         logger.log(`Skipping startup connect for on-demand server: ${name}`);
         continue;
       }
@@ -2541,7 +2543,15 @@ function checkAuthError(result: any) {
   }
 }
 
+const clearIdleShutdown = (serverInfo: ServerInfo): void => {
+  if (serverInfo.idleTimeoutId) {
+    clearTimeout(serverInfo.idleTimeoutId);
+    serverInfo.idleTimeoutId = undefined;
+  }
+};
+
 const closeServerRuntime = (serverInfo: ServerInfo): void => {
+  clearIdleShutdown(serverInfo);
   if (serverInfo.keepAliveIntervalId) {
     clearInterval(serverInfo.keepAliveIntervalId);
     serverInfo.keepAliveIntervalId = undefined;
@@ -2600,10 +2610,8 @@ export function closeServer(name: string) {
  * the server offers and trigger a cold-start on the next tool call.
  */
 const shutdownOnDemandServer = (serverInfo: ServerInfo): void => {
-  if (serverInfo.idleTimeoutId) {
-    clearTimeout(serverInfo.idleTimeoutId);
-    serverInfo.idleTimeoutId = undefined;
-  }
+  // Discovery priming may finish while a tool call is using the same child.
+  if (serverInfo.activeToolCalls) return;
 
   // Close runtime (kills process) but intentionally keep tools/prompts/resources
   closeServerRuntime(serverInfo);
@@ -2616,14 +2624,19 @@ const shutdownOnDemandServer = (serverInfo: ServerInfo): void => {
 };
 
 /**
- * Resets (or starts) the idle-shutdown timer for an on-demand server.
- * Call this after every successful tool invocation.
+ * Starts the idle period once the last active call has finished.
  */
 const scheduleIdleShutdown = (serverInfo: ServerInfo): void => {
-  if (!serverInfo.config?.startOnDemand || hasCredentialTemplate(serverInfo.config)) return;
-
-  if (serverInfo.idleTimeoutId) {
-    clearTimeout(serverInfo.idleTimeoutId);
+  clearIdleShutdown(serverInfo);
+  if (
+    !serverInfo.config?.startOnDemand ||
+    !isStdioServer(serverInfo.config) ||
+    hasCredentialTemplate(serverInfo.config) ||
+    serverInfo.status !== 'connected' ||
+    !serverInfo.client ||
+    serverInfo.activeToolCalls
+  ) {
+    return;
   }
 
   const idleMs = serverInfo.config.idleTimeoutMs ?? 300_000; // default 5 minutes
@@ -2632,6 +2645,23 @@ const scheduleIdleShutdown = (serverInfo: ServerInfo): void => {
       shutdownOnDemandServer(serverInfo);
     }
   }, idleMs);
+};
+
+const beginOnDemandToolCall = (serverInfo: ServerInfo): (() => void) | undefined => {
+  if (
+    !serverInfo.config?.startOnDemand ||
+    !isStdioServer(serverInfo.config) ||
+    hasCredentialTemplate(serverInfo.config)
+  ) {
+    return undefined;
+  }
+
+  clearIdleShutdown(serverInfo);
+  serverInfo.activeToolCalls = (serverInfo.activeToolCalls ?? 0) + 1;
+  return () => {
+    serverInfo.activeToolCalls = serverInfo.activeToolCalls! - 1;
+    scheduleIdleShutdown(serverInfo);
+  };
 };
 
 /**
@@ -2796,9 +2826,9 @@ const primeOnDemandServers = (): Promise<void> => {
     targets.map(async (si) => {
       try {
         await ensureServerReady(si);
-        // Sleep the child but keep the cached tool list visible to agents.
+        // Sleep the child unless a tool call is using it; keep the cached tool list.
         shutdownOnDemandServer(si);
-        logger.log('On-demand server primed and asleep');
+        logger.log('On-demand server tool cache primed');
       } catch (error) {
         logger.warn('Failed to prime on-demand server', {
           error: summarizeErrorForLogging(error),
@@ -3325,6 +3355,7 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
   const keyName = bearerKeyContext.keyName || extra?.keyName || undefined;
   const sourceIp = requestContextService.getRequestContext()?.remoteAddress || undefined;
   let hostedReservation: HostedCreditReservation | null = null;
+  let releaseOnDemandToolCall: (() => void) | undefined;
 
   const reserveHostedIfNeeded = async (serverName: string, toolName: string) => {
     const hostedAuth = requestContextService.getHostedAuthContext();
@@ -3410,6 +3441,7 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
 
       // If the target is an on-demand server that is not yet running, wake it up now.
       // Concurrent callers are serialised via ensureServerReady's singleton promise.
+      releaseOnDemandToolCall = beginOnDemandToolCall(targetServerInfo);
       if (targetServerInfo.config?.startOnDemand && targetServerInfo.status !== 'connected') {
         await ensureServerReady(targetServerInfo);
         // Re-read status from the mutated serverInfo after async spawn
@@ -3574,9 +3606,6 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
         result: summarizeToolResultForLogging(result),
       });
 
-      // Reset idle-shutdown timer for on-demand servers after each successful call
-      scheduleIdleShutdown(targetServerInfo);
-
       // Log successful activity
       const duration = Date.now() - startTime;
       await activityLogger.logToolCall({
@@ -3633,6 +3662,7 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
     // Wake the on-demand server before invoking the tool. It may be asleep with
     // a cached tool list (visible above) but no live client. Mirrors the
     // $smart call_tool path. See #1029.
+    releaseOnDemandToolCall = beginOnDemandToolCall(serverInfo);
     if (serverInfo.config?.startOnDemand && serverInfo.status !== 'connected') {
       await ensureServerReady(serverInfo);
     }
@@ -3764,9 +3794,6 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
       result: summarizeToolResultForLogging(result),
     });
 
-    // Reset idle-shutdown timer for on-demand servers after each successful call
-    scheduleIdleShutdown(serverInfo);
-
     // Log successful activity
     const duration = Date.now() - startTime;
     await activityLogger.logToolCall({
@@ -3845,6 +3872,8 @@ const handleCallToolRequestImpl = async (request: any, extra: any) => {
       ],
       isError: true,
     };
+  } finally {
+    releaseOnDemandToolCall?.();
   }
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -578,6 +578,7 @@ export interface ServerInfo {
   config?: ServerConfig; // Reference to the original server configuration for OpenAPI passthrough headers
   // On-demand spawning runtime state
   spawningPromise?: Promise<void>; // Singleton promise: concurrent callers await this instead of double-spawning
+  activeToolCalls?: number; // Calls holding the on-demand runtime awake, including cold starts
   idleTimeoutId?: NodeJS.Timeout; // Timer ID for idle-shutdown (cleared/reset on each tool call)
   lastUsedAt?: number; // Timestamp of last tool call (ms since epoch)
   oauth?: {

--- a/tests/services/mcpService-onDemand.test.ts
+++ b/tests/services/mcpService-onDemand.test.ts
@@ -157,7 +157,17 @@ const createSleepingServerInfo = (overrides: Record<string, any> = {}) => ({
   ...overrides,
 });
 
-describe('startOnDemand wake-up (issue #1029)', () => {
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('startOnDemand lifecycle', () => {
   let createTransportSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -173,9 +183,7 @@ describe('startOnDemand wake-up (issue #1029)', () => {
     mockFindById.mockResolvedValue(ON_DEMAND_CONFIG);
     mockFindAll.mockResolvedValue([]);
     // Stub transport creation so the wake does not spawn a real child process.
-    createTransportSpy = jest
-      .spyOn(mcpService, 'createTransportFromConfig')
-      .mockResolvedValue({});
+    createTransportSpy = jest.spyOn(mcpService, 'createTransportFromConfig').mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -192,7 +200,10 @@ describe('startOnDemand wake-up (issue #1029)', () => {
     );
 
     // The child was spawned (transport + connect) and the tool was invoked.
-    expect(createTransportSpy).toHaveBeenCalledWith('demo', expect.objectContaining({ command: 'node' }));
+    expect(createTransportSpy).toHaveBeenCalledWith(
+      'demo',
+      expect.objectContaining({ command: 'node' }),
+    );
     expect(mockConnect).toHaveBeenCalledTimes(1);
     expect(mockCallTool).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'ping', arguments: {} }),
@@ -233,6 +244,161 @@ describe('startOnDemand wake-up (issue #1029)', () => {
     expect(mockCallTool).not.toHaveBeenCalled();
     // A failed wake must not leave the idle timer armed.
     expect(serverInfo.idleTimeoutId).toBeFalsy();
+  });
+
+  describe.each(['direct', 'call_tool'])('idle shutdown during %s calls (issue #1163)', (route) => {
+    const result = { content: [{ type: 'text', text: 'pong' }], isError: false };
+    const config = { ...ON_DEMAND_CONFIG, idleTimeoutMs: 1000 };
+    const call = () =>
+      mcpService.handleCallToolRequest(
+        route === 'direct'
+          ? { params: { name: 'demo::ping', arguments: {} } }
+          : { params: { name: 'call_tool', arguments: { toolName: 'demo::ping', arguments: {} } } },
+        { sessionId: 'session-1' },
+      );
+
+    const startPendingCall = async () => {
+      const started = deferred<void>();
+      const completion = deferred<typeof result>();
+      mockCallTool.mockImplementationOnce(() => {
+        started.resolve();
+        return completion.promise;
+      });
+      const pending = call();
+      await started.promise;
+      return { pending, completion };
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mcpService.setServerInfosForTest([
+        createSleepingServerInfo({
+          status: 'connected',
+          client: mockClient,
+          config,
+        }) as any,
+      ]);
+      mockFindById.mockResolvedValue(config);
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    });
+
+    const expectIdleShutdown = async () => {
+      await jest.advanceTimersByTimeAsync(999);
+      expect(mockClient.close).not.toHaveBeenCalled();
+      await jest.advanceTimersByTimeAsync(1);
+      expect(mockClient.close).toHaveBeenCalledTimes(1);
+      expect(mcpService.getServerByName('demo')?.status).toBe('disconnected');
+      expect(mcpService.getServerByName('demo')?.client).toBeUndefined();
+      expect(mcpService.getServerByName('demo')?.tools.map((tool) => tool.name)).toContain(
+        'demo::ping',
+      );
+    };
+
+    it('keeps a new call alive past the previous idle deadline, then reclaims the idle child', async () => {
+      await call();
+      await jest.advanceTimersByTimeAsync(900);
+      const active = await startPendingCall();
+      try {
+        // Also exceeds a full idle period: resetting the timer at call start is insufficient.
+        await jest.advanceTimersByTimeAsync(2000);
+        expect(mockClient.close).not.toHaveBeenCalled();
+      } finally {
+        active.completion.resolve(result);
+        await active.pending;
+      }
+      await expectIdleShutdown();
+    });
+
+    it('waits for the last concurrent call before starting the idle period', async () => {
+      const active = await startPendingCall();
+      try {
+        await jest.advanceTimersByTimeAsync(300);
+        await call();
+        await jest.advanceTimersByTimeAsync(2000);
+        expect(mockClient.close).not.toHaveBeenCalled();
+      } finally {
+        active.completion.resolve(result);
+        await active.pending;
+      }
+      await expectIdleShutdown();
+    });
+
+    it.each(['rejection', 'error result'])(
+      'reclaims the child after a tool %s',
+      async (failure) => {
+        if (failure === 'rejection') {
+          mockCallTool.mockRejectedValueOnce(new Error('tool failed'));
+        } else {
+          mockCallTool.mockResolvedValueOnce({ ...result, isError: true });
+        }
+        expect((await call()).isError).toBe(true);
+        await expectIdleShutdown();
+      },
+    );
+
+    it('preserves active calls and idle shutdown across a configuration reload', async () => {
+      const active = await startPendingCall();
+      try {
+        mockFindAll.mockResolvedValue([config]);
+        await mcpService.initializeClientsFromSettings(false, 'another-server');
+        await call();
+        await jest.advanceTimersByTimeAsync(2000);
+        expect(mockClient.close).not.toHaveBeenCalled();
+      } finally {
+        active.completion.resolve(result);
+        await active.pending;
+      }
+      await expectIdleShutdown();
+    });
+
+    it('clears the idle timer when the server is explicitly closed', async () => {
+      await call();
+      mcpService.closeServer('demo');
+      expect(mcpService.getServerByName('demo')?.idleTimeoutId).toBeUndefined();
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(mockClient.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not rearm idle shutdown when a closed runtime finishes a call', async () => {
+      const active = await startPendingCall();
+      mcpService.closeServer('demo');
+      active.completion.reject(new Error('Connection closed'));
+      expect((await active.pending).isError).toBe(true);
+      expect(mcpService.getServerByName('demo')?.idleTimeoutId).toBeUndefined();
+      await jest.advanceTimersByTimeAsync(2000);
+      expect(mockClient.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let discovery priming close a child being used by a tool call', async () => {
+      const listing = deferred<void>();
+      const prompts = deferred<{ prompts: [] }>();
+      mockClient.getServerCapabilities.mockReturnValue({ tools: {}, prompts: {} } as any);
+      mockClient.listPrompts.mockImplementationOnce(() => {
+        listing.resolve();
+        return prompts.promise;
+      });
+      mockFindAll.mockResolvedValue([config]);
+      mcpService.setServerInfosForTest([]);
+      const priming = mcpService.initializeClientsFromSettings(false, 'demo');
+      await listing.promise;
+      const active = await startPendingCall();
+      try {
+        prompts.resolve({ prompts: [] });
+        await priming;
+        await jest.advanceTimersByTimeAsync(2000);
+        expect(mockClient.close).not.toHaveBeenCalled();
+      } finally {
+        prompts.resolve({ prompts: [] });
+        active.completion.resolve(result);
+        await Promise.all([priming, active.pending]);
+        mockClient.getServerCapabilities.mockReturnValue({ tools: {} });
+      }
+      await expectIdleShutdown();
+    });
   });
 
   it('does not select a disabled on-demand server for a tool call', async () => {


### PR DESCRIPTION
A tool call that starts shortly before an on-demand server's idle deadline can be interrupted by the previous call's timer. A short concurrent call can also arm that timer while another call is still running, leaving the caller with a connection error after the tool has already performed a write.

Track active calls on the on-demand runtime, cancel idle shutdown before waking or using it, and start the idle period when the last call finishes. Release the count in `finally` so failed calls can still be reclaimed. Preserve the runtime object across configuration reloads so callers and timers share the same state, and keep discovery priming from closing a child that a tool call is using.

Fixes #1163.

### Validation

- On-demand suite: **22 tests pass**, including both tool-call paths, overlapping calls, rejected calls, error results, configuration reloads, explicit closure, and discovery priming.
- `pnpm lint`, `pnpm build`, and `node scripts/verify-dist.js` pass.
- The real stdio reproduction from #1163 now returns successfully: the call near the idle deadline completes in about **703ms**, and the overlapping call completes in about **1702ms**. Both deliver their results after writing the local record.
- `pnpm dev` starts and connects the test upstream; `/health` returns HTTP 200. After discovery priming puts the upstream to sleep, the health payload reports it as disconnected/degraded.
- `pnpm test:ci --maxWorkers=2`: **1468 passed, 15 failed**. The same 15 failures reproduce in an unchanged checkout of `fb60844f975e02de08f42b8849e927428b34fe6f`. They include transport tests where the local DNS resolves `example.com` to `198.18.0.11`, which the existing SSRF check blocks. No additional test failures were introduced.
