### PR TITLE
fix: simplify Docker quick start while preserving legacy mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ COPY . .
 RUN curl -s -f --connect-timeout 10 https://mcpm.sh/api/servers.json -o servers.json || echo "Failed to download servers.json, using bundled version"
 
 RUN pnpm build
+# Keep the legacy path available only for user-mounted configuration.
+RUN rm /app/mcp_settings.json
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/README.fr.md
+++ b/README.fr.md
@@ -55,26 +55,21 @@ MCPHub offre une manière unifiée de connecter et de gérer plusieurs serveurs 
 - **Docker** (recommandé) — le moyen le plus rapide d'exécuter MCPHub ; toutes les commandes ci-dessous l'utilisent
 - **Node.js** `^18.0.0 || >=20.0.0` et **pnpm** `10.12.4` — uniquement pour exécuter depuis les sources ou développer localement (voir [Développement local](#développement-local))
 
-### Lancer en 30 secondes
+### Démarrer avec Docker
 
 ```bash
-docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json samanhappy/mcphub
+docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub
 ```
 
 Ouvrez `http://localhost:3000` et connectez-vous avec le nom d'utilisateur `admin`. Au premier lancement, si la variable d'environnement `ADMIN_PASSWORD` n'est pas définie, un mot de passe aléatoire est généré et affiché dans les logs du serveur.
 
-La configuration, les utilisateurs et les identifiants persistent dans `./data` (via `MCPHUB_SETTING_PATH`).
+La configuration, les utilisateurs et les identifiants persistent dans `./data` par défaut.
 
-Avec vos propres serveurs ? Écrivez un `mcp_settings.json` (voir [Configuration](#configuration)), copiez-le dans `./data/` et lancez la même commande :
-
-```bash
-cp mcp_settings.json data/
-docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json samanhappy/mcphub
-```
+Avec vos propres serveurs ? Avant le premier lancement, créez `data/mcp_settings.json` (voir [Configuration](#configuration)). Ensuite, ajoutez des serveurs dans le tableau de bord ou modifiez le fichier existant et redémarrez MCPHub.
 
 ### Configuration
 
-Créez un fichier `mcp_settings.json` :
+Avant le premier lancement, créez `data/mcp_settings.json` :
 
 ```json
 {
@@ -95,7 +90,7 @@ Créez un fichier `mcp_settings.json` :
 
 ### Déploiement avec Docker
 
-Voir [Lancer en 30 secondes](#lancer-en-30-secondes) pour les commandes prêtes à copier. Montez toujours `./data` avec `-e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json` pour que la configuration, les utilisateurs et les identifiants survivent aux recréations du conteneur.
+Voir [Démarrer avec Docker](#démarrer-avec-docker) pour la commande prête à copier. Gardez `./data` monté pour conserver la configuration, les utilisateurs et les identifiants après la recréation du conteneur.
 
 Deux variantes d'image sont publiées sous `samanhappy/mcphub` :
 
@@ -106,11 +101,11 @@ Voir [Configuration Docker](https://docs.mcphub.app/configuration/docker-setup) 
 
 ### Accéder au tableau de bord
 
-Ouvrez `http://localhost:3000` (voir [Lancer en 30 secondes](#lancer-en-30-secondes) pour la connexion). Vous pouvez également prédéfinir le mot de passe :
+Ouvrez `http://localhost:3000` (voir [Démarrer avec Docker](#démarrer-avec-docker) pour la connexion). Vous pouvez également prédéfinir le mot de passe :
 
 ```bash
 # Docker : définir le mot de passe admin via une variable d'environnement
-docker run -p 3000:3000 -e ADMIN_PASSWORD=your-secure-password samanhappy/mcphub
+docker run -p 3000:3000 -v ./data:/app/data -e ADMIN_PASSWORD=your-secure-password samanhappy/mcphub
 ```
 
 > **Conseil :** Changez le mot de passe admin après la première connexion pour plus de sécurité.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > An open-source, self-hosted MCP gateway and control plane for connecting, controlling, and operating MCP servers.
 
-[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fsamanhappy%2Fmcphub.svg)](https://mcptoplist.com/server/glama%2Fsamanhappy%2Fmcphub)
 [![CI](https://github.com/samanhappy/mcphub/actions/workflows/ci.yml/badge.svg)](https://github.com/samanhappy/mcphub/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@samanhappy/mcphub)](https://www.npmjs.com/package/@samanhappy/mcphub)
 [![Docker pulls](https://img.shields.io/docker/pulls/samanhappy/mcphub)](https://hub.docker.com/r/samanhappy/mcphub)
@@ -59,26 +58,21 @@ It works with MCP clients such as Claude Code, Cursor, Cherry Studio, OpenWebUI,
 - **Docker** (recommended) — the fastest way to run MCPHub; all commands below use it
 - **Node.js** `^18.0.0 || >=20.0.0` and **pnpm** `10.12.4` — only needed to run from source or develop locally (see [Local Development](#local-development))
 
-### Run in 30 seconds
+### Start with Docker
 
 ```bash
-docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json samanhappy/mcphub
+docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub
 ```
 
 Open `http://localhost:3000` and log in with username `admin`. On first launch, if no `ADMIN_PASSWORD` environment variable is set, a random password is generated and printed to the server logs.
 
-Settings, users, and credential bindings all persist in `./data` (via `MCPHUB_SETTING_PATH`).
+Settings, users, and credential bindings persist in `./data` by default.
 
-Want your own servers? Write a `mcp_settings.json` (see [Configuration](#configuration)), copy it into `./data/`, and run the same command:
-
-```bash
-cp mcp_settings.json data/
-docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json samanhappy/mcphub
-```
+Want your own servers? Before the first launch, create `data/mcp_settings.json` (see [Configuration](#configuration)). After launch, add servers in the dashboard or edit the existing file and restart MCPHub.
 
 ### Configuration
 
-Create a `mcp_settings.json` file:
+Create `data/mcp_settings.json` before the first launch:
 
 ```json
 {
@@ -99,7 +93,7 @@ Create a `mcp_settings.json` file:
 
 ### Docker Deployment
 
-See [Run in 30 seconds](#run-in-30-seconds) for the copy-paste commands. Always mount `./data` together with `-e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json` so settings, users, and credential bindings survive restarts.
+See [Start with Docker](#start-with-docker) for the copy-paste command. Keep `./data` mounted so settings, users, and credential bindings survive container recreation.
 
 Two image variants are published under `samanhappy/mcphub`:
 
@@ -110,11 +104,11 @@ See [Docker Setup](https://docs.mcphub.app/configuration/docker-setup) for build
 
 ### Access Dashboard
 
-Open `http://localhost:3000` (see [Run in 30 seconds](#run-in-30-seconds) for login details). You can also pre-set the password:
+Open `http://localhost:3000` (see [Start with Docker](#start-with-docker) for login details). You can also pre-set the password:
 
 ```bash
 # Docker: set admin password via environment variable
-docker run -p 3000:3000 -e ADMIN_PASSWORD=your-secure-password samanhappy/mcphub
+docker run -p 3000:3000 -v ./data:/app/data -e ADMIN_PASSWORD=your-secure-password samanhappy/mcphub
 ```
 
 > **Tip:** Change the admin password after first login for security.

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,26 +57,21 @@ MCPHub 是 AI 客户端与 MCP 服务器之间的统一控制点。一次连接�
 - **Docker**（推荐）—— 运行 MCPHub 最快的方式，下面的命令都基于它
 - **Node.js** `^18.0.0 || >=20.0.0` 和 **pnpm** `10.12.4` —— 仅从源码运行或参与本地开发时需要（见[本地开发](#本地开发)）
 
-### 30 秒运行
+### 使用 Docker 启动
 
 ```bash
-docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json samanhappy/mcphub
+docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub
 ```
 
 打开 `http://localhost:3000`，使用用户名 `admin` 登录。首次启动时，如果未设置 `ADMIN_PASSWORD` 环境变量，系统将自动生成随机密码并输出到服务器日志中。
 
-配置、用户和凭据绑定都会持久化到 `./data`（通过 `MCPHUB_SETTING_PATH`）。
+配置、用户和凭据绑定默认持久化到 `./data`。
 
-想用自己的服务器？编写 `mcp_settings.json`（见[配置](#配置)），拷贝到 `./data/` 下，用同一条命令运行：
-
-```bash
-cp mcp_settings.json data/
-docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json samanhappy/mcphub
-```
+想用自己的服务器？首次启动前，创建 `data/mcp_settings.json`（见[配置](#配置)）。启动后，可在控制台添加服务器，或编辑现有配置文件并重启 MCPHub。
 
 ### 配置
 
-创建 `mcp_settings.json` 文件：
+首次启动前，创建 `data/mcp_settings.json` 文件：
 
 ```json
 {
@@ -97,7 +92,7 @@ docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp
 
 ### Docker 部署
 
-可复制的命令见[30 秒运行](#30-秒运行)。请始终挂载 `./data` 并设置 `-e MCPHUB_SETTING_PATH=/app/data/mcp_settings.json`，这样配置、用户和凭据绑定在容器重建后不会丢失。
+可复制的命令见[使用 Docker 启动](#使用-docker-启动)。请保持挂载 `./data`，这样配置、用户和凭据绑定在容器重建后不会丢失。
 
 `samanhappy/mcphub` 提供两种镜像变体：
 
@@ -108,11 +103,11 @@ docker run -p 3000:3000 -v ./data:/app/data -e MCPHUB_SETTING_PATH=/app/data/mcp
 
 ### 访问控制台
 
-打开 `http://localhost:3000`（登录方式见[30 秒运行](#30-秒运行)）。也可以预先设置密码：
+打开 `http://localhost:3000`（登录方式见[使用 Docker 启动](#使用-docker-启动)）。也可以预先设置密码：
 
 ```bash
 # Docker：通过环境变量设置管理员密码
-docker run -p 3000:3000 -e ADMIN_PASSWORD=your-secure-password samanhappy/mcphub
+docker run -p 3000:3000 -v ./data:/app/data -e ADMIN_PASSWORD=your-secure-password samanhappy/mcphub
 ```
 
 > **提示：** 首次登录后请及时修改管理员密码以确保安全。

--- a/docs/configuration/docker-setup.mdx
+++ b/docs/configuration/docker-setup.mdx
@@ -21,9 +21,13 @@ docker pull samanhappy/mcphub:latest
 docker run -d \
   --name mcphub \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   samanhappy/mcphub:latest
 ```
+
+The image defaults to `/app/data/mcp_settings.json`. Mount the entire data directory to persist settings, users, credential bindings, and their encryption key. For custom servers, create `data/mcp_settings.json` before the first launch, or edit the existing file afterward. With detached mode (`-d`), run `docker logs mcphub` to see the generated initial admin password.
+
+Existing file mounts at `/app/mcp_settings.json` are detected automatically and take precedence over the data directory, so existing Docker commands keep working. An explicit `MCPHUB_SETTING_PATH` always takes precedence over both locations. For full persistence, migrate the settings file and its existing `.credentials.json` and `.credentials.key` sidecars together into the mounted data directory. Explicit `MCPHUB_SETTING_PATH` values remain supported.
 
 ### Building from Source
 
@@ -39,7 +43,7 @@ docker build -t mcphub:local .
 docker run -d \
   --name mcphub \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   mcphub:local
 ```
 
@@ -56,14 +60,14 @@ docker run -d \
   --name mcphub \
   --privileged \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   mcphub:extended
 
 # Option 2: Run with Docker socket mounted (use host's Docker daemon)
 docker run -d \
   --name mcphub \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   mcphub:extended
 
@@ -112,9 +116,8 @@ services:
       - JWT_SECRET=${JWT_SECRET:-your-jwt-secret}
       - DB_URL=postgresql://mcphub:password@postgres:5432/mcphub
     volumes:
-      - ./mcp_settings.json:/app/mcp_settings.json:ro
       - ./servers.json:/app/servers.json:ro
-      - mcphub_data:/app/data
+      - ./data:/app/data
     depends_on:
       postgres:
         condition: service_healthy
@@ -145,7 +148,6 @@ services:
 
 volumes:
   postgres_data:
-  mcphub_data:
 
 networks:
   mcphub-network:
@@ -189,9 +191,8 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - REDIS_URL=redis://redis:6379
     volumes:
-      - ./mcp_settings.json:/app/mcp_settings.json:ro
       - ./servers.json:/app/servers.json:ro
-      - mcphub_data:/app/data
+      - ./data:/app/data
       - mcphub_logs:/app/logs
     depends_on:
       postgres:
@@ -244,7 +245,6 @@ services:
 volumes:
   postgres_data:
   redis_data:
-  mcphub_data:
   mcphub_logs:
   nginx_logs:
 
@@ -394,7 +394,7 @@ docker-compose down
 
 ### MCP Settings Volume Mount
 
-Create your `mcp_settings.json`:
+Before the first launch, create `data/mcp_settings.json`:
 
 ```json
 {

--- a/docs/zh/configuration/docker-setup.mdx
+++ b/docs/zh/configuration/docker-setup.mdx
@@ -21,9 +21,13 @@ docker pull samanhappy/mcphub:latest
 docker run -d \
   --name mcphub \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   samanhappy/mcphub:latest
 ```
+
+镜像默认使用 `/app/data/mcp_settings.json`。挂载整个数据目录可持久化配置、用户、凭据绑定及其加密密钥。如需自定义服务器，可在首次启动前创建 `data/mcp_settings.json`，或在启动后编辑现有文件。后台运行（`-d`）时，通过 `docker logs mcphub` 查看首次生成的管理员密码。
+
+启动时会自动识别旧方式挂载的 `/app/mcp_settings.json`，并优先于数据目录使用，因此原有 Docker 命令无需修改。显式设置的 `MCPHUB_SETTING_PATH` 始终拥有最高优先级。为完整持久化数据，应将配置文件及已有的 `.credentials.json`、`.credentials.key` 伴随文件一起迁入挂载的数据目录。仍支持显式覆盖 `MCPHUB_SETTING_PATH`。
 
 ### 从源码构建
 
@@ -39,7 +43,7 @@ docker build -t mcphub:local .
 docker run -d \
   --name mcphub \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   mcphub:local
 ```
 
@@ -56,14 +60,14 @@ docker run -d \
   --name mcphub \
   --privileged \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   mcphub:extended
 
 # 方式 2: 挂载 Docker socket（使用宿主机的 Docker 守护进程）
 docker run -d \
   --name mcphub \
   -p 3000:3000 \
-  -v $(pwd)/mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
   -v /var/run/docker.sock:/var/run/docker.sock \
   mcphub:extended
 
@@ -111,9 +115,8 @@ services:
       - JWT_SECRET=${JWT_SECRET:-your-jwt-secret}
       - DB_URL=postgresql://mcphub:password@postgres:5432/mcphub
     volumes:
-      - ./mcp_settings.json:/app/mcp_settings.json:ro
       - ./servers.json:/app/servers.json:ro
-      - mcphub_data:/app/data
+      - ./data:/app/data
     depends_on:
       postgres:
         condition: service_healthy
@@ -144,7 +147,6 @@ services:
 
 volumes:
   postgres_data:
-  mcphub_data:
 
 networks:
   mcphub-network:
@@ -187,9 +189,8 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - REDIS_URL=redis://redis:6379
     volumes:
-      - ./mcp_settings.json:/app/mcp_settings.json:ro
       - ./servers.json:/app/servers.json:ro
-      - mcphub_data:/app/data
+      - ./data:/app/data
       - mcphub_logs:/app/logs
     depends_on:
       postgres:
@@ -242,7 +243,6 @@ services:
 volumes:
   postgres_data:
   redis_data:
-  mcphub_data:
   mcphub_logs:
   nginx_logs:
 
@@ -391,7 +391,7 @@ docker-compose down
 
 ### MCP 设置卷挂载
 
-创建您的 `mcp_settings.json`：
+首次启动前，创建 `data/mcp_settings.json`：
 
 ```json
 {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Explicit overrides win; preserve legacy file mounts before using the data directory.
+if [ -z "$MCPHUB_SETTING_PATH" ]; then
+  if [ -f /app/mcp_settings.json ]; then
+    export MCPHUB_SETTING_PATH=/app/mcp_settings.json
+  else
+    export MCPHUB_SETTING_PATH=/app/data/mcp_settings.json
+  fi
+fi
+
 NPM_REGISTRY=${NPM_REGISTRY:-https://registry.npmjs.org/}
 echo "Setting npm registry to ${NPM_REGISTRY}"
 npm config set registry "$NPM_REGISTRY"

--- a/tests/scripts/docker-entrypoint.test.ts
+++ b/tests/scripts/docker-entrypoint.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+const projectRoot = path.resolve(__dirname, '../..');
+
+describe('Docker settings path selection', () => {
+  let directory: string;
+
+  beforeEach(() => {
+    directory = fs.mkdtempSync(path.join(os.tmpdir(), 'mcphub-entrypoint-'));
+    fs.writeFileSync(path.join(directory, 'npm'), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    // Exercise the real entrypoint with an isolated equivalent of the container's /app.
+    const script = fs.readFileSync(path.join(projectRoot, 'entrypoint.sh'), 'utf8');
+    fs.writeFileSync(
+      path.join(directory, 'entrypoint.sh'),
+      script.replaceAll('/app/', `${directory}/`),
+    );
+  });
+
+  afterEach(() => fs.rmSync(directory, { recursive: true, force: true }));
+
+  const run = (settingsPath?: string) => {
+    const env: NodeJS.ProcessEnv = {
+      HOME: directory,
+      BASH_ENV: '/dev/null',
+      PATH: directory,
+    };
+    if (settingsPath !== undefined) env.MCPHUB_SETTING_PATH = settingsPath;
+    return execFileSync(
+      '/bin/bash',
+      [
+        path.join(directory, 'entrypoint.sh'),
+        '/bin/bash',
+        '-c',
+        'printf "selected=%s" "$MCPHUB_SETTING_PATH"',
+      ],
+      { env, encoding: 'utf8' },
+    ).split('selected=')[1];
+  };
+
+  it('uses the data directory on a fresh installation', () => {
+    expect(run()).toBe(path.join(directory, 'data/mcp_settings.json'));
+  });
+
+  it('retains the legacy file even when a data directory configuration also exists', () => {
+    fs.writeFileSync(path.join(directory, 'mcp_settings.json'), '{"users":[]}');
+    fs.mkdirSync(path.join(directory, 'data'));
+    fs.writeFileSync(path.join(directory, 'data/mcp_settings.json'), '{}');
+    expect(run()).toBe(path.join(directory, 'mcp_settings.json'));
+    expect(fs.readFileSync(path.join(directory, 'mcp_settings.json'), 'utf8')).toBe('{"users":[]}');
+  });
+
+  it('honors an explicit path even with a legacy file present', () => {
+    fs.writeFileSync(path.join(directory, 'mcp_settings.json'), '{}');
+    const explicitPath = path.join(directory, 'data/mcp_settings.json');
+    expect(run(explicitPath)).toBe(explicitPath);
+  });
+});


### PR DESCRIPTION
Docker quick start now needs only the port mapping and a data directory mount. The container entrypoint honors an explicit `MCPHUB_SETTING_PATH`, otherwise keeps using an existing `/app/mcp_settings.json` file, and defaults new installations to `/app/data/mcp_settings.json`. The image removes its bundled root settings example after building so it cannot mask the new default.

Update the English, Chinese, and French READMEs and bilingual Docker deployment examples, remove duplicate startup commands, and remove the MCP Toplist badge. Add regression coverage for fresh installations, legacy file precedence, and explicit overrides.

Validation:
- `pnpm lint`, `pnpm test:ci`, `pnpm build`, and `node scripts/verify-dist.js`.
- Built the current Dockerfile locally and verified healthy startup and generated-password login.
- Recreated containers with both the new data-directory mount and the existing two-mount command; settings and admin login persisted.
- Verified explicit path overrides take precedence without changing legacy credentials.
