### PR TITLE
fix(auth): stop successful logins from spending the auth attempt budget

### DIFF
--- a/src/utils/rateLimit.test.ts
+++ b/src/utils/rateLimit.test.ts
@@ -8,6 +8,7 @@ jest.mock('express-rate-limit', () => ({
 }));
 
 import {
+  authAttemptRateLimiter,
   authenticatedRouteRateLimiter,
   createStandardRateLimiter,
   mcpConnectionRateLimiter,
@@ -33,6 +34,16 @@ describe('rateLimit configuration', () => {
       max: 480,
       standardHeaders: true,
       legacyHeaders: false,
+    });
+  });
+
+  it('keeps the auth attempt budget for rejected attempts only', () => {
+    expect(authAttemptRateLimiter).toMatchObject({
+      windowMs: 15 * 60 * 1000,
+      max: 20,
+      standardHeaders: true,
+      legacyHeaders: false,
+      skipSuccessfulRequests: true,
     });
   });
 

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -5,7 +5,11 @@ const isTestEnv =
   process.env.JEST_WORKER_ID !== undefined ||
   process.env.VITEST_WORKER_ID !== undefined;
 
-export const createStandardRateLimiter = (options: { windowMs: number; max: number }) =>
+export const createStandardRateLimiter = (options: {
+  windowMs: number;
+  max: number;
+  skipSuccessfulRequests?: boolean;
+}) =>
   rateLimit({
     ...options,
     standardHeaders: true,
@@ -33,9 +37,13 @@ export const mcpConnectionRateLimiter = createStandardRateLimiter({
   max: 480,
 });
 
+// Only rejected attempts consume this budget. Counting successful logins would lock out
+// API clients and service accounts that legitimately re-authenticate in bursts, for
+// example after a restart invalidated their cached tokens.
 export const authAttemptRateLimiter = createStandardRateLimiter({
   windowMs: 15 * 60 * 1000,
   max: 20,
+  skipSuccessfulRequests: true,
 });
 
 export const spaPageRateLimiter = createStandardRateLimiter({

--- a/tests/integration/auth-rate-limit.test.ts
+++ b/tests/integration/auth-rate-limit.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import express from 'express';
+import type { RequestHandler } from 'express';
+import request from 'supertest';
+
+const originalEnv = process.env;
+
+/**
+ * The shared limiters disable themselves under test runners (`skip: () => isTestEnv`),
+ * so the module is re-imported with a production-like environment to exercise the real
+ * counting behavior rather than a bypassed middleware.
+ */
+const loadAuthAttemptRateLimiter = async (): Promise<RequestHandler> => {
+  jest.resetModules();
+  process.env = { ...originalEnv, NODE_ENV: 'production' };
+  delete process.env.JEST_WORKER_ID;
+  delete process.env.VITEST_WORKER_ID;
+
+  const { authAttemptRateLimiter } = await import('../../src/utils/rateLimit.js');
+  return authAttemptRateLimiter as unknown as RequestHandler;
+};
+
+const buildLoginApp = (limiter: RequestHandler) => {
+  const app = express();
+  app.post('/api/auth/login', limiter, (req, res) => {
+    if (req.headers['x-valid-credentials'] === 'true') {
+      res.status(200).json({ success: true, token: 'token' });
+      return;
+    }
+    res.status(401).json({ success: false, message: 'Invalid credentials' });
+  });
+  return app;
+};
+
+describe('auth attempt rate limiting', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.resetModules();
+  });
+
+  it('does not spend the auth attempt budget on successful logins', async () => {
+    const app = buildLoginApp(await loadAuthAttemptRateLimiter());
+
+    // Well beyond the 20-attempt cap: a service account that re-authenticates in a burst
+    // (for example after a restart invalidated its cached token) must not lock itself out.
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      const response = await request(app)
+        .post('/api/auth/login')
+        .set('x-valid-credentials', 'true')
+        .send({ username: 'admin', password: 'correct' });
+
+      expect(response.status).toBe(200);
+    }
+
+    const afterSuccesses = await request(app)
+      .post('/api/auth/login')
+      .send({ username: 'admin', password: 'wrong' });
+
+    expect(afterSuccesses.status).toBe(401);
+  });
+
+  it('still blocks repeated failed logins', async () => {
+    const app = buildLoginApp(await loadAuthAttemptRateLimiter());
+
+    const statuses: number[] = [];
+    for (let attempt = 0; attempt < 21; attempt += 1) {
+      const response = await request(app)
+        .post('/api/auth/login')
+        .send({ username: 'admin', password: 'wrong' });
+
+      statuses.push(response.status);
+    }
+
+    expect(statuses.slice(0, 20)).toEqual(Array(20).fill(401));
+    expect(statuses[20]).toBe(429);
+  });
+});


### PR DESCRIPTION
Fixes #1134.

## Problem

`authAttemptRateLimiter` caps `/api/auth/login` and `/api/auth/register` at 20 attempts
per 15 minutes, and counts every request regardless of outcome. A client authenticating
with **valid** credentials therefore spends the same budget as an attacker guessing
passwords.

This is not theoretical — it locked an API integration out of a production deployment
after upgrading v1.0.23 → v1.0.36. In v1.0.23 login was only counted against the shared
600/15 min authenticated-route budget (the login route falls through
`authenticatedRouter`, mounted earlier on the same router), so the effective cap for a
service account dropped 30x in v1.0.36.

The lockout is triggered by any burst of legitimate logins. In our case `JWT_SECRET` was
unset, so a restart regenerated the signing secret (`src/config/jwt.ts:5-6`), every cached
service-account token became invalid at once, and each client worker re-authenticated
independently — well past 20 within seconds. Two properties made it worse:

- the default 429 body is `text/html`, so clients parsing the login response as JSON see a
  generic auth failure rather than rate limiting;
- the default `MemoryStore` is in-process and a retrying client keeps re-arming the
  counter, so recovery required restarting MCPHub.

## Change

Add `skipSuccessfulRequests: true` to `authAttemptRateLimiter` only. Per the
express-rate-limit docs a request counts as successful when its status is `< 400`, so
every rejected login still counts and the brute-force protection is unchanged — only
successful authentications stop consuming the budget.

`createStandardRateLimiter` gains an optional `skipSuccessfulRequests` field; no other
limiter passes it, so their behavior is untouched.

## Validation

- `tests/integration/auth-rate-limit.test.ts` (new): drives the real limiter through
  supertest. Re-imports the module with a production-like environment, because the shared
  limiters disable themselves under test runners (`skip: () => isTestEnv`).
  - 25 consecutive successful logins all return 200, and a following bad-credential
    attempt still returns 401 rather than 429.
  - 20 failed logins return 401 and the 21st returns 429 — brute-force protection intact.
  - Verified this suite fails on the unpatched code (the 21st success returned 429).
- `src/utils/rateLimit.test.ts`: extended in the existing configuration-assertion style.
- `npx jest`: 1502 passed. Four suites fail identically on unmodified `origin/main` on this
  Windows machine (`processTree`, `mcpbController`, `docker-entrypoint`,
  `credentialBindingService`) and are unrelated to this change.
- `npx tsc --noEmit`, `eslint` and `prettier --check` clean on the touched files.

## Not included

Two related ideas from the issue thread, left out to keep this focused — happy to add
either here or in a follow-up if you want them:

- making the cap configurable via an environment variable (the limiter is keyed by IP, so
  every client behind one egress proxy shares a single budget);
- returning the 429 as JSON so clients can distinguish rate limiting from bad credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uX3gBcFLJLsbcX1mbJck9
