### PR TITLE
fix: cache OAuth clients only after credential persistence

### DIFF
--- a/src/services/oauthClientRegistration.ts
+++ b/src/services/oauthClientRegistration.ts
@@ -34,6 +34,7 @@ interface RegisteredClientInfo {
 
 // Cache for registered clients to avoid re-registering on every restart
 const registeredClients = new Map<string, RegisteredClientInfo>();
+const pendingRegistrations = new Map<string, Promise<RegisteredClientInfo>>();
 
 export const createOAuthFetch = async (serverConfig?: ServerConfig): Promise<FetchLike> => {
   const ownerUser = serverConfig?.owner
@@ -252,6 +253,31 @@ export const registerClient = async (
     return cached;
   }
 
+  const pending = pendingRegistrations.get(serverName);
+  if (pending) {
+    return pending;
+  }
+
+  const registration = registerAndPersistClient(
+    serverName,
+    serverConfig,
+    autoDetectedIssuer,
+    autoDetectedScopes,
+  );
+  pendingRegistrations.set(serverName, registration);
+  try {
+    return await registration;
+  } finally {
+    pendingRegistrations.delete(serverName);
+  }
+};
+
+const registerAndPersistClient = async (
+  serverName: string,
+  serverConfig: ServerConfig,
+  autoDetectedIssuer?: string,
+  autoDetectedScopes?: string[],
+): Promise<RegisteredClientInfo> => {
   const dynamicConfig = serverConfig.oauth?.dynamicRegistration;
 
   try {

--- a/src/services/oauthClientRegistration.ts
+++ b/src/services/oauthClientRegistration.ts
@@ -337,9 +337,6 @@ export const registerClient = async (
       metadata: config,
     };
 
-    // Cache the registered client
-    registeredClients.set(serverName, clientInfo);
-
     // Persist the client credentials and scopes to configuration
     const persistedConfig = await persistClientCredentials(serverName, {
       clientId,
@@ -350,12 +347,15 @@ export const registerClient = async (
       revocationEndpoint: clientInfo.config.serverMetadata().revocation_endpoint,
     });
 
-    if (persistedConfig) {
-      serverConfig.oauth = {
-        ...(serverConfig.oauth || {}),
-        ...persistedConfig.oauth,
-      };
+    if (!persistedConfig) {
+      throw new Error(`Failed to persist OAuth client credentials for server ${serverName}`);
     }
+
+    serverConfig.oauth = {
+      ...(serverConfig.oauth || {}),
+      ...persistedConfig.oauth,
+    };
+    registeredClients.set(serverName, clientInfo);
 
     return clientInfo;
   } catch (error) {

--- a/src/services/oauthSettingsStore.ts
+++ b/src/services/oauthSettingsStore.ts
@@ -89,6 +89,10 @@ export const persistClientCredentials = async (
     }
   });
 
+  if (!updated) {
+    return undefined;
+  }
+
   logger.log(`Persisted OAuth client credentials for server: ${serverName}`);
   if (credentials.scopes && credentials.scopes.length > 0) {
     logger.log(`Stored OAuth scopes for ${serverName}: ${credentials.scopes.join(', ')}`);

--- a/tests/integration/oauth-registration-persistence.test.ts
+++ b/tests/integration/oauth-registration-persistence.test.ts
@@ -1,0 +1,91 @@
+const mockDynamicClientRegistration = jest.fn();
+const mockFindById = jest.fn();
+const mockUpdate = jest.fn();
+
+jest.mock('openid-client', () => ({
+  customFetch: Symbol('customFetch'),
+  dynamicClientRegistration: mockDynamicClientRegistration,
+  None: jest.fn(),
+}));
+
+jest.mock('../../src/dao/index.js', () => ({
+  getServerDao: () => ({ findById: mockFindById, update: mockUpdate }),
+  getSystemConfigDao: () => ({ get: async () => ({}) }),
+  getUserDao: () => ({ findByUsername: async () => undefined }),
+}));
+
+import {
+  getRegisteredClient,
+  registerClient,
+  removeRegisteredClient,
+} from '../../src/services/oauthClientRegistration.js';
+import { ServerConfig } from '../../src/types/index.js';
+
+describe('OAuth registration persistence', () => {
+  const serverName = 'registration-persistence';
+  const makeConfig = (): ServerConfig => ({
+    url: 'https://mcp.example.com/mcp',
+    oauth: { dynamicRegistration: { enabled: true, issuer: 'https://issuer.example.com' } },
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    removeRegisteredClient(serverName);
+    mockFindById.mockImplementation(async () => ({ name: serverName, ...makeConfig() }));
+    mockUpdate.mockImplementation(async (_name, updates) => ({ name: serverName, ...updates }));
+    mockDynamicClientRegistration.mockImplementation(async () => ({
+      client_id: `client-${mockDynamicClientRegistration.mock.calls.length}`,
+      client_secret: 'secret',
+      serverMetadata: () => ({ token_endpoint: 'https://issuer.example.com/token' }),
+    }));
+  });
+
+  afterEach(() => removeRegisteredClient(serverName));
+
+  it.each(['missing record', 'write rejection', 'empty update result'])(
+    'leaves registration retryable after %s',
+    async (failure) => {
+      if (failure === 'missing record') mockFindById.mockResolvedValueOnce(undefined);
+      if (failure === 'write rejection')
+        mockUpdate.mockRejectedValueOnce(new Error('write failed'));
+      if (failure === 'empty update result') mockUpdate.mockResolvedValueOnce(null);
+      const config = makeConfig();
+
+      await expect(registerClient(serverName, config)).rejects.toThrow();
+      expect(getRegisteredClient(serverName)).toBeUndefined();
+      expect(config.oauth?.clientId).toBeUndefined();
+
+      const registered = await registerClient(serverName, config);
+      expect(registered.clientId).toBe('client-2');
+      expect(mockUpdate).toHaveBeenLastCalledWith(serverName, {
+        oauth: expect.objectContaining({ clientId: 'client-2', clientSecret: 'secret' }),
+      });
+      expect(config.oauth?.clientId).toBe('client-2');
+      expect(getRegisteredClient(serverName)).toBe(registered);
+      expect(await registerClient(serverName, config)).toBe(registered);
+      expect(mockDynamicClientRegistration).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('keeps the client invisible until the write completes', async () => {
+    let finishWrite!: () => void;
+    let writeStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      writeStarted = resolve;
+    });
+    mockUpdate.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishWrite = () => resolve({ name: serverName });
+          writeStarted();
+        }),
+    );
+    const registration = registerClient(serverName, makeConfig());
+    await started;
+    const cachedDuringWrite = getRegisteredClient(serverName);
+    finishWrite();
+    const registered = await registration;
+    expect(cachedDuringWrite).toBeUndefined();
+    expect(getRegisteredClient(serverName)).toBe(registered);
+  });
+});

--- a/tests/integration/oauth-registration-persistence.test.ts
+++ b/tests/integration/oauth-registration-persistence.test.ts
@@ -19,6 +19,7 @@ import {
   registerClient,
   removeRegisteredClient,
 } from '../../src/services/oauthClientRegistration.js';
+import { logger } from '../../src/utils/logger.js';
 import { ServerConfig } from '../../src/types/index.js';
 
 describe('OAuth registration persistence', () => {
@@ -40,7 +41,10 @@ describe('OAuth registration persistence', () => {
     }));
   });
 
