### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -55117,6 +55117,162 @@
       }
     ]
   },
+  "you-mcp": {
+    "display_name": "You.com MCP Server",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/youdotcom-oss/agent-skills"
+    },
+    "homepage": "https://you.com/docs",
+    "author": {
+      "name": "youdotcom-oss"
+    },
+    "license": "MIT",
+    "categories": [
+      "Web Services"
+    ],
+    "tags": [
+      "search",
+      "web",
+      "research",
+      "contents",
+      "citations",
+      "finance",
+      "mcp"
+    ],
+    "arguments": {
+      "YDC_API_KEY": {
+        "description": "You.com API key for the authenticated MCP endpoint (https://api.you.com/mcp). Optional: the keyless endpoint https://api.you.com/mcp?profile=free works without a key.",
+        "required": false,
+        "example": "your-youcom-api-key"
+      }
+    },
+    "installations": {
+      "npm": {
+        "type": "npm",
+        "command": "npx",
+        "args": [
+          "-y",
+          "mcp-remote",
+          "https://api.you.com/mcp"
+        ],
+        "env": {
+          "YDC_API_KEY": "${YDC_API_KEY}"
+        },
+        "description": "Connect to the hosted You.com MCP server via mcp-remote (no local install of the server itself)"
+      },
+      "npm-free": {
+        "type": "npm",
+        "command": "npx",
+        "args": [
+          "-y",
+          "mcp-remote",
+          "https://api.you.com/mcp?profile=free"
+        ],
+        "env": {},
+        "description": "Connect keyless to the free profile (you-search only, no API key needed)"
+      }
+    },
+    "examples": [
+      {
+        "title": "Web Search",
+        "description": "Search the web for current information and sources.",
+        "prompt": "Search the web for the latest MCP gateway release notes and give me the URLs."
+      },
+      {
+        "title": "Read a URL",
+        "description": "Fetch page content as markdown or HTML for citation-first answers.",
+        "prompt": "Read https://you.com/docs and summarize the API authentication options."
+      },
+      {
+        "title": "Keyless search",
+        "description": "Use the free profile endpoint when no API key is configured.",
+        "prompt": "Search for 'streamable http mcp transport' using the free profile and list the top sources."
+      }
+    ],
+    "name": "you-mcp",
+    "description": "Web search, URL content extraction, and cited research tools from You.com, hosted as a remote MCP server.",
+    "tools": [
+      {
+        "name": "you-search",
+        "description": "Search the web for current information, facts, news, and sources. Best for current events, facts about people, companies, and organizations, finding primary sources, and verifying claims. Returns ranked results with URLs and snippets; read them with you-contents before answering. Supports inline site:, lang:, and loc: filters plus a freshness window.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Short natural-language phrase describing one thing to find."
+            },
+            "count": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 30,
+              "description": "Max results per section."
+            },
+            "freshness": {
+              "type": "string",
+              "description": "Limit results to a recent window: day, week, month, year, or a date range YYYY-MM-DDtoYYYY-MM-DD."
+            },
+            "extraction": {
+              "type": "string",
+              "enum": [
+                "none",
+                "highlights",
+                "full_page"
+              ],
+              "default": "highlights",
+              "description": "Extraction mode: highlights returns query-relevant passages; none returns plain snippets; full_page crawls each result and returns full page content."
+            },
+            "knowledge": {
+              "type": "string",
+              "enum": [
+                "core"
+              ],
+              "description": "Include licensed knowledge results alongside web and news results."
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      },
+      {
+        "name": "you-contents",
+        "description": "Fetch content from specific URLs in markdown or HTML so answers can be built from read pages rather than snippets. Use HTML when layout or tables matter; otherwise prefer markdown.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "urls": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of URLs to read (1-3 at a time works best)."
+            },
+            "formats": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "markdown",
+                  "html"
+                ]
+              },
+              "default": [
+                "markdown"
+              ],
+              "description": "Output formats for the extracted content."
+            }
+          },
+          "required": [
+            "urls"
+          ]
+        }
+      }
+    ]
+  },
   "gotohuman-mcp-server": {
     "display_name": "gotoHuman MCP Server",
     "repository": {


### PR DESCRIPTION
Adds the hosted You.com MCP server (web search + URL content extraction) to the `servers.json` market catalog, so it shows up on the Market page next to the other search providers (tavily, exa, brave, perplexity) under Web Services.

## What changed

One new `you-mcp` entry in `servers.json` — no code changes:

- `display_name`: "You.com MCP Server"
- Two tools documented: `you-search` (ranked web results, freshness window, inline `site:`/`lang:`/`loc:` filters) and `you-contents` (fetch page content as markdown/HTML)
- Two installations:
  - `npm` — `npx -y mcp-remote https://api.you.com/mcp`, with `YDC_API_KEY: ${YDC_API_KEY}` env for the authenticated endpoint
  - `npm-free` — `npx -y mcp-remote https://api.you.com/mcp?profile=free`, keyless, basic `you-search` only
- `YDC_API_KEY` documented as an optional argument (the free profile needs no key)
- Examples for search, URL reading, and the keyless profile

Since the You.com server is remote (streamable HTTP), the npm installation bridges it locally with [mcp-remote](https://github.com/geelen/mcp-remote) — the same stdio-shaped install flow the Market page already uses, no local server package needed. The entry sits right after `tavily-mcp` so the search providers stay grouped.

## Why useful here

The catalog already lists most major search providers as MCP servers; You.com was the notable gap. Its MCP server also exposes `you-contents`, which pairs with `you-search` for read-the-source answers rather than snippet-only ones.

## Validation

- `pnpm install --frozen-lockfile`, `pnpm backend:build`, `pnpm lint` — clean
- `pnpm test` — 201 suites / 1507 tests pass
- Loaded the entry through the `marketService` code path and verified the discovery install-snippet shape (`pickInstallation` preference picks `npm` and renders command/args/env correctly)
- Live checks against the endpoint: `initialize` + `tools/list` + a `you-search` call on the free profile returned 17 web results; `npx -y mcp-remote https://api.you.com/mcp?profile=free` connects via StreamableHTTPClientTransport (OAuth discovery + proxy established); the authenticated endpoint returns 401 without credentials, which matches the documented auth
- `servers.json` was already not prettier-formatted before this change; the new entry follows the file's existing 2-space style and CI (eslint + jest) is unaffected

Happy to adjust the entry shape (tags, categories, examples, or a single installation) if you'd prefer it differently.