-  afterEach(() => removeRegisteredClient(serverName));
+  afterEach(() => {
+    removeRegisteredClient(serverName);
+    jest.restoreAllMocks();
+  });
 
   it.each(['missing record', 'write rejection', 'empty update result'])(
     'leaves registration retryable after %s',
@@ -49,11 +53,15 @@ describe('OAuth registration persistence', () => {
       if (failure === 'write rejection')
         mockUpdate.mockRejectedValueOnce(new Error('write failed'));
       if (failure === 'empty update result') mockUpdate.mockResolvedValueOnce(null);
+      const log = jest.spyOn(logger, 'log');
       const config = makeConfig();
 
       await expect(registerClient(serverName, config)).rejects.toThrow();
       expect(getRegisteredClient(serverName)).toBeUndefined();
       expect(config.oauth?.clientId).toBeUndefined();
+      expect(log).not.toHaveBeenCalledWith(
+        `Persisted OAuth client credentials for server: ${serverName}`,
+      );
 
       const registered = await registerClient(serverName, config);
       expect(registered.clientId).toBe('client-2');
@@ -64,6 +72,53 @@ describe('OAuth registration persistence', () => {
       expect(getRegisteredClient(serverName)).toBe(registered);
       expect(await registerClient(serverName, config)).toBe(registered);
       expect(mockDynamicClientRegistration).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([false, true])(
+    'shares pending registration and clears it after failure=%s',
+    async (fail) => {
+      let finishWrite!: () => void;
+      let writeStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        writeStarted = resolve;
+      });
+      const writeError = new Error('write failed');
+      mockUpdate.mockImplementationOnce(
+        () =>
+          new Promise((resolve, reject) => {
+            finishWrite = () => (fail ? reject(writeError) : resolve({ name: serverName }));
+            writeStarted();
+          }),
+      );
+
+      const first = registerClient(serverName, makeConfig());
+      const second = registerClient(serverName, makeConfig());
+      await started;
+      const third = registerClient(serverName, makeConfig());
+      const resultsPromise = Promise.allSettled([first, second, third]);
+      const cachedDuringWrite = getRegisteredClient(serverName);
+      finishWrite();
+      const results = await resultsPromise;
+      expect(cachedDuringWrite).toBeUndefined();
+      expect(mockDynamicClientRegistration).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+      if (fail) {
+        expect(results).toEqual(Array(3).fill({ status: 'rejected', reason: writeError }));
+        expect(getRegisteredClient(serverName)).toBeUndefined();
+        const retried = await registerClient(serverName, makeConfig());
+        expect(retried.clientId).toBe('client-2');
+        expect(getRegisteredClient(serverName)).toBe(retried);
+        expect(mockDynamicClientRegistration).toHaveBeenCalledTimes(2);
+        expect(mockUpdate).toHaveBeenCalledTimes(2);
+      } else {
+        const registered = getRegisteredClient(serverName);
+        expect(registered?.clientId).toBe('client-1');
+        expect(results).toEqual(Array(3).fill({ status: 'fulfilled', value: registered }));
+        removeRegisteredClient(serverName);
+        expect((await registerClient(serverName, makeConfig())).clientId).toBe('client-2');
+      }
     },
   );
 

--- a/tests/services/oauthClientRegistration.test.ts
+++ b/tests/services/oauthClientRegistration.test.ts
@@ -28,6 +28,7 @@ jest.mock('../../src/dao/index.js', () => ({
   getUserDao: jest.fn(() => ({ findByUsername: mockFindByUsername })),
 }));
 
+import { persistClientCredentials } from '../../src/services/oauthSettingsStore.js';
 import { getSystemConfigDao } from '../../src/dao/index.js';
 import {
   fetchProtectedResourceMetadata,
@@ -42,6 +43,9 @@ describe('registerClient redirect URI handling', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest
+      .mocked(persistClientCredentials)
+      .mockResolvedValue({ oauth: { clientId: 'registered-client' } });
     removeRegisteredClient('notion');
     process.env = { ...originalEnv };
     delete process.env.INSTALL_BASE_URL;


### PR DESCRIPTION
When upstream dynamic client registration succeeds but credential persistence fails, retries currently reuse an unpersisted cached client. Publish the client to the process cache only after persistence succeeds, and fail registration when no server configuration was persisted. Avoid logging successful credential persistence for a missing server.

Share an in-flight registration promise per server so concurrent callers perform one upstream registration and one persistence write. Clear the pending promise after success or failure so later registration remains retryable.

DAO-boundary integration regressions cover missing records, rejected writes, empty update results, successful retries, cache visibility during persistence, concurrent success/failure, pending-promise cleanup, and absence of false persistence-success logs. Existing registration mocks now return a successful persistence result.

Validation:
- Confirmed the persistence and concurrency regressions fail before their respective fixes and pass afterward.
- `pnpm lint`
- `pnpm test:ci --runInBand`: 198 suites, 1,489 tests passed.
- `pnpm build`
- `node scripts/verify-dist.js`
- Prettier check and `git diff --check`

Integration coverage mocks the upstream registration and DAO boundaries; no live OAuth provider or database was used.

Fixes #1158
